### PR TITLE
Add ASAN and UBSAN stages to CI, fix various errors [AP-1386]

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -63,10 +63,6 @@ run:ubsan --action_env="UBSAN_OPTIONS=print_stacktrace=1"
 # rate that suppressions or an ignore list are impractical.
 common:ubsan --cxxopt=-fno-sanitize=vptr
 common:ubsan --linkopt=-fno-sanitize=vptr
-# enum sanitizer is really annoying in this repo even though it's useful
-common:ubsan --cxxopt=-fno-sanitize=enum
-common:ubsan --copt=-fno-sanitize=enum
-common:ubsan --linkopt=-fno-sanitize=enum
 common:ubsan --platform_suffix=ubsan
 
 # Dynamic memory sanitizer

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,101 @@
+# Causes the build to default to the custom toolchain
+build --incompatible_enable_cc_toolchain_resolution
+
 build --action_env=BAZEL_CXXOPTS='-std=c++14'
 
 build:clang-tidy --aspects @rules_swiftnav//clang_tidy:clang_tidy.bzl%clang_tidy_aspect
 build:clang-tidy --output_groups=report
+
+# Shared sanitizer configuration
+common:sanitize -c dbg
+common:sanitize --cxxopt=-g3
+common:sanitize --copt=-g3
+common:sanitize --linkopt=-g3
+#common:sanitize --cxxopt=-O1
+#common:sanitize --copt=-O1
+#common:sanitize --linkopt=-O1
+common:sanitize --cxxopt=-fno-omit-frame-pointer
+common:sanitize --copt=-fno-omit-frame-pointer
+common:sanitize --linkopt=-fno-omit-frame-pointer
+common:sanitize --@rules_swiftnav//cc:enable_symbolizer=true
+
+# Sanitizer overhead can cause some functions to become so large that
+# the compiler falls back to a linear register allocator.  This
+# shouldn't cause a sanitizer build to fail.
+common:sanitize --cxxopt=-Wno-error=disabled-optimization
+common:sanitize --copt=-Wno-error=disabled-optimization 
+common:sanitize --linkopt=-Wno-error=disabled-optimization
+# https://github.com/bazelbuild/bazel/issues/12797#issuecomment-980641064
+common:sanitize --linkopt='-fsanitize-link-c++-runtime'
+common:sanitize --cxxopt=-fPIC
+common:sanitize --copt=-fPIC
+common:sanitize --linkopt=-fPIC
+
+# Address sanitizer
+common:asan --config=sanitize
+common:asan --cxxopt=-fsanitize=address
+common:asan --copt=-fsanitize=address
+common:asan --linkopt=-fsanitize=address
+common:asan --cxxopt=-fno-optimize-sibling-calls
+common:asan --copt=-fno-optimize-sibling-calls
+common:asan --linkopt=-fno-optimize-sibling-calls
+common:asan --platform_suffix=asan
+
+# Undefined behavior sanitizer
+common:ubsan --config=sanitize
+common:ubsan --cxxopt=-fsanitize=undefined
+common:ubsan --copt=-fsanitize=undefined
+common:ubsan --linkopt=-fsanitize=undefined
+common:ubsan --cxxopt=-fno-sanitize-recover=all
+common:ubsan --copt=-fno-sanitize-recover=all
+common:ubsan --linkopt=-fno-sanitize-recover=all
+common:ubsan --cxxopt=-fsanitize=local-bounds
+common:ubsan --copt=-fsanitize=local-bounds
+common:ubsan --linkopt=-fsanitize=local-bounds
+common:ubsan --@rules_swiftnav//cc:enable_rtti=true
+# Unfortunately the current build setup doesn't seem to provide stack
+# frame names using clang++ and llvm-symbolizer.  (This was also the
+# case in cmake, but the default of g++ there _did_ provide frame
+# names in backtraces.)
+test:ubsan --action_env="UBSAN_OPTIONS=print_stacktrace=1"
+run:ubsan --action_env="UBSAN_OPTIONS=print_stacktrace=1"
+# vptr sanitizer is horribly broken to the point of throwing false positives at a
+# rate that suppressions or an ignore list are impractical.
+common:ubsan --cxxopt=-fno-sanitize=vptr
+common:ubsan --linkopt=-fno-sanitize=vptr
+# enum sanitizer is really annoying in this repo even though it's useful
+common:ubsan --cxxopt=-fno-sanitize=enum
+common:ubsan --copt=-fno-sanitize=enum
+common:ubsan --linkopt=-fno-sanitize=enum
+common:ubsan --platform_suffix=ubsan
+
+# Dynamic memory sanitizer
+#
+# Warning: takes an incredible amount of space!  Try testing only one
+# target at a time.
+common:msan --config=sanitize
+common:msan --cxxopt=-fsanitize=memory
+common:msan --copt=-fsanitize=memory
+common:msan --linkopt=-fsanitize=memory
+common:msan --cxxopt=-fsanitize-memory-track-origins=2
+common:msan --copt=-fsanitize-memory-track-origins=2
+common:msan --linkopt=-fsanitize-memory-track-origins=2
+common:msan --cxxopt=-fsanitize-memory-use-after-dtor
+common:msan --copt=-fsanitize-memory-use-after-dtor
+common:msan --linkopt=-fsanitize-memory-use-after-dtor
+common:msan --platform_suffix=msan
+
+# > Currently, ThreadSanitizer symbolizes its output using an external
+# > addr2line process (this will be fixed in future).
+#
+# https://clang.llvm.org/docs/ThreadSanitizer.html#usage
+common:tsan --config=sanitize
+common:tsan --cxxopt=-fsanitize=thread
+common:tsan --copt=-fsanitize=thread
+common:tsan --linkopt=-fsanitize=thread
+common:tsan --platform_suffix=tsan
+
+# Helpful aliases
+common:asan_ubsan --config=asan
+common:asan_ubsan --config=ubsan
+common:ubsan_asan --config=asan_ubsan

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -140,15 +140,18 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Install Bazel
-        run: |
-          curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.15.0/bazelisk-linux-amd64"
-          mkdir -p "${GITHUB_WORKSPACE}/bin/"
-          mv bazelisk-linux-amd64 "${GITHUB_WORKSPACE}/bin/bazel"
-          chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
+
+      - uses: bazelbuild/setup-bazelisk@v2
+
+      - name: Mount bazel cache
+        uses: actions/cache@v1
+        with:
+          path: "~/.cache/bazel"
+          key: bazel
+
       - name: Bazel Build & Test
         run: |
-          ${GITHUB_WORKSPACE}/bin/bazel test //...
+          bazel test //...
 
 
   asan:
@@ -158,15 +161,18 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Install Bazel
-        run: |
-          curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.15.0/bazelisk-linux-amd64"
-          mkdir -p "${GITHUB_WORKSPACE}/bin/"
-          mv bazelisk-linux-amd64 "${GITHUB_WORKSPACE}/bin/bazel"
-          chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
+
+      - uses: bazelbuild/setup-bazelisk@v2
+
+      - name: Mount bazel cache
+        uses: actions/cache@v1
+        with:
+          path: "~/.cache/bazel"
+          key: bazel
+
       - name: Bazel Build & Test
         run: |
-          ${GITHUB_WORKSPACE}/bin/bazel test --config=asan //...
+          bazel test --config=asan //...
 
 
   ubsan:
@@ -176,15 +182,18 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Install Bazel
-        run: |
-          curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.15.0/bazelisk-linux-amd64"
-          mkdir -p "${GITHUB_WORKSPACE}/bin/"
-          mv bazelisk-linux-amd64 "${GITHUB_WORKSPACE}/bin/bazel"
-          chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
+
+      - uses: bazelbuild/setup-bazelisk@v2
+
+      - name: Mount bazel cache
+        uses: actions/cache@v1
+        with:
+          path: "~/.cache/bazel"
+          key: bazel
+
       - name: Bazel Build & Test
         run: |
-          ${GITHUB_WORKSPACE}/bin/bazel test --config=ubsan //...
+          bazel test --config=ubsan //...
 
 
   windows-2019:

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -151,6 +151,42 @@ jobs:
           ${GITHUB_WORKSPACE}/bin/bazel test //...
 
 
+  asan:
+    name: ASAN
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Install Bazel
+        run: |
+          curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.15.0/bazelisk-linux-amd64"
+          mkdir -p "${GITHUB_WORKSPACE}/bin/"
+          mv bazelisk-linux-amd64 "${GITHUB_WORKSPACE}/bin/bazel"
+          chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
+      - name: Bazel Build & Test
+        run: |
+          ${GITHUB_WORKSPACE}/bin/bazel test --config=asan //...
+
+
+  ubsan:
+    name: UBSAN
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Install Bazel
+        run: |
+          curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.15.0/bazelisk-linux-amd64"
+          mkdir -p "${GITHUB_WORKSPACE}/bin/"
+          mv bazelisk-linux-amd64 "${GITHUB_WORKSPACE}/bin/bazel"
+          chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
+      - name: Bazel Build & Test
+        run: |
+          ${GITHUB_WORKSPACE}/bin/bazel test --config=ubsan //...
+
+
   windows-2019:
     strategy:
       matrix:

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -4,9 +4,19 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_swiftnav",
-    strip_prefix = "rules_swiftnav-82e89313fc0c2046a2b19d4a4da5167a88f5da3f",
-    url = "https://github.com/swift-nav/rules_swiftnav/archive/82e89313fc0c2046a2b19d4a4da5167a88f5da3f.tar.gz",
+    strip_prefix = "rules_swiftnav-cb82c790d50dd87f301df67b710161906dafb0c2",
+    url = "https://github.com/swift-nav/rules_swiftnav/archive/cb82c790d50dd87f301df67b710161906dafb0c2.tar.gz",
 )
+
+load(
+    "@rules_swiftnav//cc:repositories.bzl",
+    "register_swift_cc_toolchains",
+    "swift_cc_toolchain",
+)
+
+swift_cc_toolchain()
+
+register_swift_cc_toolchains()
 
 http_archive(
     name = "rules_foreign_cc",

--- a/c/test/cpp/auto_check_sbp_acquisition_MsgAcqResult.cc
+++ b/c/test/cpp/auto_check_sbp_acquisition_MsgAcqResult.cc
@@ -340,7 +340,7 @@ class Testauto_check_sbp_acquisition_MsgAcqResult0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_acquisition_MsgAcqResultDepA.cc
+++ b/c/test/cpp/auto_check_sbp_acquisition_MsgAcqResultDepA.cc
@@ -346,7 +346,7 @@ class Testauto_check_sbp_acquisition_MsgAcqResultDepA0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1126,7 +1126,7 @@ class Testauto_check_sbp_acquisition_MsgAcqResultDepA1
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1906,7 +1906,7 @@ class Testauto_check_sbp_acquisition_MsgAcqResultDepA2
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2686,7 +2686,7 @@ class Testauto_check_sbp_acquisition_MsgAcqResultDepA3
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -3466,7 +3466,7 @@ class Testauto_check_sbp_acquisition_MsgAcqResultDepA4
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -4246,7 +4246,7 @@ class Testauto_check_sbp_acquisition_MsgAcqResultDepA5
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_acquisition_MsgAcqResultDepB.cc
+++ b/c/test/cpp/auto_check_sbp_acquisition_MsgAcqResultDepB.cc
@@ -348,7 +348,7 @@ class Testauto_check_sbp_acquisition_MsgAcqResultDepB0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1142,7 +1142,7 @@ class Testauto_check_sbp_acquisition_MsgAcqResultDepB1
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1936,7 +1936,7 @@ class Testauto_check_sbp_acquisition_MsgAcqResultDepB2
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2730,7 +2730,7 @@ class Testauto_check_sbp_acquisition_MsgAcqResultDepB3
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -3524,7 +3524,7 @@ class Testauto_check_sbp_acquisition_MsgAcqResultDepB4
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_acquisition_MsgAcqResultDepC.cc
+++ b/c/test/cpp/auto_check_sbp_acquisition_MsgAcqResultDepC.cc
@@ -348,7 +348,7 @@ class Testauto_check_sbp_acquisition_MsgAcqResultDepC0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1142,7 +1142,7 @@ class Testauto_check_sbp_acquisition_MsgAcqResultDepC1
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1936,7 +1936,7 @@ class Testauto_check_sbp_acquisition_MsgAcqResultDepC2
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2730,7 +2730,7 @@ class Testauto_check_sbp_acquisition_MsgAcqResultDepC3
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -3524,7 +3524,7 @@ class Testauto_check_sbp_acquisition_MsgAcqResultDepC4
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_acquisition_MsgAcqSvProfile.cc
+++ b/c/test/cpp/auto_check_sbp_acquisition_MsgAcqSvProfile.cc
@@ -383,7 +383,7 @@ class Testauto_check_sbp_acquisition_MsgAcqSvProfile0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_acquisition_MsgAcqSvProfileDep.cc
+++ b/c/test/cpp/auto_check_sbp_acquisition_MsgAcqSvProfileDep.cc
@@ -387,7 +387,7 @@ class Testauto_check_sbp_acquisition_MsgAcqSvProfileDep0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_bootload_MsgBootloaderHandshakeReq.cc
+++ b/c/test/cpp/auto_check_sbp_bootload_MsgBootloaderHandshakeReq.cc
@@ -345,7 +345,7 @@ class Testauto_check_sbp_bootload_MsgBootloaderHandshakeReq0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_bootload_MsgBootloaderHandshakeResp.cc
+++ b/c/test/cpp/auto_check_sbp_bootload_MsgBootloaderHandshakeResp.cc
@@ -354,7 +354,7 @@ class Testauto_check_sbp_bootload_MsgBootloaderHandshakeResp0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1296,7 +1296,7 @@ class Testauto_check_sbp_bootload_MsgBootloaderHandshakeResp1
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_bootload_MsgBootloaderJumptoApp.cc
+++ b/c/test/cpp/auto_check_sbp_bootload_MsgBootloaderJumptoApp.cc
@@ -345,7 +345,7 @@ class Testauto_check_sbp_bootload_MsgBootloaderJumptoApp0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_bootload_MsgNapDeviceDnaReq.cc
+++ b/c/test/cpp/auto_check_sbp_bootload_MsgNapDeviceDnaReq.cc
@@ -340,7 +340,7 @@ class Testauto_check_sbp_bootload_MsgNapDeviceDnaReq0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_bootload_MsgNapDeviceDnaResp.cc
+++ b/c/test/cpp/auto_check_sbp_bootload_MsgNapDeviceDnaResp.cc
@@ -357,7 +357,7 @@ class Testauto_check_sbp_bootload_MsgNapDeviceDnaResp0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_ext_events_MsgExtEvent.cc
+++ b/c/test/cpp/auto_check_sbp_ext_events_MsgExtEvent.cc
@@ -339,7 +339,7 @@ class Testauto_check_sbp_ext_events_MsgExtEvent0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_file_io_MsgFileioConfigReq.cc
+++ b/c/test/cpp/auto_check_sbp_file_io_MsgFileioConfigReq.cc
@@ -342,7 +342,7 @@ class Testauto_check_sbp_file_io_MsgFileioConfigReq0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_file_io_MsgFileioConfigResp.cc
+++ b/c/test/cpp/auto_check_sbp_file_io_MsgFileioConfigResp.cc
@@ -345,7 +345,7 @@ class Testauto_check_sbp_file_io_MsgFileioConfigResp0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_file_io_MsgFileioReadDirReq.cc
+++ b/c/test/cpp/auto_check_sbp_file_io_MsgFileioReadDirReq.cc
@@ -348,7 +348,7 @@ class Testauto_check_sbp_file_io_MsgFileioReadDirReq0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_file_io_MsgFileioReadDirResp.cc
+++ b/c/test/cpp/auto_check_sbp_file_io_MsgFileioReadDirResp.cc
@@ -351,7 +351,7 @@ class Testauto_check_sbp_file_io_MsgFileioReadDirResp0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_file_io_MsgFileioReadReq.cc
+++ b/c/test/cpp/auto_check_sbp_file_io_MsgFileioReadReq.cc
@@ -350,7 +350,7 @@ class Testauto_check_sbp_file_io_MsgFileioReadReq0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_file_io_MsgFileioReadResp.cc
+++ b/c/test/cpp/auto_check_sbp_file_io_MsgFileioReadResp.cc
@@ -844,7 +844,7 @@ class Testauto_check_sbp_file_io_MsgFileioReadResp0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_file_io_MsgFileioRemove.cc
+++ b/c/test/cpp/auto_check_sbp_file_io_MsgFileioRemove.cc
@@ -345,7 +345,7 @@ class Testauto_check_sbp_file_io_MsgFileioRemove0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_file_io_MsgFileioWriteResp.cc
+++ b/c/test/cpp/auto_check_sbp_file_io_MsgFileioWriteResp.cc
@@ -342,7 +342,7 @@ class Testauto_check_sbp_file_io_MsgFileioWriteResp0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_flash_MsgFlashDone.cc
+++ b/c/test/cpp/auto_check_sbp_flash_MsgFlashDone.cc
@@ -334,7 +334,7 @@ class Testauto_check_sbp_flash_MsgFlashDone0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_flash_MsgFlashErase.cc
+++ b/c/test/cpp/auto_check_sbp_flash_MsgFlashErase.cc
@@ -339,7 +339,7 @@ class Testauto_check_sbp_flash_MsgFlashErase0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_flash_MsgFlashProgram.cc
+++ b/c/test/cpp/auto_check_sbp_flash_MsgFlashProgram.cc
@@ -848,7 +848,7 @@ class Testauto_check_sbp_flash_MsgFlashProgram0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_flash_MsgFlashReadReq.cc
+++ b/c/test/cpp/auto_check_sbp_flash_MsgFlashReadReq.cc
@@ -349,7 +349,7 @@ class Testauto_check_sbp_flash_MsgFlashReadReq0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_flash_MsgFlashReadResp.cc
+++ b/c/test/cpp/auto_check_sbp_flash_MsgFlashReadResp.cc
@@ -349,7 +349,7 @@ class Testauto_check_sbp_flash_MsgFlashReadResp0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_flash_MsgM25FlashWriteStatus.cc
+++ b/c/test/cpp/auto_check_sbp_flash_MsgM25FlashWriteStatus.cc
@@ -345,7 +345,7 @@ class Testauto_check_sbp_flash_MsgM25FlashWriteStatus0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_flash_MsgStmFlashLockSector.cc
+++ b/c/test/cpp/auto_check_sbp_flash_MsgStmFlashLockSector.cc
@@ -343,7 +343,7 @@ class Testauto_check_sbp_flash_MsgStmFlashLockSector0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_flash_MsgStmFlashUnlockSector.cc
+++ b/c/test/cpp/auto_check_sbp_flash_MsgStmFlashUnlockSector.cc
@@ -346,7 +346,7 @@ class Testauto_check_sbp_flash_MsgStmFlashUnlockSector0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_flash_MsgStmUniqueIdReq.cc
+++ b/c/test/cpp/auto_check_sbp_flash_MsgStmUniqueIdReq.cc
@@ -340,7 +340,7 @@ class Testauto_check_sbp_flash_MsgStmUniqueIdReq0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_flash_MsgStmUniqueIdResp.cc
+++ b/c/test/cpp/auto_check_sbp_flash_MsgStmUniqueIdResp.cc
@@ -364,7 +364,7 @@ class Testauto_check_sbp_flash_MsgStmUniqueIdResp0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_imu_MsgImuAux.cc
+++ b/c/test/cpp/auto_check_sbp_imu_MsgImuAux.cc
@@ -337,7 +337,7 @@ class Testauto_check_sbp_imu_MsgImuAux0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_imu_MsgImuRaw.cc
+++ b/c/test/cpp/auto_check_sbp_imu_MsgImuRaw.cc
@@ -342,7 +342,7 @@ class Testauto_check_sbp_imu_MsgImuRaw0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_integrity_MsgAcknowledge.cc
+++ b/c/test/cpp/auto_check_sbp_integrity_MsgAcknowledge.cc
@@ -344,7 +344,7 @@ class Testauto_check_sbp_integrity_MsgAcknowledge0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_integrity_MsgSsrFlagHighLevel.cc
+++ b/c/test/cpp/auto_check_sbp_integrity_MsgSsrFlagHighLevel.cc
@@ -369,7 +369,7 @@ class Testauto_check_sbp_integrity_MsgSsrFlagHighLevel0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_integrity_MsgSsrFlagIonoGridPointSatLos.cc
+++ b/c/test/cpp/auto_check_sbp_integrity_MsgSsrFlagIonoGridPointSatLos.cc
@@ -365,7 +365,7 @@ class Testauto_check_sbp_integrity_MsgSsrFlagIonoGridPointSatLos0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_integrity_MsgSsrFlagIonoGridPoints.cc
+++ b/c/test/cpp/auto_check_sbp_integrity_MsgSsrFlagIonoGridPoints.cc
@@ -360,7 +360,7 @@ class Testauto_check_sbp_integrity_MsgSsrFlagIonoGridPoints0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_integrity_MsgSsrFlagIonoTileSatLos.cc
+++ b/c/test/cpp/auto_check_sbp_integrity_MsgSsrFlagIonoTileSatLos.cc
@@ -360,7 +360,7 @@ class Testauto_check_sbp_integrity_MsgSsrFlagIonoTileSatLos0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_integrity_MsgSsrFlagSatellites.cc
+++ b/c/test/cpp/auto_check_sbp_integrity_MsgSsrFlagSatellites.cc
@@ -356,7 +356,7 @@ class Testauto_check_sbp_integrity_MsgSsrFlagSatellites0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_integrity_MsgSsrFlagTropoGridPoints.cc
+++ b/c/test/cpp/auto_check_sbp_integrity_MsgSsrFlagTropoGridPoints.cc
@@ -360,7 +360,7 @@ class Testauto_check_sbp_integrity_MsgSsrFlagTropoGridPoints0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_linux_MsgLinuxCpuState.cc
+++ b/c/test/cpp/auto_check_sbp_linux_MsgLinuxCpuState.cc
@@ -360,7 +360,7 @@ class Testauto_check_sbp_linux_MsgLinuxCpuState0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_linux_MsgLinuxCpuStateDepA.cc
+++ b/c/test/cpp/auto_check_sbp_linux_MsgLinuxCpuStateDepA.cc
@@ -360,7 +360,7 @@ class Testauto_check_sbp_linux_MsgLinuxCpuStateDepA0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_linux_MsgLinuxMemState.cc
+++ b/c/test/cpp/auto_check_sbp_linux_MsgLinuxMemState.cc
@@ -360,7 +360,7 @@ class Testauto_check_sbp_linux_MsgLinuxMemState0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_linux_MsgLinuxMemStateDepA.cc
+++ b/c/test/cpp/auto_check_sbp_linux_MsgLinuxMemStateDepA.cc
@@ -360,7 +360,7 @@ class Testauto_check_sbp_linux_MsgLinuxMemStateDepA0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_linux_MsgLinuxProcessFdCount.cc
+++ b/c/test/cpp/auto_check_sbp_linux_MsgLinuxProcessFdCount.cc
@@ -355,7 +355,7 @@ class Testauto_check_sbp_linux_MsgLinuxProcessFdCount0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_linux_MsgLinuxProcessFdSummary.cc
+++ b/c/test/cpp/auto_check_sbp_linux_MsgLinuxProcessFdSummary.cc
@@ -362,7 +362,7 @@ class Testauto_check_sbp_linux_MsgLinuxProcessFdSummary0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_linux_MsgLinuxProcessSocketCounts.cc
+++ b/c/test/cpp/auto_check_sbp_linux_MsgLinuxProcessSocketCounts.cc
@@ -360,7 +360,7 @@ class Testauto_check_sbp_linux_MsgLinuxProcessSocketCounts0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_linux_MsgLinuxProcessSocketQueues.cc
+++ b/c/test/cpp/auto_check_sbp_linux_MsgLinuxProcessSocketQueues.cc
@@ -378,7 +378,7 @@ class Testauto_check_sbp_linux_MsgLinuxProcessSocketQueues0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_linux_MsgLinuxSocketUsage.cc
+++ b/c/test/cpp/auto_check_sbp_linux_MsgLinuxSocketUsage.cc
@@ -407,7 +407,7 @@ class Testauto_check_sbp_linux_MsgLinuxSocketUsage0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_linux_MsgLinuxSysState.cc
+++ b/c/test/cpp/auto_check_sbp_linux_MsgLinuxSysState.cc
@@ -349,7 +349,7 @@ class Testauto_check_sbp_linux_MsgLinuxSysState0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_linux_MsgLinuxSysStateDepA.cc
+++ b/c/test/cpp/auto_check_sbp_linux_MsgLinuxSysStateDepA.cc
@@ -348,7 +348,7 @@ class Testauto_check_sbp_linux_MsgLinuxSysStateDepA0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_logging_MsgFwd.cc
+++ b/c/test/cpp/auto_check_sbp_logging_MsgFwd.cc
@@ -364,7 +364,7 @@ class Testauto_check_sbp_logging_MsgFwd0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_logging_MsgLog.cc
+++ b/c/test/cpp/auto_check_sbp_logging_MsgLog.cc
@@ -338,7 +338,7 @@ class Testauto_check_sbp_logging_MsgLog0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_logging_MsgPrintDep.cc
+++ b/c/test/cpp/auto_check_sbp_logging_MsgPrintDep.cc
@@ -340,7 +340,7 @@ class Testauto_check_sbp_logging_MsgPrintDep0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1220,7 +1220,7 @@ class Testauto_check_sbp_logging_MsgPrintDep1 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2098,7 +2098,7 @@ class Testauto_check_sbp_logging_MsgPrintDep2 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2977,7 +2977,7 @@ class Testauto_check_sbp_logging_MsgPrintDep3 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -3857,7 +3857,7 @@ class Testauto_check_sbp_logging_MsgPrintDep4 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -4736,7 +4736,7 @@ class Testauto_check_sbp_logging_MsgPrintDep5 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_mag_MsgMagRaw.cc
+++ b/c/test/cpp/auto_check_sbp_mag_MsgMagRaw.cc
@@ -339,7 +339,7 @@ class Testauto_check_sbp_mag_MsgMagRaw0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgAgeCorrections.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgAgeCorrections.cc
@@ -344,7 +344,7 @@ class Testauto_check_sbp_navigation_MsgAgeCorrections0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgBaselineECEF.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgBaselineECEF.cc
@@ -347,7 +347,7 @@ class Testauto_check_sbp_navigation_MsgBaselineECEF0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1140,7 +1140,7 @@ class Testauto_check_sbp_navigation_MsgBaselineECEF1 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1933,7 +1933,7 @@ class Testauto_check_sbp_navigation_MsgBaselineECEF2 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2726,7 +2726,7 @@ class Testauto_check_sbp_navigation_MsgBaselineECEF3 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -3519,7 +3519,7 @@ class Testauto_check_sbp_navigation_MsgBaselineECEF4 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgBaselineECEFDepA.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgBaselineECEFDepA.cc
@@ -349,7 +349,7 @@ class Testauto_check_sbp_navigation_MsgBaselineECEFDepA0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1159,7 +1159,7 @@ class Testauto_check_sbp_navigation_MsgBaselineECEFDepA1
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1969,7 +1969,7 @@ class Testauto_check_sbp_navigation_MsgBaselineECEFDepA2
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2779,7 +2779,7 @@ class Testauto_check_sbp_navigation_MsgBaselineECEFDepA3
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -3589,7 +3589,7 @@ class Testauto_check_sbp_navigation_MsgBaselineECEFDepA4
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -4399,7 +4399,7 @@ class Testauto_check_sbp_navigation_MsgBaselineECEFDepA5
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -5209,7 +5209,7 @@ class Testauto_check_sbp_navigation_MsgBaselineECEFDepA6
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -6019,7 +6019,7 @@ class Testauto_check_sbp_navigation_MsgBaselineECEFDepA7
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -6829,7 +6829,7 @@ class Testauto_check_sbp_navigation_MsgBaselineECEFDepA8
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -7639,7 +7639,7 @@ class Testauto_check_sbp_navigation_MsgBaselineECEFDepA9
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -8449,7 +8449,7 @@ class Testauto_check_sbp_navigation_MsgBaselineECEFDepA10
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgBaselineHeadingDepA.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgBaselineHeadingDepA.cc
@@ -348,7 +348,7 @@ class Testauto_check_sbp_navigation_MsgBaselineHeadingDepA0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgBaselineNED.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgBaselineNED.cc
@@ -347,7 +347,7 @@ class Testauto_check_sbp_navigation_MsgBaselineNED0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1145,7 +1145,7 @@ class Testauto_check_sbp_navigation_MsgBaselineNED1 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1943,7 +1943,7 @@ class Testauto_check_sbp_navigation_MsgBaselineNED2 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2741,7 +2741,7 @@ class Testauto_check_sbp_navigation_MsgBaselineNED3 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -3539,7 +3539,7 @@ class Testauto_check_sbp_navigation_MsgBaselineNED4 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgBaselineNEDDepA.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgBaselineNEDDepA.cc
@@ -350,7 +350,7 @@ class Testauto_check_sbp_navigation_MsgBaselineNEDDepA0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1162,7 +1162,7 @@ class Testauto_check_sbp_navigation_MsgBaselineNEDDepA1
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1974,7 +1974,7 @@ class Testauto_check_sbp_navigation_MsgBaselineNEDDepA2
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2786,7 +2786,7 @@ class Testauto_check_sbp_navigation_MsgBaselineNEDDepA3
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -3598,7 +3598,7 @@ class Testauto_check_sbp_navigation_MsgBaselineNEDDepA4
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -4410,7 +4410,7 @@ class Testauto_check_sbp_navigation_MsgBaselineNEDDepA5
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -5222,7 +5222,7 @@ class Testauto_check_sbp_navigation_MsgBaselineNEDDepA6
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -6034,7 +6034,7 @@ class Testauto_check_sbp_navigation_MsgBaselineNEDDepA7
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -6846,7 +6846,7 @@ class Testauto_check_sbp_navigation_MsgBaselineNEDDepA8
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -7658,7 +7658,7 @@ class Testauto_check_sbp_navigation_MsgBaselineNEDDepA9
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -8470,7 +8470,7 @@ class Testauto_check_sbp_navigation_MsgBaselineNEDDepA10
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgDops.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgDops.cc
@@ -340,7 +340,7 @@ class Testauto_check_sbp_navigation_MsgDops0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgDopsDepA.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgDopsDepA.cc
@@ -340,7 +340,7 @@ class Testauto_check_sbp_navigation_MsgDopsDepA0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1113,7 +1113,7 @@ class Testauto_check_sbp_navigation_MsgDopsDepA1 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1886,7 +1886,7 @@ class Testauto_check_sbp_navigation_MsgDopsDepA2 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2659,7 +2659,7 @@ class Testauto_check_sbp_navigation_MsgDopsDepA3 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -3432,7 +3432,7 @@ class Testauto_check_sbp_navigation_MsgDopsDepA4 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -4205,7 +4205,7 @@ class Testauto_check_sbp_navigation_MsgDopsDepA5 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -4978,7 +4978,7 @@ class Testauto_check_sbp_navigation_MsgDopsDepA6 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -5751,7 +5751,7 @@ class Testauto_check_sbp_navigation_MsgDopsDepA7 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -6524,7 +6524,7 @@ class Testauto_check_sbp_navigation_MsgDopsDepA8 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgGPSTime.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgGPSTime.cc
@@ -338,7 +338,7 @@ class Testauto_check_sbp_navigation_MsgGPSTime0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1095,7 +1095,7 @@ class Testauto_check_sbp_navigation_MsgGPSTime1 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1852,7 +1852,7 @@ class Testauto_check_sbp_navigation_MsgGPSTime2 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2609,7 +2609,7 @@ class Testauto_check_sbp_navigation_MsgGPSTime3 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -3366,7 +3366,7 @@ class Testauto_check_sbp_navigation_MsgGPSTime4 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgGPSTimeDepA.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgGPSTimeDepA.cc
@@ -345,7 +345,7 @@ class Testauto_check_sbp_navigation_MsgGPSTimeDepA0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1118,7 +1118,7 @@ class Testauto_check_sbp_navigation_MsgGPSTimeDepA1 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1891,7 +1891,7 @@ class Testauto_check_sbp_navigation_MsgGPSTimeDepA2 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2664,7 +2664,7 @@ class Testauto_check_sbp_navigation_MsgGPSTimeDepA3 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -3437,7 +3437,7 @@ class Testauto_check_sbp_navigation_MsgGPSTimeDepA4 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -4210,7 +4210,7 @@ class Testauto_check_sbp_navigation_MsgGPSTimeDepA5 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -4984,7 +4984,7 @@ class Testauto_check_sbp_navigation_MsgGPSTimeDepA6 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -5757,7 +5757,7 @@ class Testauto_check_sbp_navigation_MsgGPSTimeDepA7 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -6531,7 +6531,7 @@ class Testauto_check_sbp_navigation_MsgGPSTimeDepA8 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -7304,7 +7304,7 @@ class Testauto_check_sbp_navigation_MsgGPSTimeDepA9 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -8078,7 +8078,7 @@ class Testauto_check_sbp_navigation_MsgGPSTimeDepA10 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgGPSTimeGNSS.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgGPSTimeGNSS.cc
@@ -344,7 +344,7 @@ class Testauto_check_sbp_navigation_MsgGPSTimeGNSS0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1115,7 +1115,7 @@ class Testauto_check_sbp_navigation_MsgGPSTimeGNSS1 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1886,7 +1886,7 @@ class Testauto_check_sbp_navigation_MsgGPSTimeGNSS2 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2657,7 +2657,7 @@ class Testauto_check_sbp_navigation_MsgGPSTimeGNSS3 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -3428,7 +3428,7 @@ class Testauto_check_sbp_navigation_MsgGPSTimeGNSS4 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgPosECEF.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgPosECEF.cc
@@ -341,7 +341,7 @@ class Testauto_check_sbp_navigation_MsgPosECEF0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1122,7 +1122,7 @@ class Testauto_check_sbp_navigation_MsgPosECEF1 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1903,7 +1903,7 @@ class Testauto_check_sbp_navigation_MsgPosECEF2 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2684,7 +2684,7 @@ class Testauto_check_sbp_navigation_MsgPosECEF3 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgPosECEFCov.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgPosECEFCov.cc
@@ -350,7 +350,7 @@ class Testauto_check_sbp_navigation_MsgPosECEFCov0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgPosECEFCovGNSS.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgPosECEFCovGNSS.cc
@@ -354,7 +354,7 @@ class Testauto_check_sbp_navigation_MsgPosECEFCovGNSS0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgPosECEFDepA.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgPosECEFDepA.cc
@@ -348,7 +348,7 @@ class Testauto_check_sbp_navigation_MsgPosECEFDepA0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1146,7 +1146,7 @@ class Testauto_check_sbp_navigation_MsgPosECEFDepA1 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1943,7 +1943,7 @@ class Testauto_check_sbp_navigation_MsgPosECEFDepA2 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2740,7 +2740,7 @@ class Testauto_check_sbp_navigation_MsgPosECEFDepA3 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -3537,7 +3537,7 @@ class Testauto_check_sbp_navigation_MsgPosECEFDepA4 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -4334,7 +4334,7 @@ class Testauto_check_sbp_navigation_MsgPosECEFDepA5 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -5132,7 +5132,7 @@ class Testauto_check_sbp_navigation_MsgPosECEFDepA6 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -5929,7 +5929,7 @@ class Testauto_check_sbp_navigation_MsgPosECEFDepA7 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -6727,7 +6727,7 @@ class Testauto_check_sbp_navigation_MsgPosECEFDepA8 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -7525,7 +7525,7 @@ class Testauto_check_sbp_navigation_MsgPosECEFDepA9 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -8323,7 +8323,7 @@ class Testauto_check_sbp_navigation_MsgPosECEFDepA10 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgPosECEFGNSS.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgPosECEFGNSS.cc
@@ -347,7 +347,7 @@ class Testauto_check_sbp_navigation_MsgPosECEFGNSS0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgPosLLH.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgPosLLH.cc
@@ -342,7 +342,7 @@ class Testauto_check_sbp_navigation_MsgPosLLH0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1127,7 +1127,7 @@ class Testauto_check_sbp_navigation_MsgPosLLH1 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1912,7 +1912,7 @@ class Testauto_check_sbp_navigation_MsgPosLLH2 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2697,7 +2697,7 @@ class Testauto_check_sbp_navigation_MsgPosLLH3 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -3482,7 +3482,7 @@ class Testauto_check_sbp_navigation_MsgPosLLH4 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgPosLLHCov.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgPosLLHCov.cc
@@ -347,7 +347,7 @@ class Testauto_check_sbp_navigation_MsgPosLLHCov0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgPosLLHDepA.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgPosLLHDepA.cc
@@ -347,7 +347,7 @@ class Testauto_check_sbp_navigation_MsgPosLLHDepA0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1148,7 +1148,7 @@ class Testauto_check_sbp_navigation_MsgPosLLHDepA1 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1949,7 +1949,7 @@ class Testauto_check_sbp_navigation_MsgPosLLHDepA2 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2750,7 +2750,7 @@ class Testauto_check_sbp_navigation_MsgPosLLHDepA3 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -3551,7 +3551,7 @@ class Testauto_check_sbp_navigation_MsgPosLLHDepA4 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -4352,7 +4352,7 @@ class Testauto_check_sbp_navigation_MsgPosLLHDepA5 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -5153,7 +5153,7 @@ class Testauto_check_sbp_navigation_MsgPosLLHDepA6 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -5954,7 +5954,7 @@ class Testauto_check_sbp_navigation_MsgPosLLHDepA7 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -6755,7 +6755,7 @@ class Testauto_check_sbp_navigation_MsgPosLLHDepA8 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -7556,7 +7556,7 @@ class Testauto_check_sbp_navigation_MsgPosLLHDepA9 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -8357,7 +8357,7 @@ class Testauto_check_sbp_navigation_MsgPosLLHDepA10 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgPosLlhAcc.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgPosLlhAcc.cc
@@ -350,7 +350,7 @@ class Testauto_check_sbp_navigation_MsgPosLlhAcc0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgPosLlhCovGnss.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgPosLlhCovGnss.cc
@@ -353,7 +353,7 @@ class Testauto_check_sbp_navigation_MsgPosLlhCovGnss0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgPosLlhGnss.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgPosLlhGnss.cc
@@ -346,7 +346,7 @@ class Testauto_check_sbp_navigation_MsgPosLlhGnss0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgPoseRelative.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgPoseRelative.cc
@@ -367,7 +367,7 @@ class Testauto_check_sbp_navigation_MsgPoseRelative0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgProtectionLevel.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgProtectionLevel.cc
@@ -363,7 +363,7 @@ class Testauto_check_sbp_navigation_MsgProtectionLevel0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgProtectionLevelDepA.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgProtectionLevelDepA.cc
@@ -351,7 +351,7 @@ class Testauto_check_sbp_navigation_MsgProtectionLevelDepA0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgReferenceFrameParam.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgReferenceFrameParam.cc
@@ -379,7 +379,7 @@ class Testauto_check_sbp_navigation_MsgReferenceFrameParam0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgUTCLeapSecond.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgUTCLeapSecond.cc
@@ -350,7 +350,7 @@ class Testauto_check_sbp_navigation_MsgUTCLeapSecond0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgUTCTime.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgUTCTime.cc
@@ -343,7 +343,7 @@ class Testauto_check_sbp_navigation_MsgUTCTime0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgUTCTimeGNSS.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgUTCTimeGNSS.cc
@@ -349,7 +349,7 @@ class Testauto_check_sbp_navigation_MsgUTCTimeGNSS0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgVelBody.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgVelBody.cc
@@ -346,7 +346,7 @@ class Testauto_check_sbp_navigation_MsgVelBody0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgVelCog.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgVelCog.cc
@@ -342,7 +342,7 @@ class Testauto_check_sbp_navigation_MsgVelCog0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1126,7 +1126,7 @@ class Testauto_check_sbp_navigation_MsgVelCog1 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1910,7 +1910,7 @@ class Testauto_check_sbp_navigation_MsgVelCog2 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgVelECEF.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgVelECEF.cc
@@ -341,7 +341,7 @@ class Testauto_check_sbp_navigation_MsgVelECEF0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1120,7 +1120,7 @@ class Testauto_check_sbp_navigation_MsgVelECEF1 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1899,7 +1899,7 @@ class Testauto_check_sbp_navigation_MsgVelECEF2 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2678,7 +2678,7 @@ class Testauto_check_sbp_navigation_MsgVelECEF3 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -3457,7 +3457,7 @@ class Testauto_check_sbp_navigation_MsgVelECEF4 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgVelECEFCov.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgVelECEFCov.cc
@@ -350,7 +350,7 @@ class Testauto_check_sbp_navigation_MsgVelECEFCov0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgVelECEFDepA.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgVelECEFDepA.cc
@@ -348,7 +348,7 @@ class Testauto_check_sbp_navigation_MsgVelECEFDepA0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1144,7 +1144,7 @@ class Testauto_check_sbp_navigation_MsgVelECEFDepA1 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1940,7 +1940,7 @@ class Testauto_check_sbp_navigation_MsgVelECEFDepA2 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2736,7 +2736,7 @@ class Testauto_check_sbp_navigation_MsgVelECEFDepA3 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -3532,7 +3532,7 @@ class Testauto_check_sbp_navigation_MsgVelECEFDepA4 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -4328,7 +4328,7 @@ class Testauto_check_sbp_navigation_MsgVelECEFDepA5 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -5124,7 +5124,7 @@ class Testauto_check_sbp_navigation_MsgVelECEFDepA6 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -5919,7 +5919,7 @@ class Testauto_check_sbp_navigation_MsgVelECEFDepA7 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -6714,7 +6714,7 @@ class Testauto_check_sbp_navigation_MsgVelECEFDepA8 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -7510,7 +7510,7 @@ class Testauto_check_sbp_navigation_MsgVelECEFDepA9 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -8306,7 +8306,7 @@ class Testauto_check_sbp_navigation_MsgVelECEFDepA10 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgVelEcefCovGnss.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgVelEcefCovGnss.cc
@@ -354,7 +354,7 @@ class Testauto_check_sbp_navigation_MsgVelEcefCovGnss0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgVelEcefGnss.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgVelEcefGnss.cc
@@ -347,7 +347,7 @@ class Testauto_check_sbp_navigation_MsgVelEcefGnss0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgVelNED.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgVelNED.cc
@@ -342,7 +342,7 @@ class Testauto_check_sbp_navigation_MsgVelNED0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1125,7 +1125,7 @@ class Testauto_check_sbp_navigation_MsgVelNED1 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1908,7 +1908,7 @@ class Testauto_check_sbp_navigation_MsgVelNED2 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2691,7 +2691,7 @@ class Testauto_check_sbp_navigation_MsgVelNED3 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -3474,7 +3474,7 @@ class Testauto_check_sbp_navigation_MsgVelNED4 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgVelNEDCOV.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgVelNEDCOV.cc
@@ -347,7 +347,7 @@ class Testauto_check_sbp_navigation_MsgVelNEDCOV0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgVelNEDDepA.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgVelNEDDepA.cc
@@ -347,7 +347,7 @@ class Testauto_check_sbp_navigation_MsgVelNEDDepA0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1146,7 +1146,7 @@ class Testauto_check_sbp_navigation_MsgVelNEDDepA1 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1945,7 +1945,7 @@ class Testauto_check_sbp_navigation_MsgVelNEDDepA2 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2744,7 +2744,7 @@ class Testauto_check_sbp_navigation_MsgVelNEDDepA3 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -3543,7 +3543,7 @@ class Testauto_check_sbp_navigation_MsgVelNEDDepA4 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -4342,7 +4342,7 @@ class Testauto_check_sbp_navigation_MsgVelNEDDepA5 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -5141,7 +5141,7 @@ class Testauto_check_sbp_navigation_MsgVelNEDDepA6 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -5940,7 +5940,7 @@ class Testauto_check_sbp_navigation_MsgVelNEDDepA7 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -6739,7 +6739,7 @@ class Testauto_check_sbp_navigation_MsgVelNEDDepA8 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -7538,7 +7538,7 @@ class Testauto_check_sbp_navigation_MsgVelNEDDepA9 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -8337,7 +8337,7 @@ class Testauto_check_sbp_navigation_MsgVelNEDDepA10 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgVelNedCovGnss.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgVelNedCovGnss.cc
@@ -353,7 +353,7 @@ class Testauto_check_sbp_navigation_MsgVelNedCovGnss0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_navigation_MsgVelNedGnss.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgVelNedGnss.cc
@@ -346,7 +346,7 @@ class Testauto_check_sbp_navigation_MsgVelNedGnss0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_ndb_MsgNdbEvent.cc
+++ b/c/test/cpp/auto_check_sbp_ndb_MsgNdbEvent.cc
@@ -344,7 +344,7 @@ class Testauto_check_sbp_ndb_MsgNdbEvent0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgAlmanacGLO.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgAlmanacGLO.cc
@@ -352,7 +352,7 @@ class Testauto_check_sbp_observation_MsgAlmanacGLO0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgAlmanacGLODep.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgAlmanacGLODep.cc
@@ -358,7 +358,7 @@ class Testauto_check_sbp_observation_MsgAlmanacGLODep0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgAlmanacGPS.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgAlmanacGPS.cc
@@ -354,7 +354,7 @@ class Testauto_check_sbp_observation_MsgAlmanacGPS0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgAlmanacGPSDep.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgAlmanacGPSDep.cc
@@ -360,7 +360,7 @@ class Testauto_check_sbp_observation_MsgAlmanacGPSDep0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgBasePosEcef.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgBasePosEcef.cc
@@ -343,7 +343,7 @@ class Testauto_check_sbp_observation_MsgBasePosEcef0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgBasePosLLH.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgBasePosLLH.cc
@@ -341,7 +341,7 @@ class Testauto_check_sbp_observation_MsgBasePosLLH0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisBds.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisBds.cc
@@ -372,7 +372,7 @@ class Testauto_check_sbp_observation_MsgEphemerisBds0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisDepA.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisDepA.cc
@@ -368,7 +368,7 @@ class Testauto_check_sbp_observation_MsgEphemerisDepA0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisDepC.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisDepC.cc
@@ -373,7 +373,7 @@ class Testauto_check_sbp_observation_MsgEphemerisDepC0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisDepD.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisDepD.cc
@@ -373,7 +373,7 @@ class Testauto_check_sbp_observation_MsgEphemerisDepD0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGLO.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGLO.cc
@@ -370,7 +370,7 @@ class Testauto_check_sbp_observation_MsgEphemerisGLO0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGLODepA.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGLODepA.cc
@@ -370,7 +370,7 @@ class Testauto_check_sbp_observation_MsgEphemerisGLODepA0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGLODepB.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGLODepB.cc
@@ -369,7 +369,7 @@ class Testauto_check_sbp_observation_MsgEphemerisGLODepB0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGLODepC.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGLODepC.cc
@@ -371,7 +371,7 @@ class Testauto_check_sbp_observation_MsgEphemerisGLODepC0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGLODepD.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGLODepD.cc
@@ -372,7 +372,7 @@ class Testauto_check_sbp_observation_MsgEphemerisGLODepD0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGPS.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGPS.cc
@@ -371,7 +371,7 @@ class Testauto_check_sbp_observation_MsgEphemerisGPS0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGPSDepE.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGPSDepE.cc
@@ -374,7 +374,7 @@ class Testauto_check_sbp_observation_MsgEphemerisGPSDepE0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGPSDepF.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGPSDepF.cc
@@ -373,7 +373,7 @@ class Testauto_check_sbp_observation_MsgEphemerisGPSDepF0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGal.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGal.cc
@@ -373,7 +373,7 @@ class Testauto_check_sbp_observation_MsgEphemerisGal0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGalDepA.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGalDepA.cc
@@ -374,7 +374,7 @@ class Testauto_check_sbp_observation_MsgEphemerisGalDepA0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisSbas.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisSbas.cc
@@ -370,7 +370,7 @@ class Testauto_check_sbp_observation_MsgEphemerisSbas0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisSbasDepA.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisSbasDepA.cc
@@ -371,7 +371,7 @@ class Testauto_check_sbp_observation_MsgEphemerisSbasDepA0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisSbasDepB.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisSbasDepB.cc
@@ -370,7 +370,7 @@ class Testauto_check_sbp_observation_MsgEphemerisSbasDepB0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgGloBiases.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgGloBiases.cc
@@ -340,7 +340,7 @@ class Testauto_check_sbp_observation_MsgGloBiases0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgGnssCapb.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgGnssCapb.cc
@@ -351,7 +351,7 @@ class Testauto_check_sbp_observation_MsgGnssCapb0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgGroupDelay.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgGroupDelay.cc
@@ -345,7 +345,7 @@ class Testauto_check_sbp_observation_MsgGroupDelay0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgGroupDelayDepA.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgGroupDelayDepA.cc
@@ -349,7 +349,7 @@ class Testauto_check_sbp_observation_MsgGroupDelayDepA0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgGroupDelayDepB.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgGroupDelayDepB.cc
@@ -351,7 +351,7 @@ class Testauto_check_sbp_observation_MsgGroupDelayDepB0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgIono.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgIono.cc
@@ -343,7 +343,7 @@ class Testauto_check_sbp_observation_MsgIono0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgObs.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgObs.cc
@@ -489,7 +489,7 @@ class Testauto_check_sbp_observation_MsgObs0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2144,7 +2144,7 @@ class Testauto_check_sbp_observation_MsgObs1 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgObsDepB.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgObsDepB.cc
@@ -392,7 +392,7 @@ class Testauto_check_sbp_observation_MsgObsDepB0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1502,7 +1502,7 @@ class Testauto_check_sbp_observation_MsgObsDepB1 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2483,7 +2483,7 @@ class Testauto_check_sbp_observation_MsgObsDepB2 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -3593,7 +3593,7 @@ class Testauto_check_sbp_observation_MsgObsDepB3 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -4574,7 +4574,7 @@ class Testauto_check_sbp_observation_MsgObsDepB4 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgObsDepC.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgObsDepC.cc
@@ -383,7 +383,7 @@ class Testauto_check_sbp_observation_MsgObsDepC0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1441,7 +1441,7 @@ class Testauto_check_sbp_observation_MsgObsDepC1 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2413,7 +2413,7 @@ class Testauto_check_sbp_observation_MsgObsDepC2 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -3471,7 +3471,7 @@ class Testauto_check_sbp_observation_MsgObsDepC3 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -4443,7 +4443,7 @@ class Testauto_check_sbp_observation_MsgObsDepC4 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgOsr.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgOsr.cc
@@ -467,7 +467,7 @@ class Testauto_check_sbp_observation_MsgOsr0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgSvAzEl.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgSvAzEl.cc
@@ -499,7 +499,7 @@ class Testauto_check_sbp_observation_MsgSvAzEl0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_MsgSvConfigurationGpsDep.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgSvConfigurationGpsDep.cc
@@ -349,7 +349,7 @@ class Testauto_check_sbp_observation_MsgSvConfigurationGpsDep0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_msgEphemerisDepB.cc
+++ b/c/test/cpp/auto_check_sbp_observation_msgEphemerisDepB.cc
@@ -369,7 +369,7 @@ class Testauto_check_sbp_observation_msgEphemerisDepB0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1332,7 +1332,7 @@ class Testauto_check_sbp_observation_msgEphemerisDepB1
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2295,7 +2295,7 @@ class Testauto_check_sbp_observation_msgEphemerisDepB2
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -3258,7 +3258,7 @@ class Testauto_check_sbp_observation_msgEphemerisDepB3
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -4221,7 +4221,7 @@ class Testauto_check_sbp_observation_msgEphemerisDepB4
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -5184,7 +5184,7 @@ class Testauto_check_sbp_observation_msgEphemerisDepB5
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_msgEphemerisQzss.cc
+++ b/c/test/cpp/auto_check_sbp_observation_msgEphemerisQzss.cc
@@ -373,7 +373,7 @@ class Testauto_check_sbp_observation_msgEphemerisQzss0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_observation_msgObsDepA.cc
+++ b/c/test/cpp/auto_check_sbp_observation_msgObsDepA.cc
@@ -387,7 +387,7 @@ class Testauto_check_sbp_observation_msgObsDepA0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1437,7 +1437,7 @@ class Testauto_check_sbp_observation_msgObsDepA1 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2296,7 +2296,7 @@ class Testauto_check_sbp_observation_msgObsDepA2 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -3346,7 +3346,7 @@ class Testauto_check_sbp_observation_msgObsDepA3 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -4191,7 +4191,7 @@ class Testauto_check_sbp_observation_msgObsDepA4 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -5191,7 +5191,7 @@ class Testauto_check_sbp_observation_msgObsDepA5 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_orientation_MsgAngularRate.cc
+++ b/c/test/cpp/auto_check_sbp_orientation_MsgAngularRate.cc
@@ -344,7 +344,7 @@ class Testauto_check_sbp_orientation_MsgAngularRate0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_orientation_MsgBaselineHeading.cc
+++ b/c/test/cpp/auto_check_sbp_orientation_MsgBaselineHeading.cc
@@ -346,7 +346,7 @@ class Testauto_check_sbp_orientation_MsgBaselineHeading0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_orientation_MsgOrientEuler.cc
+++ b/c/test/cpp/auto_check_sbp_orientation_MsgOrientEuler.cc
@@ -347,7 +347,7 @@ class Testauto_check_sbp_orientation_MsgOrientEuler0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_orientation_MsgOrientQuat.cc
+++ b/c/test/cpp/auto_check_sbp_orientation_MsgOrientQuat.cc
@@ -347,7 +347,7 @@ class Testauto_check_sbp_orientation_MsgOrientQuat0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_piksi_MsgAlmanac.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgAlmanac.cc
@@ -333,7 +333,7 @@ class Testauto_check_sbp_piksi_MsgAlmanac0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_piksi_MsgCellModemStatus.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgCellModemStatus.cc
@@ -844,7 +844,7 @@ class Testauto_check_sbp_piksi_MsgCellModemStatus0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_piksi_MsgCommandOutput.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgCommandOutput.cc
@@ -347,7 +347,7 @@ class Testauto_check_sbp_piksi_MsgCommandOutput0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_piksi_MsgCommandReq.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgCommandReq.cc
@@ -343,7 +343,7 @@ class Testauto_check_sbp_piksi_MsgCommandReq0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_piksi_MsgCommandResp.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgCommandResp.cc
@@ -341,7 +341,7 @@ class Testauto_check_sbp_piksi_MsgCommandResp0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_piksi_MsgCwResults.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgCwResults.cc
@@ -334,7 +334,7 @@ class Testauto_check_sbp_piksi_MsgCwResults0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_piksi_MsgCwStart.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgCwStart.cc
@@ -333,7 +333,7 @@ class Testauto_check_sbp_piksi_MsgCwStart0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_piksi_MsgDeviceMonitor.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgDeviceMonitor.cc
@@ -346,7 +346,7 @@ class Testauto_check_sbp_piksi_MsgDeviceMonitor0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1125,7 +1125,7 @@ class Testauto_check_sbp_piksi_MsgDeviceMonitor1 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1904,7 +1904,7 @@ class Testauto_check_sbp_piksi_MsgDeviceMonitor2 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2683,7 +2683,7 @@ class Testauto_check_sbp_piksi_MsgDeviceMonitor3 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -3462,7 +3462,7 @@ class Testauto_check_sbp_piksi_MsgDeviceMonitor4 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_piksi_MsgFrontEndGain.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgFrontEndGain.cc
@@ -372,7 +372,7 @@ class Testauto_check_sbp_piksi_MsgFrontEndGain0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_piksi_MsgIarState.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgIarState.cc
@@ -333,7 +333,7 @@ class Testauto_check_sbp_piksi_MsgIarState0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1065,7 +1065,7 @@ class Testauto_check_sbp_piksi_MsgIarState1 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1797,7 +1797,7 @@ class Testauto_check_sbp_piksi_MsgIarState2 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2529,7 +2529,7 @@ class Testauto_check_sbp_piksi_MsgIarState3 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -3261,7 +3261,7 @@ class Testauto_check_sbp_piksi_MsgIarState4 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -3993,7 +3993,7 @@ class Testauto_check_sbp_piksi_MsgIarState5 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -4725,7 +4725,7 @@ class Testauto_check_sbp_piksi_MsgIarState6 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_piksi_MsgInitBaseDep.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgInitBaseDep.cc
@@ -339,7 +339,7 @@ class Testauto_check_sbp_piksi_MsgInitBaseDep0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_piksi_MsgMaskSatellite.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgMaskSatellite.cc
@@ -344,7 +344,7 @@ class Testauto_check_sbp_piksi_MsgMaskSatellite0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_piksi_MsgMaskSatelliteDep.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgMaskSatelliteDep.cc
@@ -345,7 +345,7 @@ class Testauto_check_sbp_piksi_MsgMaskSatelliteDep0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_piksi_MsgNetworkBandwidthUsage.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgNetworkBandwidthUsage.cc
@@ -410,7 +410,7 @@ class Testauto_check_sbp_piksi_MsgNetworkBandwidthUsage0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_piksi_MsgNetworkStateReq.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgNetworkStateReq.cc
@@ -340,7 +340,7 @@ class Testauto_check_sbp_piksi_MsgNetworkStateReq0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_piksi_MsgNetworkStateResp.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgNetworkStateResp.cc
@@ -393,7 +393,7 @@ class Testauto_check_sbp_piksi_MsgNetworkStateResp0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_piksi_MsgReset.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgReset.cc
@@ -333,7 +333,7 @@ class Testauto_check_sbp_piksi_MsgReset0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_piksi_MsgResetDep.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgResetDep.cc
@@ -333,7 +333,7 @@ class Testauto_check_sbp_piksi_MsgResetDep0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_piksi_MsgResetFilters.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgResetFilters.cc
@@ -339,7 +339,7 @@ class Testauto_check_sbp_piksi_MsgResetFilters0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_piksi_MsgSetTime.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgSetTime.cc
@@ -333,7 +333,7 @@ class Testauto_check_sbp_piksi_MsgSetTime0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_piksi_MsgSpecan.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgSpecan.cc
@@ -797,7 +797,7 @@ class Testauto_check_sbp_piksi_MsgSpecan0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_piksi_MsgSpecanDep.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgSpecanDep.cc
@@ -805,7 +805,7 @@ class Testauto_check_sbp_piksi_MsgSpecanDep0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_piksi_MsgThreadState.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgThreadState.cc
@@ -348,7 +348,7 @@ class Testauto_check_sbp_piksi_MsgThreadState0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1111,7 +1111,7 @@ class Testauto_check_sbp_piksi_MsgThreadState1 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1874,7 +1874,7 @@ class Testauto_check_sbp_piksi_MsgThreadState2 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2637,7 +2637,7 @@ class Testauto_check_sbp_piksi_MsgThreadState3 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -3401,7 +3401,7 @@ class Testauto_check_sbp_piksi_MsgThreadState4 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -4164,7 +4164,7 @@ class Testauto_check_sbp_piksi_MsgThreadState5 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -4927,7 +4927,7 @@ class Testauto_check_sbp_piksi_MsgThreadState6 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -5690,7 +5690,7 @@ class Testauto_check_sbp_piksi_MsgThreadState7 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -6453,7 +6453,7 @@ class Testauto_check_sbp_piksi_MsgThreadState8 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -7217,7 +7217,7 @@ class Testauto_check_sbp_piksi_MsgThreadState9 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -7981,7 +7981,7 @@ class Testauto_check_sbp_piksi_MsgThreadState10 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_piksi_MsgUartState.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgUartState.cc
@@ -361,7 +361,7 @@ class Testauto_check_sbp_piksi_MsgUartState0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1301,7 +1301,7 @@ class Testauto_check_sbp_piksi_MsgUartState1 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2220,7 +2220,7 @@ class Testauto_check_sbp_piksi_MsgUartState2 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_piksi_MsgUartStateDepA.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgUartStateDepA.cc
@@ -363,7 +363,7 @@ class Testauto_check_sbp_piksi_MsgUartStateDepA0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1284,7 +1284,7 @@ class Testauto_check_sbp_piksi_MsgUartStateDepA1 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2205,7 +2205,7 @@ class Testauto_check_sbp_piksi_MsgUartStateDepA2 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -3126,7 +3126,7 @@ class Testauto_check_sbp_piksi_MsgUartStateDepA3 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -4047,7 +4047,7 @@ class Testauto_check_sbp_piksi_MsgUartStateDepA4 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -4969,7 +4969,7 @@ class Testauto_check_sbp_piksi_MsgUartStateDepA5 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_profiling_MsgMeasurementPoint.cc
+++ b/c/test/cpp/auto_check_sbp_profiling_MsgMeasurementPoint.cc
@@ -355,7 +355,7 @@ class Testauto_check_sbp_profiling_MsgMeasurementPoint0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_sbas_MsgSbasRaw.cc
+++ b/c/test/cpp/auto_check_sbp_sbas_MsgSbasRaw.cc
@@ -391,7 +391,7 @@ class Testauto_check_sbp_sbas_MsgSbasRaw0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_settings_MsgSettingsReadByIndexDone.cc
+++ b/c/test/cpp/auto_check_sbp_settings_MsgSettingsReadByIndexDone.cc
@@ -345,7 +345,7 @@ class Testauto_check_sbp_settings_MsgSettingsReadByIndexDone0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_settings_MsgSettingsReadByIndexReq.cc
+++ b/c/test/cpp/auto_check_sbp_settings_MsgSettingsReadByIndexReq.cc
@@ -347,7 +347,7 @@ class Testauto_check_sbp_settings_MsgSettingsReadByIndexReq0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_settings_MsgSettingsReadByIndexResp.cc
+++ b/c/test/cpp/auto_check_sbp_settings_MsgSettingsReadByIndexResp.cc
@@ -357,7 +357,7 @@ class Testauto_check_sbp_settings_MsgSettingsReadByIndexResp0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1389,7 +1389,7 @@ class Testauto_check_sbp_settings_MsgSettingsReadByIndexResp1
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2443,7 +2443,7 @@ class Testauto_check_sbp_settings_MsgSettingsReadByIndexResp2
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -3467,7 +3467,7 @@ class Testauto_check_sbp_settings_MsgSettingsReadByIndexResp3
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -4492,7 +4492,7 @@ class Testauto_check_sbp_settings_MsgSettingsReadByIndexResp4
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_settings_MsgSettingsReadReq.cc
+++ b/c/test/cpp/auto_check_sbp_settings_MsgSettingsReadReq.cc
@@ -346,7 +346,7 @@ class Testauto_check_sbp_settings_MsgSettingsReadReq0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_settings_MsgSettingsReadResp.cc
+++ b/c/test/cpp/auto_check_sbp_settings_MsgSettingsReadResp.cc
@@ -351,7 +351,7 @@ class Testauto_check_sbp_settings_MsgSettingsReadResp0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_settings_MsgSettingsRegister.cc
+++ b/c/test/cpp/auto_check_sbp_settings_MsgSettingsRegister.cc
@@ -351,7 +351,7 @@ class Testauto_check_sbp_settings_MsgSettingsRegister0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_settings_MsgSettingsRegisterResp.cc
+++ b/c/test/cpp/auto_check_sbp_settings_MsgSettingsRegisterResp.cc
@@ -355,7 +355,7 @@ class Testauto_check_sbp_settings_MsgSettingsRegisterResp0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_settings_MsgSettingsSave.cc
+++ b/c/test/cpp/auto_check_sbp_settings_MsgSettingsSave.cc
@@ -339,7 +339,7 @@ class Testauto_check_sbp_settings_MsgSettingsSave0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_settings_MsgSettingsWrite.cc
+++ b/c/test/cpp/auto_check_sbp_settings_MsgSettingsWrite.cc
@@ -348,7 +348,7 @@ class Testauto_check_sbp_settings_MsgSettingsWrite0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_settings_MsgSettingsWriteResp.cc
+++ b/c/test/cpp/auto_check_sbp_settings_MsgSettingsWriteResp.cc
@@ -352,7 +352,7 @@ class Testauto_check_sbp_settings_MsgSettingsWriteResp0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_signing_MsgCertificateChain.cc
+++ b/c/test/cpp/auto_check_sbp_signing_MsgCertificateChain.cc
@@ -612,7 +612,7 @@ class Testauto_check_sbp_signing_MsgCertificateChain0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_signing_MsgCertificateChainDep.cc
+++ b/c/test/cpp/auto_check_sbp_signing_MsgCertificateChainDep.cc
@@ -597,7 +597,7 @@ class Testauto_check_sbp_signing_MsgCertificateChainDep0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_signing_MsgEcdsaCertificate.cc
+++ b/c/test/cpp/auto_check_sbp_signing_MsgEcdsaCertificate.cc
@@ -845,7 +845,7 @@ class Testauto_check_sbp_signing_MsgEcdsaCertificate0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_signing_MsgEcdsaSignature.cc
+++ b/c/test/cpp/auto_check_sbp_signing_MsgEcdsaSignature.cc
@@ -503,7 +503,7 @@ class Testauto_check_sbp_signing_MsgEcdsaSignature0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_signing_MsgEcdsaSignatureDepA.cc
+++ b/c/test/cpp/auto_check_sbp_signing_MsgEcdsaSignatureDepA.cc
@@ -850,7 +850,7 @@ class Testauto_check_sbp_signing_MsgEcdsaSignatureDepA0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_signing_MsgEcdsaSignatureDepB.cc
+++ b/c/test/cpp/auto_check_sbp_signing_MsgEcdsaSignatureDepB.cc
@@ -505,7 +505,7 @@ class Testauto_check_sbp_signing_MsgEcdsaSignatureDepB0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_signing_MsgEd25519CertificateDep.cc
+++ b/c/test/cpp/auto_check_sbp_signing_MsgEd25519CertificateDep.cc
@@ -556,7 +556,7 @@ class Testauto_check_sbp_signing_MsgEd25519CertificateDep0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_signing_MsgEd25519SignatureDepA.cc
+++ b/c/test/cpp/auto_check_sbp_signing_MsgEd25519SignatureDepA.cc
@@ -563,7 +563,7 @@ class Testauto_check_sbp_signing_MsgEd25519SignatureDepA0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_signing_MsgEd25519SignatureDepB.cc
+++ b/c/test/cpp/auto_check_sbp_signing_MsgEd25519SignatureDepB.cc
@@ -565,7 +565,7 @@ class Testauto_check_sbp_signing_MsgEd25519SignatureDepB0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_solution_meta_MsgSolnMeta.cc
+++ b/c/test/cpp/auto_check_sbp_solution_meta_MsgSolnMeta.cc
@@ -698,7 +698,7 @@ class Testauto_check_sbp_solution_meta_MsgSolnMeta0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_solution_meta_MsgSolnMetaDepA.cc
+++ b/c/test/cpp/auto_check_sbp_solution_meta_MsgSolnMetaDepA.cc
@@ -705,7 +705,7 @@ class Testauto_check_sbp_solution_meta_MsgSolnMetaDepA0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrCodeBiases.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrCodeBiases.cc
@@ -590,7 +590,7 @@ class Testauto_check_sbp_ssr_MsgSsrCodeBiases0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrCodePhaseBiasesBounds.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrCodePhaseBiasesBounds.cc
@@ -376,7 +376,7 @@ class Testauto_check_sbp_ssr_MsgSsrCodePhaseBiasesBounds0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrGridDefinitionDepA.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrGridDefinitionDepA.cc
@@ -845,7 +845,7 @@ class Testauto_check_sbp_ssr_MsgSsrGridDefinitionDepA0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrGriddedCorrection.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrGriddedCorrection.cc
@@ -587,7 +587,7 @@ class Testauto_check_sbp_ssr_MsgSsrGriddedCorrection0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrGriddedCorrectionBounds.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrGriddedCorrectionBounds.cc
@@ -385,7 +385,7 @@ class Testauto_check_sbp_ssr_MsgSsrGriddedCorrectionBounds0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1437,7 +1437,7 @@ class Testauto_check_sbp_ssr_MsgSsrGriddedCorrectionBounds1
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrGriddedCorrectionDepA.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrGriddedCorrectionDepA.cc
@@ -593,7 +593,7 @@ class Testauto_check_sbp_ssr_MsgSsrGriddedCorrectionDepA0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrGriddedCorrectionNoStdDepA.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrGriddedCorrectionNoStdDepA.cc
@@ -597,7 +597,7 @@ class Testauto_check_sbp_ssr_MsgSsrGriddedCorrectionNoStdDepA0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrOrbitClock.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrOrbitClock.cc
@@ -357,7 +357,7 @@ class Testauto_check_sbp_ssr_MsgSsrOrbitClock0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrOrbitClockBounds.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrOrbitClockBounds.cc
@@ -372,7 +372,7 @@ class Testauto_check_sbp_ssr_MsgSsrOrbitClockBounds0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrOrbitClockBoundsDegradation.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrOrbitClockBoundsDegradation.cc
@@ -373,7 +373,7 @@ class Testauto_check_sbp_ssr_MsgSsrOrbitClockBoundsDegradation0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrOrbitClockDepA.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrOrbitClockDepA.cc
@@ -358,7 +358,7 @@ class Testauto_check_sbp_ssr_MsgSsrOrbitClockDepA0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrPhaseBiases.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrPhaseBiases.cc
@@ -531,7 +531,7 @@ class Testauto_check_sbp_ssr_MsgSsrPhaseBiases0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrSatelliteApc.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrSatelliteApc.cc
@@ -398,7 +398,7 @@ class Testauto_check_sbp_ssr_MsgSsrSatelliteApc0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrSatelliteApcDepA.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrSatelliteApcDepA.cc
@@ -706,7 +706,7 @@ class Testauto_check_sbp_ssr_MsgSsrSatelliteApcDepA0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrStecCorrection.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrStecCorrection.cc
@@ -373,7 +373,7 @@ class Testauto_check_sbp_ssr_MsgSsrStecCorrection0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrStecCorrectionDep.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrStecCorrectionDep.cc
@@ -584,7 +584,7 @@ class Testauto_check_sbp_ssr_MsgSsrStecCorrectionDep0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrStecCorrectionDepA.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrStecCorrectionDepA.cc
@@ -595,7 +595,7 @@ class Testauto_check_sbp_ssr_MsgSsrStecCorrectionDepA0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrTileDefinition.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrTileDefinition.cc
@@ -355,7 +355,7 @@ class Testauto_check_sbp_ssr_MsgSsrTileDefinition0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrTileDefinitionDepA.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrTileDefinitionDepA.cc
@@ -355,7 +355,7 @@ class Testauto_check_sbp_ssr_MsgSsrTileDefinitionDepA0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrTileDefinitionDepB.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrTileDefinitionDepB.cc
@@ -356,7 +356,7 @@ class Testauto_check_sbp_ssr_MsgSsrTileDefinitionDepB0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_system_MsgCsacTelemetry.cc
+++ b/c/test/cpp/auto_check_sbp_system_MsgCsacTelemetry.cc
@@ -348,7 +348,7 @@ class Testauto_check_sbp_system_MsgCsacTelemetry0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_system_MsgCsacTelemetryLabels.cc
+++ b/c/test/cpp/auto_check_sbp_system_MsgCsacTelemetryLabels.cc
@@ -352,7 +352,7 @@ class Testauto_check_sbp_system_MsgCsacTelemetryLabels0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_system_MsgDgnssStatus.cc
+++ b/c/test/cpp/auto_check_sbp_system_MsgDgnssStatus.cc
@@ -348,7 +348,7 @@ class Testauto_check_sbp_system_MsgDgnssStatus0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_system_MsgGnssTimeOffset.cc
+++ b/c/test/cpp/auto_check_sbp_system_MsgGnssTimeOffset.cc
@@ -345,7 +345,7 @@ class Testauto_check_sbp_system_MsgGnssTimeOffset0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_system_MsgGroupMeta.cc
+++ b/c/test/cpp/auto_check_sbp_system_MsgGroupMeta.cc
@@ -344,7 +344,7 @@ class Testauto_check_sbp_system_MsgGroupMeta0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1158,7 +1158,7 @@ class Testauto_check_sbp_system_MsgGroupMeta1 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_system_MsgHeartbeat.cc
+++ b/c/test/cpp/auto_check_sbp_system_MsgHeartbeat.cc
@@ -334,7 +334,7 @@ class Testauto_check_sbp_system_MsgHeartbeat0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1069,7 +1069,7 @@ class Testauto_check_sbp_system_MsgHeartbeat1 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_system_MsgInsStatus.cc
+++ b/c/test/cpp/auto_check_sbp_system_MsgInsStatus.cc
@@ -336,7 +336,7 @@ class Testauto_check_sbp_system_MsgInsStatus0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_system_MsgInsUpdates.cc
+++ b/c/test/cpp/auto_check_sbp_system_MsgInsUpdates.cc
@@ -344,7 +344,7 @@ class Testauto_check_sbp_system_MsgInsUpdates0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_system_MsgPpsTime.cc
+++ b/c/test/cpp/auto_check_sbp_system_MsgPpsTime.cc
@@ -336,7 +336,7 @@ class Testauto_check_sbp_system_MsgPpsTime0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_system_MsgSensorAidEvent.cc
+++ b/c/test/cpp/auto_check_sbp_system_MsgSensorAidEvent.cc
@@ -349,7 +349,7 @@ class Testauto_check_sbp_system_MsgSensorAidEvent0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_system_MsgStartup.cc
+++ b/c/test/cpp/auto_check_sbp_system_MsgStartup.cc
@@ -337,7 +337,7 @@ class Testauto_check_sbp_system_MsgStartup0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1085,7 +1085,7 @@ class Testauto_check_sbp_system_MsgStartup1 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_system_MsgStatusJournal.cc
+++ b/c/test/cpp/auto_check_sbp_system_MsgStatusJournal.cc
@@ -360,7 +360,7 @@ class Testauto_check_sbp_system_MsgStatusJournal0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1248,7 +1248,7 @@ class Testauto_check_sbp_system_MsgStatusJournal1 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_system_MsgStatusReport.cc
+++ b/c/test/cpp/auto_check_sbp_system_MsgStatusReport.cc
@@ -585,7 +585,7 @@ class Testauto_check_sbp_system_MsgStatusReport0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_telemetry_MsgTelSv.cc
+++ b/c/test/cpp/auto_check_sbp_telemetry_MsgTelSv.cc
@@ -350,7 +350,7 @@ class Testauto_check_sbp_telemetry_MsgTelSv0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_tracking_MsgMeasurementState.cc
+++ b/c/test/cpp/auto_check_sbp_tracking_MsgMeasurementState.cc
@@ -659,7 +659,7 @@ class Testauto_check_sbp_tracking_MsgMeasurementState0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_tracking_MsgTrackingIq.cc
+++ b/c/test/cpp/auto_check_sbp_tracking_MsgTrackingIq.cc
@@ -349,7 +349,7 @@ class Testauto_check_sbp_tracking_MsgTrackingIq0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_tracking_MsgTrackingIqDepA.cc
+++ b/c/test/cpp/auto_check_sbp_tracking_MsgTrackingIqDepA.cc
@@ -354,7 +354,7 @@ class Testauto_check_sbp_tracking_MsgTrackingIqDepA0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_tracking_MsgTrackingIqDepB.cc
+++ b/c/test/cpp/auto_check_sbp_tracking_MsgTrackingIqDepB.cc
@@ -353,7 +353,7 @@ class Testauto_check_sbp_tracking_MsgTrackingIqDepB0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_tracking_MsgTrackingState.cc
+++ b/c/test/cpp/auto_check_sbp_tracking_MsgTrackingState.cc
@@ -657,7 +657,7 @@ class Testauto_check_sbp_tracking_MsgTrackingState0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -3152,7 +3152,7 @@ class Testauto_check_sbp_tracking_MsgTrackingState1 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -4353,7 +4353,7 @@ class Testauto_check_sbp_tracking_MsgTrackingState2 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -5554,7 +5554,7 @@ class Testauto_check_sbp_tracking_MsgTrackingState3 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -6755,7 +6755,7 @@ class Testauto_check_sbp_tracking_MsgTrackingState4 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -7956,7 +7956,7 @@ class Testauto_check_sbp_tracking_MsgTrackingState5 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_tracking_MsgTrackingStateDepB.cc
+++ b/c/test/cpp/auto_check_sbp_tracking_MsgTrackingStateDepB.cc
@@ -511,7 +511,7 @@ class Testauto_check_sbp_tracking_MsgTrackingStateDepB0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_tracking_MsgTrackingStateDetailedDep.cc
+++ b/c/test/cpp/auto_check_sbp_tracking_MsgTrackingStateDetailedDep.cc
@@ -371,7 +371,7 @@ class Testauto_check_sbp_tracking_MsgTrackingStateDetailedDep0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1325,7 +1325,7 @@ class Testauto_check_sbp_tracking_MsgTrackingStateDetailedDep1
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2278,7 +2278,7 @@ class Testauto_check_sbp_tracking_MsgTrackingStateDetailedDep2
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -3231,7 +3231,7 @@ class Testauto_check_sbp_tracking_MsgTrackingStateDetailedDep3
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -4185,7 +4185,7 @@ class Testauto_check_sbp_tracking_MsgTrackingStateDetailedDep4
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_tracking_MsgTrackingStateDetailedDepA.cc
+++ b/c/test/cpp/auto_check_sbp_tracking_MsgTrackingStateDetailedDepA.cc
@@ -373,7 +373,7 @@ class Testauto_check_sbp_tracking_MsgTrackingStateDetailedDepA0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_tracking_MsgtrackingStateDepA.cc
+++ b/c/test/cpp/auto_check_sbp_tracking_MsgtrackingStateDepA.cc
@@ -387,7 +387,7 @@ class Testauto_check_sbp_tracking_MsgtrackingStateDepA0
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -1425,7 +1425,7 @@ class Testauto_check_sbp_tracking_MsgtrackingStateDepA1
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -2463,7 +2463,7 @@ class Testauto_check_sbp_tracking_MsgtrackingStateDepA2
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -3501,7 +3501,7 @@ class Testauto_check_sbp_tracking_MsgtrackingStateDepA3
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -4538,7 +4538,7 @@ class Testauto_check_sbp_tracking_MsgtrackingStateDepA4
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;
@@ -5575,7 +5575,7 @@ class Testauto_check_sbp_tracking_MsgtrackingStateDepA5
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_user_MsgUserData.cc
+++ b/c/test/cpp/auto_check_sbp_user_MsgUserData.cc
@@ -844,7 +844,7 @@ class Testauto_check_sbp_user_MsgUserData0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_vehicle_MsgOdometry.cc
+++ b/c/test/cpp/auto_check_sbp_vehicle_MsgOdometry.cc
@@ -337,7 +337,7 @@ class Testauto_check_sbp_vehicle_MsgOdometry0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/cpp/auto_check_sbp_vehicle_MsgWheeltick.cc
+++ b/c/test/cpp/auto_check_sbp_vehicle_MsgWheeltick.cc
@@ -339,7 +339,7 @@ class Testauto_check_sbp_vehicle_MsgWheeltick0 : public ::testing::Test {
   template <typename T,
             std::enable_if_t<std::is_integral<T>::value, bool> = true>
   void make_lesser_greater(T &lesser, T &greater) {
-    if (greater == std::numeric_limits<T>::max()) {
+    if (lesser > std::numeric_limits<T>::min()) {
       lesser--;
     } else {
       greater++;

--- a/c/test/legacy/cpp/auto_check_sbp_acquisition_MsgAcqResult.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_acquisition_MsgAcqResult.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/legacy_state.h>
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_acquisition_MsgAcqResult0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -121,8 +128,12 @@ TEST_F(Test_legacy_auto_check_sbp_acquisition_MsgAcqResult0, Test) {
       << "incorrect value for cn0, expected 14.5, is " << last_msg_->cn0;
   EXPECT_LT((last_msg_->cp * 100 - 72.1999969482 * 100), 0.05)
       << "incorrect value for cp, expected 72.1999969482, is " << last_msg_->cp;
-  EXPECT_EQ(last_msg_->sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.code)),
+            0)
       << "incorrect value for sid.code, expected 0, is " << last_msg_->sid.code;
-  EXPECT_EQ(last_msg_->sid.sat, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.sat)),
+            8)
       << "incorrect value for sid.sat, expected 8, is " << last_msg_->sid.sat;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_acquisition_MsgAcqResultDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_acquisition_MsgAcqResultDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/legacy_state.h>
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_acquisition_MsgAcqResultDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -119,7 +126,9 @@ TEST_F(Test_legacy_auto_check_sbp_acquisition_MsgAcqResultDepA0, Test) {
       << "incorrect value for cf, expected 8241.94335938, is " << last_msg_->cf;
   EXPECT_LT((last_msg_->cp * 100 - 727.0 * 100), 0.05)
       << "incorrect value for cp, expected 727.0, is " << last_msg_->cp;
-  EXPECT_EQ(last_msg_->prn, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->prn)),
+            8)
       << "incorrect value for prn, expected 8, is " << last_msg_->prn;
   EXPECT_LT((last_msg_->snr * 100 - 14.5 * 100), 0.05)
       << "incorrect value for snr, expected 14.5, is " << last_msg_->snr;
@@ -214,7 +223,9 @@ TEST_F(Test_legacy_auto_check_sbp_acquisition_MsgAcqResultDepA1, Test) {
       << "incorrect value for cf, expected 749.26763916, is " << last_msg_->cf;
   EXPECT_LT((last_msg_->cp * 100 - 359.5 * 100), 0.05)
       << "incorrect value for cp, expected 359.5, is " << last_msg_->cp;
-  EXPECT_EQ(last_msg_->prn, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->prn)),
+            9)
       << "incorrect value for prn, expected 9, is " << last_msg_->prn;
   EXPECT_LT((last_msg_->snr * 100 - 15.3000001907 * 100), 0.05)
       << "incorrect value for snr, expected 15.3000001907, is "
@@ -311,7 +322,9 @@ TEST_F(Test_legacy_auto_check_sbp_acquisition_MsgAcqResultDepA2, Test) {
       << last_msg_->cf;
   EXPECT_LT((last_msg_->cp * 100 - 40.5 * 100), 0.05)
       << "incorrect value for cp, expected 40.5, is " << last_msg_->cp;
-  EXPECT_EQ(last_msg_->prn, 11)
+  EXPECT_EQ(get_as<decltype(last_msg_->prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->prn)),
+            11)
       << "incorrect value for prn, expected 11, is " << last_msg_->prn;
   EXPECT_LT((last_msg_->snr * 100 - 18.1000003815 * 100), 0.05)
       << "incorrect value for snr, expected 18.1000003815, is "
@@ -408,7 +421,9 @@ TEST_F(Test_legacy_auto_check_sbp_acquisition_MsgAcqResultDepA3, Test) {
       << last_msg_->cf;
   EXPECT_LT((last_msg_->cp * 100 - 548.5 * 100), 0.05)
       << "incorrect value for cp, expected 548.5, is " << last_msg_->cp;
-  EXPECT_EQ(last_msg_->prn, 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->prn)),
+            12)
       << "incorrect value for prn, expected 12, is " << last_msg_->prn;
   EXPECT_LT((last_msg_->snr * 100 - 15.3000001907 * 100), 0.05)
       << "incorrect value for snr, expected 15.3000001907, is "
@@ -504,7 +519,9 @@ TEST_F(Test_legacy_auto_check_sbp_acquisition_MsgAcqResultDepA4, Test) {
       << "incorrect value for cf, expected 4745.36132812, is " << last_msg_->cf;
   EXPECT_LT((last_msg_->cp * 100 - 780.5 * 100), 0.05)
       << "incorrect value for cp, expected 780.5, is " << last_msg_->cp;
-  EXPECT_EQ(last_msg_->prn, 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->prn)),
+            14)
       << "incorrect value for prn, expected 14, is " << last_msg_->prn;
   EXPECT_LT((last_msg_->snr * 100 - 15.3000001907 * 100), 0.05)
       << "incorrect value for snr, expected 15.3000001907, is "
@@ -601,7 +618,9 @@ TEST_F(Test_legacy_auto_check_sbp_acquisition_MsgAcqResultDepA5, Test) {
       << last_msg_->cf;
   EXPECT_LT((last_msg_->cp * 100 - 584.5 * 100), 0.05)
       << "incorrect value for cp, expected 584.5, is " << last_msg_->cp;
-  EXPECT_EQ(last_msg_->prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->prn)),
+            0)
       << "incorrect value for prn, expected 0, is " << last_msg_->prn;
   EXPECT_LT((last_msg_->snr * 100 - 163.222229004 * 100), 0.05)
       << "incorrect value for snr, expected 163.222229004, is "

--- a/c/test/legacy/cpp/auto_check_sbp_acquisition_MsgAcqResultDepB.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_acquisition_MsgAcqResultDepB.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/legacy_state.h>
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_acquisition_MsgAcqResultDepB0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -121,12 +128,18 @@ TEST_F(Test_legacy_auto_check_sbp_acquisition_MsgAcqResultDepB0, Test) {
       << "incorrect value for cf, expected 4995.1171875, is " << last_msg_->cf;
   EXPECT_LT((last_msg_->cp * 100 - 322.0 * 100), 0.05)
       << "incorrect value for cp, expected 322.0, is " << last_msg_->cp;
-  EXPECT_EQ(last_msg_->sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.code)),
+            0)
       << "incorrect value for sid.code, expected 0, is " << last_msg_->sid.code;
-  EXPECT_EQ(last_msg_->sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.reserved)),
+            0)
       << "incorrect value for sid.reserved, expected 0, is "
       << last_msg_->sid.reserved;
-  EXPECT_EQ(last_msg_->sid.sat, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.sat)),
+            9)
       << "incorrect value for sid.sat, expected 9, is " << last_msg_->sid.sat;
   EXPECT_LT((last_msg_->snr * 100 - 36.663608551 * 100), 0.05)
       << "incorrect value for snr, expected 36.663608551, is "
@@ -225,12 +238,18 @@ TEST_F(Test_legacy_auto_check_sbp_acquisition_MsgAcqResultDepB1, Test) {
       << last_msg_->cf;
   EXPECT_LT((last_msg_->cp * 100 - 843.0 * 100), 0.05)
       << "incorrect value for cp, expected 843.0, is " << last_msg_->cp;
-  EXPECT_EQ(last_msg_->sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.code)),
+            0)
       << "incorrect value for sid.code, expected 0, is " << last_msg_->sid.code;
-  EXPECT_EQ(last_msg_->sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.reserved)),
+            0)
       << "incorrect value for sid.reserved, expected 0, is "
       << last_msg_->sid.reserved;
-  EXPECT_EQ(last_msg_->sid.sat, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.sat)),
+            3)
       << "incorrect value for sid.sat, expected 3, is " << last_msg_->sid.sat;
   EXPECT_LT((last_msg_->snr * 100 - 36.1687545776 * 100), 0.05)
       << "incorrect value for snr, expected 36.1687545776, is "
@@ -328,12 +347,18 @@ TEST_F(Test_legacy_auto_check_sbp_acquisition_MsgAcqResultDepB2, Test) {
       << "incorrect value for cf, expected 4745.36132812, is " << last_msg_->cf;
   EXPECT_LT((last_msg_->cp * 100 - 794.0 * 100), 0.05)
       << "incorrect value for cp, expected 794.0, is " << last_msg_->cp;
-  EXPECT_EQ(last_msg_->sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.code)),
+            0)
       << "incorrect value for sid.code, expected 0, is " << last_msg_->sid.code;
-  EXPECT_EQ(last_msg_->sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.reserved)),
+            0)
       << "incorrect value for sid.reserved, expected 0, is "
       << last_msg_->sid.reserved;
-  EXPECT_EQ(last_msg_->sid.sat, 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.sat)),
+            18)
       << "incorrect value for sid.sat, expected 18, is " << last_msg_->sid.sat;
   EXPECT_LT((last_msg_->snr * 100 - 35.7772369385 * 100), 0.05)
       << "incorrect value for snr, expected 35.7772369385, is "
@@ -431,12 +456,18 @@ TEST_F(Test_legacy_auto_check_sbp_acquisition_MsgAcqResultDepB3, Test) {
       << "incorrect value for cf, expected 2497.55859375, is " << last_msg_->cf;
   EXPECT_LT((last_msg_->cp * 100 - 258.5 * 100), 0.05)
       << "incorrect value for cp, expected 258.5, is " << last_msg_->cp;
-  EXPECT_EQ(last_msg_->sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.code)),
+            0)
       << "incorrect value for sid.code, expected 0, is " << last_msg_->sid.code;
-  EXPECT_EQ(last_msg_->sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.reserved)),
+            0)
       << "incorrect value for sid.reserved, expected 0, is "
       << last_msg_->sid.reserved;
-  EXPECT_EQ(last_msg_->sid.sat, 17)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.sat)),
+            17)
       << "incorrect value for sid.sat, expected 17, is " << last_msg_->sid.sat;
   EXPECT_LT((last_msg_->snr * 100 - 35.6945114136 * 100), 0.05)
       << "incorrect value for snr, expected 35.6945114136, is "
@@ -535,12 +566,18 @@ TEST_F(Test_legacy_auto_check_sbp_acquisition_MsgAcqResultDepB4, Test) {
       << last_msg_->cf;
   EXPECT_LT((last_msg_->cp * 100 - 522.0 * 100), 0.05)
       << "incorrect value for cp, expected 522.0, is " << last_msg_->cp;
-  EXPECT_EQ(last_msg_->sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.code)),
+            0)
       << "incorrect value for sid.code, expected 0, is " << last_msg_->sid.code;
-  EXPECT_EQ(last_msg_->sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.reserved)),
+            0)
       << "incorrect value for sid.reserved, expected 0, is "
       << last_msg_->sid.reserved;
-  EXPECT_EQ(last_msg_->sid.sat, 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.sat)),
+            5)
       << "incorrect value for sid.sat, expected 5, is " << last_msg_->sid.sat;
   EXPECT_LT((last_msg_->snr * 100 - 35.5241775513 * 100), 0.05)
       << "incorrect value for snr, expected 35.5241775513, is "

--- a/c/test/legacy/cpp/auto_check_sbp_acquisition_MsgAcqResultDepC.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_acquisition_MsgAcqResultDepC.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/legacy_state.h>
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_acquisition_MsgAcqResultDepC0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -124,12 +131,18 @@ TEST_F(Test_legacy_auto_check_sbp_acquisition_MsgAcqResultDepC0, Test) {
       << last_msg_->cn0;
   EXPECT_LT((last_msg_->cp * 100 - 457.192230225 * 100), 0.05)
       << "incorrect value for cp, expected 457.192230225, is " << last_msg_->cp;
-  EXPECT_EQ(last_msg_->sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.code)),
+            0)
       << "incorrect value for sid.code, expected 0, is " << last_msg_->sid.code;
-  EXPECT_EQ(last_msg_->sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.reserved)),
+            0)
       << "incorrect value for sid.reserved, expected 0, is "
       << last_msg_->sid.reserved;
-  EXPECT_EQ(last_msg_->sid.sat, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.sat)),
+            10)
       << "incorrect value for sid.sat, expected 10, is " << last_msg_->sid.sat;
 }
 class Test_legacy_auto_check_sbp_acquisition_MsgAcqResultDepC1
@@ -228,12 +241,18 @@ TEST_F(Test_legacy_auto_check_sbp_acquisition_MsgAcqResultDepC1, Test) {
       << last_msg_->cn0;
   EXPECT_LT((last_msg_->cp * 100 - 865.465759277 * 100), 0.05)
       << "incorrect value for cp, expected 865.465759277, is " << last_msg_->cp;
-  EXPECT_EQ(last_msg_->sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.code)),
+            0)
       << "incorrect value for sid.code, expected 0, is " << last_msg_->sid.code;
-  EXPECT_EQ(last_msg_->sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.reserved)),
+            0)
       << "incorrect value for sid.reserved, expected 0, is "
       << last_msg_->sid.reserved;
-  EXPECT_EQ(last_msg_->sid.sat, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.sat)),
+            6)
       << "incorrect value for sid.sat, expected 6, is " << last_msg_->sid.sat;
 }
 class Test_legacy_auto_check_sbp_acquisition_MsgAcqResultDepC2
@@ -331,12 +350,18 @@ TEST_F(Test_legacy_auto_check_sbp_acquisition_MsgAcqResultDepC2, Test) {
       << last_msg_->cn0;
   EXPECT_LT((last_msg_->cp * 100 - 230.356445312 * 100), 0.05)
       << "incorrect value for cp, expected 230.356445312, is " << last_msg_->cp;
-  EXPECT_EQ(last_msg_->sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.code)),
+            0)
       << "incorrect value for sid.code, expected 0, is " << last_msg_->sid.code;
-  EXPECT_EQ(last_msg_->sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.reserved)),
+            0)
       << "incorrect value for sid.reserved, expected 0, is "
       << last_msg_->sid.reserved;
-  EXPECT_EQ(last_msg_->sid.sat, 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.sat)),
+            13)
       << "incorrect value for sid.sat, expected 13, is " << last_msg_->sid.sat;
 }
 class Test_legacy_auto_check_sbp_acquisition_MsgAcqResultDepC3
@@ -434,12 +459,18 @@ TEST_F(Test_legacy_auto_check_sbp_acquisition_MsgAcqResultDepC3, Test) {
       << last_msg_->cn0;
   EXPECT_LT((last_msg_->cp * 100 - 252.839355469 * 100), 0.05)
       << "incorrect value for cp, expected 252.839355469, is " << last_msg_->cp;
-  EXPECT_EQ(last_msg_->sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.code)),
+            0)
       << "incorrect value for sid.code, expected 0, is " << last_msg_->sid.code;
-  EXPECT_EQ(last_msg_->sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.reserved)),
+            0)
       << "incorrect value for sid.reserved, expected 0, is "
       << last_msg_->sid.reserved;
-  EXPECT_EQ(last_msg_->sid.sat, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.sat)),
+            1)
       << "incorrect value for sid.sat, expected 1, is " << last_msg_->sid.sat;
 }
 class Test_legacy_auto_check_sbp_acquisition_MsgAcqResultDepC4
@@ -537,11 +568,17 @@ TEST_F(Test_legacy_auto_check_sbp_acquisition_MsgAcqResultDepC4, Test) {
       << last_msg_->cn0;
   EXPECT_LT((last_msg_->cp * 100 - 920.591918945 * 100), 0.05)
       << "incorrect value for cp, expected 920.591918945, is " << last_msg_->cp;
-  EXPECT_EQ(last_msg_->sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.code)),
+            0)
       << "incorrect value for sid.code, expected 0, is " << last_msg_->sid.code;
-  EXPECT_EQ(last_msg_->sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.reserved)),
+            0)
       << "incorrect value for sid.reserved, expected 0, is "
       << last_msg_->sid.reserved;
-  EXPECT_EQ(last_msg_->sid.sat, 27)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.sat)),
+            27)
       << "incorrect value for sid.sat, expected 27, is " << last_msg_->sid.sat;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_acquisition_MsgAcqSvProfile.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_acquisition_MsgAcqSvProfile.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/legacy_state.h>
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_acquisition_MsgAcqSvProfile0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -169,121 +176,238 @@ TEST_F(Test_legacy_auto_check_sbp_acquisition_MsgAcqSvProfile0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->acq_sv_profile[0].bin_width, 174)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[0].bin_width)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[0].bin_width)),
+            174)
       << "incorrect value for acq_sv_profile[0].bin_width, expected 174, is "
       << last_msg_->acq_sv_profile[0].bin_width;
-  EXPECT_EQ(last_msg_->acq_sv_profile[0].cf, 47)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->acq_sv_profile[0].cf)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->acq_sv_profile[0].cf)),
+      47)
       << "incorrect value for acq_sv_profile[0].cf, expected 47, is "
       << last_msg_->acq_sv_profile[0].cf;
-  EXPECT_EQ(last_msg_->acq_sv_profile[0].cf_max, 147)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[0].cf_max)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[0].cf_max)),
+            147)
       << "incorrect value for acq_sv_profile[0].cf_max, expected 147, is "
       << last_msg_->acq_sv_profile[0].cf_max;
-  EXPECT_EQ(last_msg_->acq_sv_profile[0].cf_min, 61)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[0].cf_min)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[0].cf_min)),
+            61)
       << "incorrect value for acq_sv_profile[0].cf_min, expected 61, is "
       << last_msg_->acq_sv_profile[0].cf_min;
-  EXPECT_EQ(last_msg_->acq_sv_profile[0].cn0, 38)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->acq_sv_profile[0].cn0)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->acq_sv_profile[0].cn0)),
+      38)
       << "incorrect value for acq_sv_profile[0].cn0, expected 38, is "
       << last_msg_->acq_sv_profile[0].cn0;
-  EXPECT_EQ(last_msg_->acq_sv_profile[0].cp, 140)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->acq_sv_profile[0].cp)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->acq_sv_profile[0].cp)),
+      140)
       << "incorrect value for acq_sv_profile[0].cp, expected 140, is "
       << last_msg_->acq_sv_profile[0].cp;
-  EXPECT_EQ(last_msg_->acq_sv_profile[0].int_time, 97)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[0].int_time)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[0].int_time)),
+            97)
       << "incorrect value for acq_sv_profile[0].int_time, expected 97, is "
       << last_msg_->acq_sv_profile[0].int_time;
-  EXPECT_EQ(last_msg_->acq_sv_profile[0].job_type, 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[0].job_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[0].job_type)),
+            7)
       << "incorrect value for acq_sv_profile[0].job_type, expected 7, is "
       << last_msg_->acq_sv_profile[0].job_type;
-  EXPECT_EQ(last_msg_->acq_sv_profile[0].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[0].sid.code)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[0].sid.code)),
+            0)
       << "incorrect value for acq_sv_profile[0].sid.code, expected 0, is "
       << last_msg_->acq_sv_profile[0].sid.code;
-  EXPECT_EQ(last_msg_->acq_sv_profile[0].sid.sat, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[0].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[0].sid.sat)),
+            22)
       << "incorrect value for acq_sv_profile[0].sid.sat, expected 22, is "
       << last_msg_->acq_sv_profile[0].sid.sat;
-  EXPECT_EQ(last_msg_->acq_sv_profile[0].status, 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[0].status)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[0].status)),
+            13)
       << "incorrect value for acq_sv_profile[0].status, expected 13, is "
       << last_msg_->acq_sv_profile[0].status;
-  EXPECT_EQ(last_msg_->acq_sv_profile[0].time_spent, 49)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[0].time_spent)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[0].time_spent)),
+            49)
       << "incorrect value for acq_sv_profile[0].time_spent, expected 49, is "
       << last_msg_->acq_sv_profile[0].time_spent;
-  EXPECT_EQ(last_msg_->acq_sv_profile[0].timestamp, 52)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[0].timestamp)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[0].timestamp)),
+            52)
       << "incorrect value for acq_sv_profile[0].timestamp, expected 52, is "
       << last_msg_->acq_sv_profile[0].timestamp;
-  EXPECT_EQ(last_msg_->acq_sv_profile[1].bin_width, 121)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[1].bin_width)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[1].bin_width)),
+            121)
       << "incorrect value for acq_sv_profile[1].bin_width, expected 121, is "
       << last_msg_->acq_sv_profile[1].bin_width;
-  EXPECT_EQ(last_msg_->acq_sv_profile[1].cf, 237)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->acq_sv_profile[1].cf)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->acq_sv_profile[1].cf)),
+      237)
       << "incorrect value for acq_sv_profile[1].cf, expected 237, is "
       << last_msg_->acq_sv_profile[1].cf;
-  EXPECT_EQ(last_msg_->acq_sv_profile[1].cf_max, 142)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[1].cf_max)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[1].cf_max)),
+            142)
       << "incorrect value for acq_sv_profile[1].cf_max, expected 142, is "
       << last_msg_->acq_sv_profile[1].cf_max;
-  EXPECT_EQ(last_msg_->acq_sv_profile[1].cf_min, 175)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[1].cf_min)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[1].cf_min)),
+            175)
       << "incorrect value for acq_sv_profile[1].cf_min, expected 175, is "
       << last_msg_->acq_sv_profile[1].cf_min;
-  EXPECT_EQ(last_msg_->acq_sv_profile[1].cn0, 59)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->acq_sv_profile[1].cn0)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->acq_sv_profile[1].cn0)),
+      59)
       << "incorrect value for acq_sv_profile[1].cn0, expected 59, is "
       << last_msg_->acq_sv_profile[1].cn0;
-  EXPECT_EQ(last_msg_->acq_sv_profile[1].cp, 12)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->acq_sv_profile[1].cp)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->acq_sv_profile[1].cp)),
+      12)
       << "incorrect value for acq_sv_profile[1].cp, expected 12, is "
       << last_msg_->acq_sv_profile[1].cp;
-  EXPECT_EQ(last_msg_->acq_sv_profile[1].int_time, 253)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[1].int_time)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[1].int_time)),
+            253)
       << "incorrect value for acq_sv_profile[1].int_time, expected 253, is "
       << last_msg_->acq_sv_profile[1].int_time;
-  EXPECT_EQ(last_msg_->acq_sv_profile[1].job_type, 166)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[1].job_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[1].job_type)),
+            166)
       << "incorrect value for acq_sv_profile[1].job_type, expected 166, is "
       << last_msg_->acq_sv_profile[1].job_type;
-  EXPECT_EQ(last_msg_->acq_sv_profile[1].sid.code, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[1].sid.code)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[1].sid.code)),
+            1)
       << "incorrect value for acq_sv_profile[1].sid.code, expected 1, is "
       << last_msg_->acq_sv_profile[1].sid.code;
-  EXPECT_EQ(last_msg_->acq_sv_profile[1].sid.sat, 23)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[1].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[1].sid.sat)),
+            23)
       << "incorrect value for acq_sv_profile[1].sid.sat, expected 23, is "
       << last_msg_->acq_sv_profile[1].sid.sat;
-  EXPECT_EQ(last_msg_->acq_sv_profile[1].status, 210)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[1].status)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[1].status)),
+            210)
       << "incorrect value for acq_sv_profile[1].status, expected 210, is "
       << last_msg_->acq_sv_profile[1].status;
-  EXPECT_EQ(last_msg_->acq_sv_profile[1].time_spent, 175)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[1].time_spent)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[1].time_spent)),
+            175)
       << "incorrect value for acq_sv_profile[1].time_spent, expected 175, is "
       << last_msg_->acq_sv_profile[1].time_spent;
-  EXPECT_EQ(last_msg_->acq_sv_profile[1].timestamp, 190)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[1].timestamp)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[1].timestamp)),
+            190)
       << "incorrect value for acq_sv_profile[1].timestamp, expected 190, is "
       << last_msg_->acq_sv_profile[1].timestamp;
-  EXPECT_EQ(last_msg_->acq_sv_profile[2].bin_width, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[2].bin_width)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[2].bin_width)),
+            8)
       << "incorrect value for acq_sv_profile[2].bin_width, expected 8, is "
       << last_msg_->acq_sv_profile[2].bin_width;
-  EXPECT_EQ(last_msg_->acq_sv_profile[2].cf, 84)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->acq_sv_profile[2].cf)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->acq_sv_profile[2].cf)),
+      84)
       << "incorrect value for acq_sv_profile[2].cf, expected 84, is "
       << last_msg_->acq_sv_profile[2].cf;
-  EXPECT_EQ(last_msg_->acq_sv_profile[2].cf_max, 191)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[2].cf_max)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[2].cf_max)),
+            191)
       << "incorrect value for acq_sv_profile[2].cf_max, expected 191, is "
       << last_msg_->acq_sv_profile[2].cf_max;
-  EXPECT_EQ(last_msg_->acq_sv_profile[2].cf_min, 91)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[2].cf_min)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[2].cf_min)),
+            91)
       << "incorrect value for acq_sv_profile[2].cf_min, expected 91, is "
       << last_msg_->acq_sv_profile[2].cf_min;
-  EXPECT_EQ(last_msg_->acq_sv_profile[2].cn0, 21)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->acq_sv_profile[2].cn0)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->acq_sv_profile[2].cn0)),
+      21)
       << "incorrect value for acq_sv_profile[2].cn0, expected 21, is "
       << last_msg_->acq_sv_profile[2].cn0;
-  EXPECT_EQ(last_msg_->acq_sv_profile[2].cp, 82)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->acq_sv_profile[2].cp)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->acq_sv_profile[2].cp)),
+      82)
       << "incorrect value for acq_sv_profile[2].cp, expected 82, is "
       << last_msg_->acq_sv_profile[2].cp;
-  EXPECT_EQ(last_msg_->acq_sv_profile[2].int_time, 153)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[2].int_time)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[2].int_time)),
+            153)
       << "incorrect value for acq_sv_profile[2].int_time, expected 153, is "
       << last_msg_->acq_sv_profile[2].int_time;
-  EXPECT_EQ(last_msg_->acq_sv_profile[2].job_type, 126)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[2].job_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[2].job_type)),
+            126)
       << "incorrect value for acq_sv_profile[2].job_type, expected 126, is "
       << last_msg_->acq_sv_profile[2].job_type;
-  EXPECT_EQ(last_msg_->acq_sv_profile[2].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[2].sid.code)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[2].sid.code)),
+            0)
       << "incorrect value for acq_sv_profile[2].sid.code, expected 0, is "
       << last_msg_->acq_sv_profile[2].sid.code;
-  EXPECT_EQ(last_msg_->acq_sv_profile[2].sid.sat, 24)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[2].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[2].sid.sat)),
+            24)
       << "incorrect value for acq_sv_profile[2].sid.sat, expected 24, is "
       << last_msg_->acq_sv_profile[2].sid.sat;
-  EXPECT_EQ(last_msg_->acq_sv_profile[2].status, 88)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[2].status)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[2].status)),
+            88)
       << "incorrect value for acq_sv_profile[2].status, expected 88, is "
       << last_msg_->acq_sv_profile[2].status;
-  EXPECT_EQ(last_msg_->acq_sv_profile[2].time_spent, 172)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[2].time_spent)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[2].time_spent)),
+            172)
       << "incorrect value for acq_sv_profile[2].time_spent, expected 172, is "
       << last_msg_->acq_sv_profile[2].time_spent;
-  EXPECT_EQ(last_msg_->acq_sv_profile[2].timestamp, 130)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[2].timestamp)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[2].timestamp)),
+            130)
       << "incorrect value for acq_sv_profile[2].timestamp, expected 130, is "
       << last_msg_->acq_sv_profile[2].timestamp;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_acquisition_MsgAcqSvProfileDep.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_acquisition_MsgAcqSvProfileDep.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/legacy_state.h>
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_acquisition_MsgAcqSvProfileDep0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -175,130 +182,256 @@ TEST_F(Test_legacy_auto_check_sbp_acquisition_MsgAcqSvProfileDep0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->acq_sv_profile[0].bin_width, 187)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[0].bin_width)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[0].bin_width)),
+            187)
       << "incorrect value for acq_sv_profile[0].bin_width, expected 187, is "
       << last_msg_->acq_sv_profile[0].bin_width;
-  EXPECT_EQ(last_msg_->acq_sv_profile[0].cf, 60)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->acq_sv_profile[0].cf)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->acq_sv_profile[0].cf)),
+      60)
       << "incorrect value for acq_sv_profile[0].cf, expected 60, is "
       << last_msg_->acq_sv_profile[0].cf;
-  EXPECT_EQ(last_msg_->acq_sv_profile[0].cf_max, 36)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[0].cf_max)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[0].cf_max)),
+            36)
       << "incorrect value for acq_sv_profile[0].cf_max, expected 36, is "
       << last_msg_->acq_sv_profile[0].cf_max;
-  EXPECT_EQ(last_msg_->acq_sv_profile[0].cf_min, 132)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[0].cf_min)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[0].cf_min)),
+            132)
       << "incorrect value for acq_sv_profile[0].cf_min, expected 132, is "
       << last_msg_->acq_sv_profile[0].cf_min;
-  EXPECT_EQ(last_msg_->acq_sv_profile[0].cn0, 151)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->acq_sv_profile[0].cn0)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->acq_sv_profile[0].cn0)),
+      151)
       << "incorrect value for acq_sv_profile[0].cn0, expected 151, is "
       << last_msg_->acq_sv_profile[0].cn0;
-  EXPECT_EQ(last_msg_->acq_sv_profile[0].cp, 241)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->acq_sv_profile[0].cp)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->acq_sv_profile[0].cp)),
+      241)
       << "incorrect value for acq_sv_profile[0].cp, expected 241, is "
       << last_msg_->acq_sv_profile[0].cp;
-  EXPECT_EQ(last_msg_->acq_sv_profile[0].int_time, 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[0].int_time)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[0].int_time)),
+            12)
       << "incorrect value for acq_sv_profile[0].int_time, expected 12, is "
       << last_msg_->acq_sv_profile[0].int_time;
-  EXPECT_EQ(last_msg_->acq_sv_profile[0].job_type, 67)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[0].job_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[0].job_type)),
+            67)
       << "incorrect value for acq_sv_profile[0].job_type, expected 67, is "
       << last_msg_->acq_sv_profile[0].job_type;
-  EXPECT_EQ(last_msg_->acq_sv_profile[0].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[0].sid.code)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[0].sid.code)),
+            0)
       << "incorrect value for acq_sv_profile[0].sid.code, expected 0, is "
       << last_msg_->acq_sv_profile[0].sid.code;
-  EXPECT_EQ(last_msg_->acq_sv_profile[0].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[0].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[0].sid.reserved)),
+            0)
       << "incorrect value for acq_sv_profile[0].sid.reserved, expected 0, is "
       << last_msg_->acq_sv_profile[0].sid.reserved;
-  EXPECT_EQ(last_msg_->acq_sv_profile[0].sid.sat, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[0].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[0].sid.sat)),
+            22)
       << "incorrect value for acq_sv_profile[0].sid.sat, expected 22, is "
       << last_msg_->acq_sv_profile[0].sid.sat;
-  EXPECT_EQ(last_msg_->acq_sv_profile[0].status, 103)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[0].status)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[0].status)),
+            103)
       << "incorrect value for acq_sv_profile[0].status, expected 103, is "
       << last_msg_->acq_sv_profile[0].status;
-  EXPECT_EQ(last_msg_->acq_sv_profile[0].time_spent, 75)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[0].time_spent)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[0].time_spent)),
+            75)
       << "incorrect value for acq_sv_profile[0].time_spent, expected 75, is "
       << last_msg_->acq_sv_profile[0].time_spent;
-  EXPECT_EQ(last_msg_->acq_sv_profile[0].timestamp, 91)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[0].timestamp)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[0].timestamp)),
+            91)
       << "incorrect value for acq_sv_profile[0].timestamp, expected 91, is "
       << last_msg_->acq_sv_profile[0].timestamp;
-  EXPECT_EQ(last_msg_->acq_sv_profile[1].bin_width, 176)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[1].bin_width)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[1].bin_width)),
+            176)
       << "incorrect value for acq_sv_profile[1].bin_width, expected 176, is "
       << last_msg_->acq_sv_profile[1].bin_width;
-  EXPECT_EQ(last_msg_->acq_sv_profile[1].cf, 212)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->acq_sv_profile[1].cf)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->acq_sv_profile[1].cf)),
+      212)
       << "incorrect value for acq_sv_profile[1].cf, expected 212, is "
       << last_msg_->acq_sv_profile[1].cf;
-  EXPECT_EQ(last_msg_->acq_sv_profile[1].cf_max, 24)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[1].cf_max)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[1].cf_max)),
+            24)
       << "incorrect value for acq_sv_profile[1].cf_max, expected 24, is "
       << last_msg_->acq_sv_profile[1].cf_max;
-  EXPECT_EQ(last_msg_->acq_sv_profile[1].cf_min, 155)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[1].cf_min)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[1].cf_min)),
+            155)
       << "incorrect value for acq_sv_profile[1].cf_min, expected 155, is "
       << last_msg_->acq_sv_profile[1].cf_min;
-  EXPECT_EQ(last_msg_->acq_sv_profile[1].cn0, 111)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->acq_sv_profile[1].cn0)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->acq_sv_profile[1].cn0)),
+      111)
       << "incorrect value for acq_sv_profile[1].cn0, expected 111, is "
       << last_msg_->acq_sv_profile[1].cn0;
-  EXPECT_EQ(last_msg_->acq_sv_profile[1].cp, 247)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->acq_sv_profile[1].cp)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->acq_sv_profile[1].cp)),
+      247)
       << "incorrect value for acq_sv_profile[1].cp, expected 247, is "
       << last_msg_->acq_sv_profile[1].cp;
-  EXPECT_EQ(last_msg_->acq_sv_profile[1].int_time, 179)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[1].int_time)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[1].int_time)),
+            179)
       << "incorrect value for acq_sv_profile[1].int_time, expected 179, is "
       << last_msg_->acq_sv_profile[1].int_time;
-  EXPECT_EQ(last_msg_->acq_sv_profile[1].job_type, 238)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[1].job_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[1].job_type)),
+            238)
       << "incorrect value for acq_sv_profile[1].job_type, expected 238, is "
       << last_msg_->acq_sv_profile[1].job_type;
-  EXPECT_EQ(last_msg_->acq_sv_profile[1].sid.code, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[1].sid.code)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[1].sid.code)),
+            1)
       << "incorrect value for acq_sv_profile[1].sid.code, expected 1, is "
       << last_msg_->acq_sv_profile[1].sid.code;
-  EXPECT_EQ(last_msg_->acq_sv_profile[1].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[1].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[1].sid.reserved)),
+            0)
       << "incorrect value for acq_sv_profile[1].sid.reserved, expected 0, is "
       << last_msg_->acq_sv_profile[1].sid.reserved;
-  EXPECT_EQ(last_msg_->acq_sv_profile[1].sid.sat, 23)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[1].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[1].sid.sat)),
+            23)
       << "incorrect value for acq_sv_profile[1].sid.sat, expected 23, is "
       << last_msg_->acq_sv_profile[1].sid.sat;
-  EXPECT_EQ(last_msg_->acq_sv_profile[1].status, 38)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[1].status)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[1].status)),
+            38)
       << "incorrect value for acq_sv_profile[1].status, expected 38, is "
       << last_msg_->acq_sv_profile[1].status;
-  EXPECT_EQ(last_msg_->acq_sv_profile[1].time_spent, 234)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[1].time_spent)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[1].time_spent)),
+            234)
       << "incorrect value for acq_sv_profile[1].time_spent, expected 234, is "
       << last_msg_->acq_sv_profile[1].time_spent;
-  EXPECT_EQ(last_msg_->acq_sv_profile[1].timestamp, 166)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[1].timestamp)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[1].timestamp)),
+            166)
       << "incorrect value for acq_sv_profile[1].timestamp, expected 166, is "
       << last_msg_->acq_sv_profile[1].timestamp;
-  EXPECT_EQ(last_msg_->acq_sv_profile[2].bin_width, 52)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[2].bin_width)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[2].bin_width)),
+            52)
       << "incorrect value for acq_sv_profile[2].bin_width, expected 52, is "
       << last_msg_->acq_sv_profile[2].bin_width;
-  EXPECT_EQ(last_msg_->acq_sv_profile[2].cf, 212)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->acq_sv_profile[2].cf)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->acq_sv_profile[2].cf)),
+      212)
       << "incorrect value for acq_sv_profile[2].cf, expected 212, is "
       << last_msg_->acq_sv_profile[2].cf;
-  EXPECT_EQ(last_msg_->acq_sv_profile[2].cf_max, 248)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[2].cf_max)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[2].cf_max)),
+            248)
       << "incorrect value for acq_sv_profile[2].cf_max, expected 248, is "
       << last_msg_->acq_sv_profile[2].cf_max;
-  EXPECT_EQ(last_msg_->acq_sv_profile[2].cf_min, 76)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[2].cf_min)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[2].cf_min)),
+            76)
       << "incorrect value for acq_sv_profile[2].cf_min, expected 76, is "
       << last_msg_->acq_sv_profile[2].cf_min;
-  EXPECT_EQ(last_msg_->acq_sv_profile[2].cn0, 68)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->acq_sv_profile[2].cn0)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->acq_sv_profile[2].cn0)),
+      68)
       << "incorrect value for acq_sv_profile[2].cn0, expected 68, is "
       << last_msg_->acq_sv_profile[2].cn0;
-  EXPECT_EQ(last_msg_->acq_sv_profile[2].cp, 101)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->acq_sv_profile[2].cp)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->acq_sv_profile[2].cp)),
+      101)
       << "incorrect value for acq_sv_profile[2].cp, expected 101, is "
       << last_msg_->acq_sv_profile[2].cp;
-  EXPECT_EQ(last_msg_->acq_sv_profile[2].int_time, 53)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[2].int_time)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[2].int_time)),
+            53)
       << "incorrect value for acq_sv_profile[2].int_time, expected 53, is "
       << last_msg_->acq_sv_profile[2].int_time;
-  EXPECT_EQ(last_msg_->acq_sv_profile[2].job_type, 142)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[2].job_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[2].job_type)),
+            142)
       << "incorrect value for acq_sv_profile[2].job_type, expected 142, is "
       << last_msg_->acq_sv_profile[2].job_type;
-  EXPECT_EQ(last_msg_->acq_sv_profile[2].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[2].sid.code)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[2].sid.code)),
+            0)
       << "incorrect value for acq_sv_profile[2].sid.code, expected 0, is "
       << last_msg_->acq_sv_profile[2].sid.code;
-  EXPECT_EQ(last_msg_->acq_sv_profile[2].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[2].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[2].sid.reserved)),
+            0)
       << "incorrect value for acq_sv_profile[2].sid.reserved, expected 0, is "
       << last_msg_->acq_sv_profile[2].sid.reserved;
-  EXPECT_EQ(last_msg_->acq_sv_profile[2].sid.sat, 24)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[2].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[2].sid.sat)),
+            24)
       << "incorrect value for acq_sv_profile[2].sid.sat, expected 24, is "
       << last_msg_->acq_sv_profile[2].sid.sat;
-  EXPECT_EQ(last_msg_->acq_sv_profile[2].status, 213)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[2].status)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[2].status)),
+            213)
       << "incorrect value for acq_sv_profile[2].status, expected 213, is "
       << last_msg_->acq_sv_profile[2].status;
-  EXPECT_EQ(last_msg_->acq_sv_profile[2].time_spent, 245)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[2].time_spent)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[2].time_spent)),
+            245)
       << "incorrect value for acq_sv_profile[2].time_spent, expected 245, is "
       << last_msg_->acq_sv_profile[2].time_spent;
-  EXPECT_EQ(last_msg_->acq_sv_profile[2].timestamp, 49)
+  EXPECT_EQ(get_as<decltype(last_msg_->acq_sv_profile[2].timestamp)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->acq_sv_profile[2].timestamp)),
+            49)
       << "incorrect value for acq_sv_profile[2].timestamp, expected 49, is "
       << last_msg_->acq_sv_profile[2].timestamp;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_bootload_MsgBootloaderHandshakeReq.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_bootload_MsgBootloaderHandshakeReq.cc
@@ -29,3 +29,10 @@
 #include <libsbp/legacy/cpp/legacy_state.h>
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}

--- a/c/test/legacy/cpp/auto_check_sbp_bootload_MsgBootloaderHandshakeResp.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_bootload_MsgBootloaderHandshakeResp.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/legacy_state.h>
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_bootload_MsgBootloaderHandshakeResp0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -120,7 +127,9 @@ TEST_F(Test_legacy_auto_check_sbp_bootload_MsgBootloaderHandshakeResp0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 0);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
   {
     const char check_string[] = {(char)118, (char)49, (char)46, (char)50,
@@ -232,16 +241,24 @@ TEST_F(Test_legacy_auto_check_sbp_bootload_MsgBootloaderHandshakeResp1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->handshake[0], 118)
+  EXPECT_EQ(get_as<decltype(last_msg_->handshake[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->handshake[0])),
+            118)
       << "incorrect value for handshake[0], expected 118, is "
       << last_msg_->handshake[0];
-  EXPECT_EQ(last_msg_->handshake[1], 49)
+  EXPECT_EQ(get_as<decltype(last_msg_->handshake[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->handshake[1])),
+            49)
       << "incorrect value for handshake[1], expected 49, is "
       << last_msg_->handshake[1];
-  EXPECT_EQ(last_msg_->handshake[2], 46)
+  EXPECT_EQ(get_as<decltype(last_msg_->handshake[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->handshake[2])),
+            46)
       << "incorrect value for handshake[2], expected 46, is "
       << last_msg_->handshake[2];
-  EXPECT_EQ(last_msg_->handshake[3], 50)
+  EXPECT_EQ(get_as<decltype(last_msg_->handshake[3])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->handshake[3])),
+            50)
       << "incorrect value for handshake[3], expected 50, is "
       << last_msg_->handshake[3];
 }

--- a/c/test/legacy/cpp/auto_check_sbp_bootload_MsgBootloaderJumptoApp.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_bootload_MsgBootloaderJumptoApp.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/legacy_state.h>
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_bootload_MsgBootloaderJumptoApp0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -112,6 +119,8 @@ TEST_F(Test_legacy_auto_check_sbp_bootload_MsgBootloaderJumptoApp0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 4813);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->jump, 216)
+  EXPECT_EQ(get_as<decltype(last_msg_->jump)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->jump)),
+            216)
       << "incorrect value for jump, expected 216, is " << last_msg_->jump;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_bootload_MsgNapDeviceDnaReq.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_bootload_MsgNapDeviceDnaReq.cc
@@ -29,3 +29,10 @@
 #include <libsbp/legacy/cpp/legacy_state.h>
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}

--- a/c/test/legacy/cpp/auto_check_sbp_bootload_MsgNapDeviceDnaResp.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_bootload_MsgNapDeviceDnaResp.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/legacy_state.h>
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_bootload_MsgNapDeviceDnaResp0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -151,20 +158,36 @@ TEST_F(Test_legacy_auto_check_sbp_bootload_MsgNapDeviceDnaResp0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 14505);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->dna[0], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->dna[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->dna[0])),
+            2)
       << "incorrect value for dna[0], expected 2, is " << last_msg_->dna[0];
-  EXPECT_EQ(last_msg_->dna[1], 187)
+  EXPECT_EQ(get_as<decltype(last_msg_->dna[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->dna[1])),
+            187)
       << "incorrect value for dna[1], expected 187, is " << last_msg_->dna[1];
-  EXPECT_EQ(last_msg_->dna[2], 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->dna[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->dna[2])),
+            1)
       << "incorrect value for dna[2], expected 1, is " << last_msg_->dna[2];
-  EXPECT_EQ(last_msg_->dna[3], 130)
+  EXPECT_EQ(get_as<decltype(last_msg_->dna[3])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->dna[3])),
+            130)
       << "incorrect value for dna[3], expected 130, is " << last_msg_->dna[3];
-  EXPECT_EQ(last_msg_->dna[4], 173)
+  EXPECT_EQ(get_as<decltype(last_msg_->dna[4])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->dna[4])),
+            173)
       << "incorrect value for dna[4], expected 173, is " << last_msg_->dna[4];
-  EXPECT_EQ(last_msg_->dna[5], 244)
+  EXPECT_EQ(get_as<decltype(last_msg_->dna[5])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->dna[5])),
+            244)
       << "incorrect value for dna[5], expected 244, is " << last_msg_->dna[5];
-  EXPECT_EQ(last_msg_->dna[6], 67)
+  EXPECT_EQ(get_as<decltype(last_msg_->dna[6])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->dna[6])),
+            67)
       << "incorrect value for dna[6], expected 67, is " << last_msg_->dna[6];
-  EXPECT_EQ(last_msg_->dna[7], 122)
+  EXPECT_EQ(get_as<decltype(last_msg_->dna[7])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->dna[7])),
+            122)
       << "incorrect value for dna[7], expected 122, is " << last_msg_->dna[7];
 }

--- a/c/test/legacy/cpp/auto_check_sbp_ext_events_MsgExtEvent.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_ext_events_MsgExtEvent.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/ext_events.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_ext_events_MsgExtEvent0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -115,15 +122,25 @@ TEST_F(Test_legacy_auto_check_sbp_ext_events_MsgExtEvent0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1781);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            3)
       << "incorrect value for flags, expected 3, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->ns_residual, 999882)
+  EXPECT_EQ(get_as<decltype(last_msg_->ns_residual)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ns_residual)),
+            999882)
       << "incorrect value for ns_residual, expected 999882, is "
       << last_msg_->ns_residual;
-  EXPECT_EQ(last_msg_->pin, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->pin)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pin)),
+            0)
       << "incorrect value for pin, expected 0, is " << last_msg_->pin;
-  EXPECT_EQ(last_msg_->tow, 254924999)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            254924999)
       << "incorrect value for tow, expected 254924999, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->wn, 1840)
+  EXPECT_EQ(get_as<decltype(last_msg_->wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->wn)),
+            1840)
       << "incorrect value for wn, expected 1840, is " << last_msg_->wn;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_file_io_MsgFileioConfigReq.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_file_io_MsgFileioConfigReq.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/file_io.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_file_io_MsgFileioConfigReq0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -112,7 +119,9 @@ TEST_F(Test_legacy_auto_check_sbp_file_io_MsgFileioConfigReq0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->sequence, 1514527339)
+  EXPECT_EQ(get_as<decltype(last_msg_->sequence)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sequence)),
+            1514527339)
       << "incorrect value for sequence, expected 1514527339, is "
       << last_msg_->sequence;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_file_io_MsgFileioConfigResp.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_file_io_MsgFileioConfigResp.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/file_io.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_file_io_MsgFileioConfigResp0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -116,16 +123,24 @@ TEST_F(Test_legacy_auto_check_sbp_file_io_MsgFileioConfigResp0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->batch_size, 1040160728)
+  EXPECT_EQ(get_as<decltype(last_msg_->batch_size)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->batch_size)),
+            1040160728)
       << "incorrect value for batch_size, expected 1040160728, is "
       << last_msg_->batch_size;
-  EXPECT_EQ(last_msg_->fileio_version, 2420269324)
+  EXPECT_EQ(get_as<decltype(last_msg_->fileio_version)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fileio_version)),
+            2420269324)
       << "incorrect value for fileio_version, expected 2420269324, is "
       << last_msg_->fileio_version;
-  EXPECT_EQ(last_msg_->sequence, 1530154154)
+  EXPECT_EQ(get_as<decltype(last_msg_->sequence)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sequence)),
+            1530154154)
       << "incorrect value for sequence, expected 1530154154, is "
       << last_msg_->sequence;
-  EXPECT_EQ(last_msg_->window_size, 53262997)
+  EXPECT_EQ(get_as<decltype(last_msg_->window_size)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->window_size)),
+            53262997)
       << "incorrect value for window_size, expected 53262997, is "
       << last_msg_->window_size;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_file_io_MsgFileioReadDirReq.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_file_io_MsgFileioReadDirReq.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/file_io.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_file_io_MsgFileioReadDirReq0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -134,10 +141,14 @@ TEST_F(Test_legacy_auto_check_sbp_file_io_MsgFileioReadDirReq0, Test) {
         << "incorrect value for last_msg_->dirname, expected string '"
         << check_string << "', is '" << last_msg_->dirname << "'";
   }
-  EXPECT_EQ(last_msg_->offset, 2251261636)
+  EXPECT_EQ(get_as<decltype(last_msg_->offset)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->offset)),
+            2251261636)
       << "incorrect value for offset, expected 2251261636, is "
       << last_msg_->offset;
-  EXPECT_EQ(last_msg_->sequence, 1526720386)
+  EXPECT_EQ(get_as<decltype(last_msg_->sequence)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sequence)),
+            1526720386)
       << "incorrect value for sequence, expected 1526720386, is "
       << last_msg_->sequence;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_file_io_MsgFileioReadDirResp.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_file_io_MsgFileioReadDirResp.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/file_io.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_file_io_MsgFileioReadDirResp0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -143,7 +150,9 @@ TEST_F(Test_legacy_auto_check_sbp_file_io_MsgFileioReadDirResp0, Test) {
         << "incorrect value for last_msg_->contents, expected string '"
         << check_string << "', is '" << last_msg_->contents << "'";
   }
-  EXPECT_EQ(last_msg_->sequence, 3957390670)
+  EXPECT_EQ(get_as<decltype(last_msg_->sequence)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sequence)),
+            3957390670)
       << "incorrect value for sequence, expected 3957390670, is "
       << last_msg_->sequence;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_file_io_MsgFileioReadReq.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_file_io_MsgFileioReadReq.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/file_io.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_file_io_MsgFileioReadReq0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -125,7 +132,9 @@ TEST_F(Test_legacy_auto_check_sbp_file_io_MsgFileioReadReq0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->chunk_size, 53)
+  EXPECT_EQ(get_as<decltype(last_msg_->chunk_size)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->chunk_size)),
+            53)
       << "incorrect value for chunk_size, expected 53, is "
       << last_msg_->chunk_size;
   {
@@ -139,10 +148,14 @@ TEST_F(Test_legacy_auto_check_sbp_file_io_MsgFileioReadReq0, Test) {
         << "incorrect value for last_msg_->filename, expected string '"
         << check_string << "', is '" << last_msg_->filename << "'";
   }
-  EXPECT_EQ(last_msg_->offset, 398373474)
+  EXPECT_EQ(get_as<decltype(last_msg_->offset)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->offset)),
+            398373474)
       << "incorrect value for offset, expected 398373474, is "
       << last_msg_->offset;
-  EXPECT_EQ(last_msg_->sequence, 679648290)
+  EXPECT_EQ(get_as<decltype(last_msg_->sequence)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sequence)),
+            679648290)
       << "incorrect value for sequence, expected 679648290, is "
       << last_msg_->sequence;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_file_io_MsgFileioReadResp.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_file_io_MsgFileioReadResp.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/file_io.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_file_io_MsgFileioReadResp0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -1383,760 +1390,1264 @@ TEST_F(Test_legacy_auto_check_sbp_file_io_MsgFileioReadResp0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->contents[0], 73)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[0])),
+            73)
       << "incorrect value for contents[0], expected 73, is "
       << last_msg_->contents[0];
-  EXPECT_EQ(last_msg_->contents[1], 231)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[1])),
+            231)
       << "incorrect value for contents[1], expected 231, is "
       << last_msg_->contents[1];
-  EXPECT_EQ(last_msg_->contents[2], 227)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[2])),
+            227)
       << "incorrect value for contents[2], expected 227, is "
       << last_msg_->contents[2];
-  EXPECT_EQ(last_msg_->contents[3], 179)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[3])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[3])),
+            179)
       << "incorrect value for contents[3], expected 179, is "
       << last_msg_->contents[3];
-  EXPECT_EQ(last_msg_->contents[4], 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[4])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[4])),
+            18)
       << "incorrect value for contents[4], expected 18, is "
       << last_msg_->contents[4];
-  EXPECT_EQ(last_msg_->contents[5], 76)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[5])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[5])),
+            76)
       << "incorrect value for contents[5], expected 76, is "
       << last_msg_->contents[5];
-  EXPECT_EQ(last_msg_->contents[6], 68)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[6])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[6])),
+            68)
       << "incorrect value for contents[6], expected 68, is "
       << last_msg_->contents[6];
-  EXPECT_EQ(last_msg_->contents[7], 229)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[7])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[7])),
+            229)
       << "incorrect value for contents[7], expected 229, is "
       << last_msg_->contents[7];
-  EXPECT_EQ(last_msg_->contents[8], 216)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[8])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[8])),
+            216)
       << "incorrect value for contents[8], expected 216, is "
       << last_msg_->contents[8];
-  EXPECT_EQ(last_msg_->contents[9], 21)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[9])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[9])),
+            21)
       << "incorrect value for contents[9], expected 21, is "
       << last_msg_->contents[9];
-  EXPECT_EQ(last_msg_->contents[10], 98)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[10])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[10])),
+            98)
       << "incorrect value for contents[10], expected 98, is "
       << last_msg_->contents[10];
-  EXPECT_EQ(last_msg_->contents[11], 183)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[11])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[11])),
+            183)
       << "incorrect value for contents[11], expected 183, is "
       << last_msg_->contents[11];
-  EXPECT_EQ(last_msg_->contents[12], 69)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[12])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[12])),
+            69)
       << "incorrect value for contents[12], expected 69, is "
       << last_msg_->contents[12];
-  EXPECT_EQ(last_msg_->contents[13], 190)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[13])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[13])),
+            190)
       << "incorrect value for contents[13], expected 190, is "
       << last_msg_->contents[13];
-  EXPECT_EQ(last_msg_->contents[14], 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[14])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[14])),
+            5)
       << "incorrect value for contents[14], expected 5, is "
       << last_msg_->contents[14];
-  EXPECT_EQ(last_msg_->contents[15], 252)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[15])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[15])),
+            252)
       << "incorrect value for contents[15], expected 252, is "
       << last_msg_->contents[15];
-  EXPECT_EQ(last_msg_->contents[16], 176)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[16])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[16])),
+            176)
       << "incorrect value for contents[16], expected 176, is "
       << last_msg_->contents[16];
-  EXPECT_EQ(last_msg_->contents[17], 55)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[17])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[17])),
+            55)
       << "incorrect value for contents[17], expected 55, is "
       << last_msg_->contents[17];
-  EXPECT_EQ(last_msg_->contents[18], 32)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[18])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[18])),
+            32)
       << "incorrect value for contents[18], expected 32, is "
       << last_msg_->contents[18];
-  EXPECT_EQ(last_msg_->contents[19], 78)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[19])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[19])),
+            78)
       << "incorrect value for contents[19], expected 78, is "
       << last_msg_->contents[19];
-  EXPECT_EQ(last_msg_->contents[20], 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[20])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[20])),
+            8)
       << "incorrect value for contents[20], expected 8, is "
       << last_msg_->contents[20];
-  EXPECT_EQ(last_msg_->contents[21], 52)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[21])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[21])),
+            52)
       << "incorrect value for contents[21], expected 52, is "
       << last_msg_->contents[21];
-  EXPECT_EQ(last_msg_->contents[22], 127)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[22])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[22])),
+            127)
       << "incorrect value for contents[22], expected 127, is "
       << last_msg_->contents[22];
-  EXPECT_EQ(last_msg_->contents[23], 50)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[23])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[23])),
+            50)
       << "incorrect value for contents[23], expected 50, is "
       << last_msg_->contents[23];
-  EXPECT_EQ(last_msg_->contents[24], 71)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[24])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[24])),
+            71)
       << "incorrect value for contents[24], expected 71, is "
       << last_msg_->contents[24];
-  EXPECT_EQ(last_msg_->contents[25], 106)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[25])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[25])),
+            106)
       << "incorrect value for contents[25], expected 106, is "
       << last_msg_->contents[25];
-  EXPECT_EQ(last_msg_->contents[26], 61)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[26])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[26])),
+            61)
       << "incorrect value for contents[26], expected 61, is "
       << last_msg_->contents[26];
-  EXPECT_EQ(last_msg_->contents[27], 79)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[27])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[27])),
+            79)
       << "incorrect value for contents[27], expected 79, is "
       << last_msg_->contents[27];
-  EXPECT_EQ(last_msg_->contents[28], 191)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[28])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[28])),
+            191)
       << "incorrect value for contents[28], expected 191, is "
       << last_msg_->contents[28];
-  EXPECT_EQ(last_msg_->contents[29], 106)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[29])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[29])),
+            106)
       << "incorrect value for contents[29], expected 106, is "
       << last_msg_->contents[29];
-  EXPECT_EQ(last_msg_->contents[30], 46)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[30])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[30])),
+            46)
       << "incorrect value for contents[30], expected 46, is "
       << last_msg_->contents[30];
-  EXPECT_EQ(last_msg_->contents[31], 79)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[31])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[31])),
+            79)
       << "incorrect value for contents[31], expected 79, is "
       << last_msg_->contents[31];
-  EXPECT_EQ(last_msg_->contents[32], 118)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[32])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[32])),
+            118)
       << "incorrect value for contents[32], expected 118, is "
       << last_msg_->contents[32];
-  EXPECT_EQ(last_msg_->contents[33], 248)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[33])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[33])),
+            248)
       << "incorrect value for contents[33], expected 248, is "
       << last_msg_->contents[33];
-  EXPECT_EQ(last_msg_->contents[34], 118)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[34])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[34])),
+            118)
       << "incorrect value for contents[34], expected 118, is "
       << last_msg_->contents[34];
-  EXPECT_EQ(last_msg_->contents[35], 207)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[35])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[35])),
+            207)
       << "incorrect value for contents[35], expected 207, is "
       << last_msg_->contents[35];
-  EXPECT_EQ(last_msg_->contents[36], 206)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[36])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[36])),
+            206)
       << "incorrect value for contents[36], expected 206, is "
       << last_msg_->contents[36];
-  EXPECT_EQ(last_msg_->contents[37], 210)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[37])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[37])),
+            210)
       << "incorrect value for contents[37], expected 210, is "
       << last_msg_->contents[37];
-  EXPECT_EQ(last_msg_->contents[38], 91)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[38])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[38])),
+            91)
       << "incorrect value for contents[38], expected 91, is "
       << last_msg_->contents[38];
-  EXPECT_EQ(last_msg_->contents[39], 73)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[39])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[39])),
+            73)
       << "incorrect value for contents[39], expected 73, is "
       << last_msg_->contents[39];
-  EXPECT_EQ(last_msg_->contents[40], 251)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[40])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[40])),
+            251)
       << "incorrect value for contents[40], expected 251, is "
       << last_msg_->contents[40];
-  EXPECT_EQ(last_msg_->contents[41], 81)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[41])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[41])),
+            81)
       << "incorrect value for contents[41], expected 81, is "
       << last_msg_->contents[41];
-  EXPECT_EQ(last_msg_->contents[42], 131)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[42])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[42])),
+            131)
       << "incorrect value for contents[42], expected 131, is "
       << last_msg_->contents[42];
-  EXPECT_EQ(last_msg_->contents[43], 205)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[43])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[43])),
+            205)
       << "incorrect value for contents[43], expected 205, is "
       << last_msg_->contents[43];
-  EXPECT_EQ(last_msg_->contents[44], 193)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[44])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[44])),
+            193)
       << "incorrect value for contents[44], expected 193, is "
       << last_msg_->contents[44];
-  EXPECT_EQ(last_msg_->contents[45], 146)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[45])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[45])),
+            146)
       << "incorrect value for contents[45], expected 146, is "
       << last_msg_->contents[45];
-  EXPECT_EQ(last_msg_->contents[46], 206)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[46])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[46])),
+            206)
       << "incorrect value for contents[46], expected 206, is "
       << last_msg_->contents[46];
-  EXPECT_EQ(last_msg_->contents[47], 185)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[47])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[47])),
+            185)
       << "incorrect value for contents[47], expected 185, is "
       << last_msg_->contents[47];
-  EXPECT_EQ(last_msg_->contents[48], 140)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[48])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[48])),
+            140)
       << "incorrect value for contents[48], expected 140, is "
       << last_msg_->contents[48];
-  EXPECT_EQ(last_msg_->contents[49], 249)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[49])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[49])),
+            249)
       << "incorrect value for contents[49], expected 249, is "
       << last_msg_->contents[49];
-  EXPECT_EQ(last_msg_->contents[50], 163)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[50])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[50])),
+            163)
       << "incorrect value for contents[50], expected 163, is "
       << last_msg_->contents[50];
-  EXPECT_EQ(last_msg_->contents[51], 231)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[51])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[51])),
+            231)
       << "incorrect value for contents[51], expected 231, is "
       << last_msg_->contents[51];
-  EXPECT_EQ(last_msg_->contents[52], 65)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[52])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[52])),
+            65)
       << "incorrect value for contents[52], expected 65, is "
       << last_msg_->contents[52];
-  EXPECT_EQ(last_msg_->contents[53], 67)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[53])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[53])),
+            67)
       << "incorrect value for contents[53], expected 67, is "
       << last_msg_->contents[53];
-  EXPECT_EQ(last_msg_->contents[54], 94)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[54])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[54])),
+            94)
       << "incorrect value for contents[54], expected 94, is "
       << last_msg_->contents[54];
-  EXPECT_EQ(last_msg_->contents[55], 250)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[55])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[55])),
+            250)
       << "incorrect value for contents[55], expected 250, is "
       << last_msg_->contents[55];
-  EXPECT_EQ(last_msg_->contents[56], 109)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[56])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[56])),
+            109)
       << "incorrect value for contents[56], expected 109, is "
       << last_msg_->contents[56];
-  EXPECT_EQ(last_msg_->contents[57], 152)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[57])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[57])),
+            152)
       << "incorrect value for contents[57], expected 152, is "
       << last_msg_->contents[57];
-  EXPECT_EQ(last_msg_->contents[58], 95)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[58])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[58])),
+            95)
       << "incorrect value for contents[58], expected 95, is "
       << last_msg_->contents[58];
-  EXPECT_EQ(last_msg_->contents[59], 123)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[59])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[59])),
+            123)
       << "incorrect value for contents[59], expected 123, is "
       << last_msg_->contents[59];
-  EXPECT_EQ(last_msg_->contents[60], 77)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[60])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[60])),
+            77)
       << "incorrect value for contents[60], expected 77, is "
       << last_msg_->contents[60];
-  EXPECT_EQ(last_msg_->contents[61], 224)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[61])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[61])),
+            224)
       << "incorrect value for contents[61], expected 224, is "
       << last_msg_->contents[61];
-  EXPECT_EQ(last_msg_->contents[62], 124)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[62])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[62])),
+            124)
       << "incorrect value for contents[62], expected 124, is "
       << last_msg_->contents[62];
-  EXPECT_EQ(last_msg_->contents[63], 238)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[63])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[63])),
+            238)
       << "incorrect value for contents[63], expected 238, is "
       << last_msg_->contents[63];
-  EXPECT_EQ(last_msg_->contents[64], 205)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[64])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[64])),
+            205)
       << "incorrect value for contents[64], expected 205, is "
       << last_msg_->contents[64];
-  EXPECT_EQ(last_msg_->contents[65], 65)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[65])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[65])),
+            65)
       << "incorrect value for contents[65], expected 65, is "
       << last_msg_->contents[65];
-  EXPECT_EQ(last_msg_->contents[66], 103)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[66])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[66])),
+            103)
       << "incorrect value for contents[66], expected 103, is "
       << last_msg_->contents[66];
-  EXPECT_EQ(last_msg_->contents[67], 35)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[67])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[67])),
+            35)
       << "incorrect value for contents[67], expected 35, is "
       << last_msg_->contents[67];
-  EXPECT_EQ(last_msg_->contents[68], 104)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[68])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[68])),
+            104)
       << "incorrect value for contents[68], expected 104, is "
       << last_msg_->contents[68];
-  EXPECT_EQ(last_msg_->contents[69], 209)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[69])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[69])),
+            209)
       << "incorrect value for contents[69], expected 209, is "
       << last_msg_->contents[69];
-  EXPECT_EQ(last_msg_->contents[70], 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[70])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[70])),
+            5)
       << "incorrect value for contents[70], expected 5, is "
       << last_msg_->contents[70];
-  EXPECT_EQ(last_msg_->contents[71], 191)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[71])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[71])),
+            191)
       << "incorrect value for contents[71], expected 191, is "
       << last_msg_->contents[71];
-  EXPECT_EQ(last_msg_->contents[72], 47)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[72])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[72])),
+            47)
       << "incorrect value for contents[72], expected 47, is "
       << last_msg_->contents[72];
-  EXPECT_EQ(last_msg_->contents[73], 249)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[73])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[73])),
+            249)
       << "incorrect value for contents[73], expected 249, is "
       << last_msg_->contents[73];
-  EXPECT_EQ(last_msg_->contents[74], 176)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[74])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[74])),
+            176)
       << "incorrect value for contents[74], expected 176, is "
       << last_msg_->contents[74];
-  EXPECT_EQ(last_msg_->contents[75], 166)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[75])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[75])),
+            166)
       << "incorrect value for contents[75], expected 166, is "
       << last_msg_->contents[75];
-  EXPECT_EQ(last_msg_->contents[76], 213)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[76])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[76])),
+            213)
       << "incorrect value for contents[76], expected 213, is "
       << last_msg_->contents[76];
-  EXPECT_EQ(last_msg_->contents[77], 46)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[77])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[77])),
+            46)
       << "incorrect value for contents[77], expected 46, is "
       << last_msg_->contents[77];
-  EXPECT_EQ(last_msg_->contents[78], 192)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[78])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[78])),
+            192)
       << "incorrect value for contents[78], expected 192, is "
       << last_msg_->contents[78];
-  EXPECT_EQ(last_msg_->contents[79], 86)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[79])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[79])),
+            86)
       << "incorrect value for contents[79], expected 86, is "
       << last_msg_->contents[79];
-  EXPECT_EQ(last_msg_->contents[80], 32)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[80])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[80])),
+            32)
       << "incorrect value for contents[80], expected 32, is "
       << last_msg_->contents[80];
-  EXPECT_EQ(last_msg_->contents[81], 103)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[81])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[81])),
+            103)
       << "incorrect value for contents[81], expected 103, is "
       << last_msg_->contents[81];
-  EXPECT_EQ(last_msg_->contents[82], 146)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[82])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[82])),
+            146)
       << "incorrect value for contents[82], expected 146, is "
       << last_msg_->contents[82];
-  EXPECT_EQ(last_msg_->contents[83], 252)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[83])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[83])),
+            252)
       << "incorrect value for contents[83], expected 252, is "
       << last_msg_->contents[83];
-  EXPECT_EQ(last_msg_->contents[84], 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[84])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[84])),
+            4)
       << "incorrect value for contents[84], expected 4, is "
       << last_msg_->contents[84];
-  EXPECT_EQ(last_msg_->contents[85], 16)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[85])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[85])),
+            16)
       << "incorrect value for contents[85], expected 16, is "
       << last_msg_->contents[85];
-  EXPECT_EQ(last_msg_->contents[86], 54)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[86])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[86])),
+            54)
       << "incorrect value for contents[86], expected 54, is "
       << last_msg_->contents[86];
-  EXPECT_EQ(last_msg_->contents[87], 161)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[87])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[87])),
+            161)
       << "incorrect value for contents[87], expected 161, is "
       << last_msg_->contents[87];
-  EXPECT_EQ(last_msg_->contents[88], 60)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[88])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[88])),
+            60)
       << "incorrect value for contents[88], expected 60, is "
       << last_msg_->contents[88];
-  EXPECT_EQ(last_msg_->contents[89], 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[89])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[89])),
+            6)
       << "incorrect value for contents[89], expected 6, is "
       << last_msg_->contents[89];
-  EXPECT_EQ(last_msg_->contents[90], 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[90])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[90])),
+            13)
       << "incorrect value for contents[90], expected 13, is "
       << last_msg_->contents[90];
-  EXPECT_EQ(last_msg_->contents[91], 191)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[91])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[91])),
+            191)
       << "incorrect value for contents[91], expected 191, is "
       << last_msg_->contents[91];
-  EXPECT_EQ(last_msg_->contents[92], 116)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[92])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[92])),
+            116)
       << "incorrect value for contents[92], expected 116, is "
       << last_msg_->contents[92];
-  EXPECT_EQ(last_msg_->contents[93], 182)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[93])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[93])),
+            182)
       << "incorrect value for contents[93], expected 182, is "
       << last_msg_->contents[93];
-  EXPECT_EQ(last_msg_->contents[94], 42)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[94])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[94])),
+            42)
       << "incorrect value for contents[94], expected 42, is "
       << last_msg_->contents[94];
-  EXPECT_EQ(last_msg_->contents[95], 191)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[95])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[95])),
+            191)
       << "incorrect value for contents[95], expected 191, is "
       << last_msg_->contents[95];
-  EXPECT_EQ(last_msg_->contents[96], 213)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[96])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[96])),
+            213)
       << "incorrect value for contents[96], expected 213, is "
       << last_msg_->contents[96];
-  EXPECT_EQ(last_msg_->contents[97], 20)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[97])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[97])),
+            20)
       << "incorrect value for contents[97], expected 20, is "
       << last_msg_->contents[97];
-  EXPECT_EQ(last_msg_->contents[98], 217)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[98])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[98])),
+            217)
       << "incorrect value for contents[98], expected 217, is "
       << last_msg_->contents[98];
-  EXPECT_EQ(last_msg_->contents[99], 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[99])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[99])),
+            8)
       << "incorrect value for contents[99], expected 8, is "
       << last_msg_->contents[99];
-  EXPECT_EQ(last_msg_->contents[100], 142)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[100])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[100])),
+            142)
       << "incorrect value for contents[100], expected 142, is "
       << last_msg_->contents[100];
-  EXPECT_EQ(last_msg_->contents[101], 187)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[101])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[101])),
+            187)
       << "incorrect value for contents[101], expected 187, is "
       << last_msg_->contents[101];
-  EXPECT_EQ(last_msg_->contents[102], 238)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[102])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[102])),
+            238)
       << "incorrect value for contents[102], expected 238, is "
       << last_msg_->contents[102];
-  EXPECT_EQ(last_msg_->contents[103], 120)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[103])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[103])),
+            120)
       << "incorrect value for contents[103], expected 120, is "
       << last_msg_->contents[103];
-  EXPECT_EQ(last_msg_->contents[104], 184)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[104])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[104])),
+            184)
       << "incorrect value for contents[104], expected 184, is "
       << last_msg_->contents[104];
-  EXPECT_EQ(last_msg_->contents[105], 250)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[105])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[105])),
+            250)
       << "incorrect value for contents[105], expected 250, is "
       << last_msg_->contents[105];
-  EXPECT_EQ(last_msg_->contents[106], 31)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[106])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[106])),
+            31)
       << "incorrect value for contents[106], expected 31, is "
       << last_msg_->contents[106];
-  EXPECT_EQ(last_msg_->contents[107], 151)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[107])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[107])),
+            151)
       << "incorrect value for contents[107], expected 151, is "
       << last_msg_->contents[107];
-  EXPECT_EQ(last_msg_->contents[108], 37)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[108])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[108])),
+            37)
       << "incorrect value for contents[108], expected 37, is "
       << last_msg_->contents[108];
-  EXPECT_EQ(last_msg_->contents[109], 51)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[109])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[109])),
+            51)
       << "incorrect value for contents[109], expected 51, is "
       << last_msg_->contents[109];
-  EXPECT_EQ(last_msg_->contents[110], 177)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[110])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[110])),
+            177)
       << "incorrect value for contents[110], expected 177, is "
       << last_msg_->contents[110];
-  EXPECT_EQ(last_msg_->contents[111], 130)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[111])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[111])),
+            130)
       << "incorrect value for contents[111], expected 130, is "
       << last_msg_->contents[111];
-  EXPECT_EQ(last_msg_->contents[112], 190)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[112])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[112])),
+            190)
       << "incorrect value for contents[112], expected 190, is "
       << last_msg_->contents[112];
-  EXPECT_EQ(last_msg_->contents[113], 155)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[113])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[113])),
+            155)
       << "incorrect value for contents[113], expected 155, is "
       << last_msg_->contents[113];
-  EXPECT_EQ(last_msg_->contents[114], 71)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[114])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[114])),
+            71)
       << "incorrect value for contents[114], expected 71, is "
       << last_msg_->contents[114];
-  EXPECT_EQ(last_msg_->contents[115], 68)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[115])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[115])),
+            68)
       << "incorrect value for contents[115], expected 68, is "
       << last_msg_->contents[115];
-  EXPECT_EQ(last_msg_->contents[116], 56)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[116])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[116])),
+            56)
       << "incorrect value for contents[116], expected 56, is "
       << last_msg_->contents[116];
-  EXPECT_EQ(last_msg_->contents[117], 238)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[117])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[117])),
+            238)
       << "incorrect value for contents[117], expected 238, is "
       << last_msg_->contents[117];
-  EXPECT_EQ(last_msg_->contents[118], 92)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[118])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[118])),
+            92)
       << "incorrect value for contents[118], expected 92, is "
       << last_msg_->contents[118];
-  EXPECT_EQ(last_msg_->contents[119], 130)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[119])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[119])),
+            130)
       << "incorrect value for contents[119], expected 130, is "
       << last_msg_->contents[119];
-  EXPECT_EQ(last_msg_->contents[120], 37)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[120])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[120])),
+            37)
       << "incorrect value for contents[120], expected 37, is "
       << last_msg_->contents[120];
-  EXPECT_EQ(last_msg_->contents[121], 137)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[121])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[121])),
+            137)
       << "incorrect value for contents[121], expected 137, is "
       << last_msg_->contents[121];
-  EXPECT_EQ(last_msg_->contents[122], 146)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[122])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[122])),
+            146)
       << "incorrect value for contents[122], expected 146, is "
       << last_msg_->contents[122];
-  EXPECT_EQ(last_msg_->contents[123], 246)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[123])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[123])),
+            246)
       << "incorrect value for contents[123], expected 246, is "
       << last_msg_->contents[123];
-  EXPECT_EQ(last_msg_->contents[124], 114)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[124])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[124])),
+            114)
       << "incorrect value for contents[124], expected 114, is "
       << last_msg_->contents[124];
-  EXPECT_EQ(last_msg_->contents[125], 116)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[125])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[125])),
+            116)
       << "incorrect value for contents[125], expected 116, is "
       << last_msg_->contents[125];
-  EXPECT_EQ(last_msg_->contents[126], 138)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[126])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[126])),
+            138)
       << "incorrect value for contents[126], expected 138, is "
       << last_msg_->contents[126];
-  EXPECT_EQ(last_msg_->contents[127], 165)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[127])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[127])),
+            165)
       << "incorrect value for contents[127], expected 165, is "
       << last_msg_->contents[127];
-  EXPECT_EQ(last_msg_->contents[128], 217)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[128])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[128])),
+            217)
       << "incorrect value for contents[128], expected 217, is "
       << last_msg_->contents[128];
-  EXPECT_EQ(last_msg_->contents[129], 79)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[129])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[129])),
+            79)
       << "incorrect value for contents[129], expected 79, is "
       << last_msg_->contents[129];
-  EXPECT_EQ(last_msg_->contents[130], 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[130])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[130])),
+            10)
       << "incorrect value for contents[130], expected 10, is "
       << last_msg_->contents[130];
-  EXPECT_EQ(last_msg_->contents[131], 189)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[131])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[131])),
+            189)
       << "incorrect value for contents[131], expected 189, is "
       << last_msg_->contents[131];
-  EXPECT_EQ(last_msg_->contents[132], 128)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[132])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[132])),
+            128)
       << "incorrect value for contents[132], expected 128, is "
       << last_msg_->contents[132];
-  EXPECT_EQ(last_msg_->contents[133], 189)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[133])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[133])),
+            189)
       << "incorrect value for contents[133], expected 189, is "
       << last_msg_->contents[133];
-  EXPECT_EQ(last_msg_->contents[134], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[134])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[134])),
+            2)
       << "incorrect value for contents[134], expected 2, is "
       << last_msg_->contents[134];
-  EXPECT_EQ(last_msg_->contents[135], 240)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[135])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[135])),
+            240)
       << "incorrect value for contents[135], expected 240, is "
       << last_msg_->contents[135];
-  EXPECT_EQ(last_msg_->contents[136], 92)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[136])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[136])),
+            92)
       << "incorrect value for contents[136], expected 92, is "
       << last_msg_->contents[136];
-  EXPECT_EQ(last_msg_->contents[137], 28)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[137])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[137])),
+            28)
       << "incorrect value for contents[137], expected 28, is "
       << last_msg_->contents[137];
-  EXPECT_EQ(last_msg_->contents[138], 126)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[138])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[138])),
+            126)
       << "incorrect value for contents[138], expected 126, is "
       << last_msg_->contents[138];
-  EXPECT_EQ(last_msg_->contents[139], 105)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[139])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[139])),
+            105)
       << "incorrect value for contents[139], expected 105, is "
       << last_msg_->contents[139];
-  EXPECT_EQ(last_msg_->contents[140], 236)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[140])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[140])),
+            236)
       << "incorrect value for contents[140], expected 236, is "
       << last_msg_->contents[140];
-  EXPECT_EQ(last_msg_->contents[141], 228)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[141])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[141])),
+            228)
       << "incorrect value for contents[141], expected 228, is "
       << last_msg_->contents[141];
-  EXPECT_EQ(last_msg_->contents[142], 194)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[142])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[142])),
+            194)
       << "incorrect value for contents[142], expected 194, is "
       << last_msg_->contents[142];
-  EXPECT_EQ(last_msg_->contents[143], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[143])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[143])),
+            0)
       << "incorrect value for contents[143], expected 0, is "
       << last_msg_->contents[143];
-  EXPECT_EQ(last_msg_->contents[144], 51)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[144])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[144])),
+            51)
       << "incorrect value for contents[144], expected 51, is "
       << last_msg_->contents[144];
-  EXPECT_EQ(last_msg_->contents[145], 61)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[145])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[145])),
+            61)
       << "incorrect value for contents[145], expected 61, is "
       << last_msg_->contents[145];
-  EXPECT_EQ(last_msg_->contents[146], 74)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[146])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[146])),
+            74)
       << "incorrect value for contents[146], expected 74, is "
       << last_msg_->contents[146];
-  EXPECT_EQ(last_msg_->contents[147], 41)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[147])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[147])),
+            41)
       << "incorrect value for contents[147], expected 41, is "
       << last_msg_->contents[147];
-  EXPECT_EQ(last_msg_->contents[148], 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[148])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[148])),
+            10)
       << "incorrect value for contents[148], expected 10, is "
       << last_msg_->contents[148];
-  EXPECT_EQ(last_msg_->contents[149], 239)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[149])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[149])),
+            239)
       << "incorrect value for contents[149], expected 239, is "
       << last_msg_->contents[149];
-  EXPECT_EQ(last_msg_->contents[150], 133)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[150])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[150])),
+            133)
       << "incorrect value for contents[150], expected 133, is "
       << last_msg_->contents[150];
-  EXPECT_EQ(last_msg_->contents[151], 106)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[151])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[151])),
+            106)
       << "incorrect value for contents[151], expected 106, is "
       << last_msg_->contents[151];
-  EXPECT_EQ(last_msg_->contents[152], 190)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[152])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[152])),
+            190)
       << "incorrect value for contents[152], expected 190, is "
       << last_msg_->contents[152];
-  EXPECT_EQ(last_msg_->contents[153], 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[153])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[153])),
+            30)
       << "incorrect value for contents[153], expected 30, is "
       << last_msg_->contents[153];
-  EXPECT_EQ(last_msg_->contents[154], 27)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[154])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[154])),
+            27)
       << "incorrect value for contents[154], expected 27, is "
       << last_msg_->contents[154];
-  EXPECT_EQ(last_msg_->contents[155], 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[155])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[155])),
+            3)
       << "incorrect value for contents[155], expected 3, is "
       << last_msg_->contents[155];
-  EXPECT_EQ(last_msg_->contents[156], 240)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[156])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[156])),
+            240)
       << "incorrect value for contents[156], expected 240, is "
       << last_msg_->contents[156];
-  EXPECT_EQ(last_msg_->contents[157], 205)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[157])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[157])),
+            205)
       << "incorrect value for contents[157], expected 205, is "
       << last_msg_->contents[157];
-  EXPECT_EQ(last_msg_->contents[158], 253)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[158])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[158])),
+            253)
       << "incorrect value for contents[158], expected 253, is "
       << last_msg_->contents[158];
-  EXPECT_EQ(last_msg_->contents[159], 113)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[159])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[159])),
+            113)
       << "incorrect value for contents[159], expected 113, is "
       << last_msg_->contents[159];
-  EXPECT_EQ(last_msg_->contents[160], 25)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[160])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[160])),
+            25)
       << "incorrect value for contents[160], expected 25, is "
       << last_msg_->contents[160];
-  EXPECT_EQ(last_msg_->contents[161], 28)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[161])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[161])),
+            28)
       << "incorrect value for contents[161], expected 28, is "
       << last_msg_->contents[161];
-  EXPECT_EQ(last_msg_->contents[162], 187)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[162])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[162])),
+            187)
       << "incorrect value for contents[162], expected 187, is "
       << last_msg_->contents[162];
-  EXPECT_EQ(last_msg_->contents[163], 81)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[163])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[163])),
+            81)
       << "incorrect value for contents[163], expected 81, is "
       << last_msg_->contents[163];
-  EXPECT_EQ(last_msg_->contents[164], 101)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[164])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[164])),
+            101)
       << "incorrect value for contents[164], expected 101, is "
       << last_msg_->contents[164];
-  EXPECT_EQ(last_msg_->contents[165], 216)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[165])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[165])),
+            216)
       << "incorrect value for contents[165], expected 216, is "
       << last_msg_->contents[165];
-  EXPECT_EQ(last_msg_->contents[166], 121)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[166])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[166])),
+            121)
       << "incorrect value for contents[166], expected 121, is "
       << last_msg_->contents[166];
-  EXPECT_EQ(last_msg_->contents[167], 41)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[167])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[167])),
+            41)
       << "incorrect value for contents[167], expected 41, is "
       << last_msg_->contents[167];
-  EXPECT_EQ(last_msg_->contents[168], 179)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[168])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[168])),
+            179)
       << "incorrect value for contents[168], expected 179, is "
       << last_msg_->contents[168];
-  EXPECT_EQ(last_msg_->contents[169], 120)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[169])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[169])),
+            120)
       << "incorrect value for contents[169], expected 120, is "
       << last_msg_->contents[169];
-  EXPECT_EQ(last_msg_->contents[170], 152)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[170])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[170])),
+            152)
       << "incorrect value for contents[170], expected 152, is "
       << last_msg_->contents[170];
-  EXPECT_EQ(last_msg_->contents[171], 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[171])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[171])),
+            18)
       << "incorrect value for contents[171], expected 18, is "
       << last_msg_->contents[171];
-  EXPECT_EQ(last_msg_->contents[172], 116)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[172])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[172])),
+            116)
       << "incorrect value for contents[172], expected 116, is "
       << last_msg_->contents[172];
-  EXPECT_EQ(last_msg_->contents[173], 53)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[173])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[173])),
+            53)
       << "incorrect value for contents[173], expected 53, is "
       << last_msg_->contents[173];
-  EXPECT_EQ(last_msg_->contents[174], 212)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[174])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[174])),
+            212)
       << "incorrect value for contents[174], expected 212, is "
       << last_msg_->contents[174];
-  EXPECT_EQ(last_msg_->contents[175], 100)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[175])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[175])),
+            100)
       << "incorrect value for contents[175], expected 100, is "
       << last_msg_->contents[175];
-  EXPECT_EQ(last_msg_->contents[176], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[176])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[176])),
+            2)
       << "incorrect value for contents[176], expected 2, is "
       << last_msg_->contents[176];
-  EXPECT_EQ(last_msg_->contents[177], 114)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[177])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[177])),
+            114)
       << "incorrect value for contents[177], expected 114, is "
       << last_msg_->contents[177];
-  EXPECT_EQ(last_msg_->contents[178], 198)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[178])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[178])),
+            198)
       << "incorrect value for contents[178], expected 198, is "
       << last_msg_->contents[178];
-  EXPECT_EQ(last_msg_->contents[179], 200)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[179])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[179])),
+            200)
       << "incorrect value for contents[179], expected 200, is "
       << last_msg_->contents[179];
-  EXPECT_EQ(last_msg_->contents[180], 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[180])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[180])),
+            10)
       << "incorrect value for contents[180], expected 10, is "
       << last_msg_->contents[180];
-  EXPECT_EQ(last_msg_->contents[181], 147)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[181])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[181])),
+            147)
       << "incorrect value for contents[181], expected 147, is "
       << last_msg_->contents[181];
-  EXPECT_EQ(last_msg_->contents[182], 25)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[182])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[182])),
+            25)
       << "incorrect value for contents[182], expected 25, is "
       << last_msg_->contents[182];
-  EXPECT_EQ(last_msg_->contents[183], 33)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[183])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[183])),
+            33)
       << "incorrect value for contents[183], expected 33, is "
       << last_msg_->contents[183];
-  EXPECT_EQ(last_msg_->contents[184], 115)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[184])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[184])),
+            115)
       << "incorrect value for contents[184], expected 115, is "
       << last_msg_->contents[184];
-  EXPECT_EQ(last_msg_->contents[185], 208)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[185])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[185])),
+            208)
       << "incorrect value for contents[185], expected 208, is "
       << last_msg_->contents[185];
-  EXPECT_EQ(last_msg_->contents[186], 113)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[186])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[186])),
+            113)
       << "incorrect value for contents[186], expected 113, is "
       << last_msg_->contents[186];
-  EXPECT_EQ(last_msg_->contents[187], 60)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[187])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[187])),
+            60)
       << "incorrect value for contents[187], expected 60, is "
       << last_msg_->contents[187];
-  EXPECT_EQ(last_msg_->contents[188], 179)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[188])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[188])),
+            179)
       << "incorrect value for contents[188], expected 179, is "
       << last_msg_->contents[188];
-  EXPECT_EQ(last_msg_->contents[189], 183)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[189])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[189])),
+            183)
       << "incorrect value for contents[189], expected 183, is "
       << last_msg_->contents[189];
-  EXPECT_EQ(last_msg_->contents[190], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[190])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[190])),
+            0)
       << "incorrect value for contents[190], expected 0, is "
       << last_msg_->contents[190];
-  EXPECT_EQ(last_msg_->contents[191], 41)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[191])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[191])),
+            41)
       << "incorrect value for contents[191], expected 41, is "
       << last_msg_->contents[191];
-  EXPECT_EQ(last_msg_->contents[192], 217)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[192])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[192])),
+            217)
       << "incorrect value for contents[192], expected 217, is "
       << last_msg_->contents[192];
-  EXPECT_EQ(last_msg_->contents[193], 206)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[193])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[193])),
+            206)
       << "incorrect value for contents[193], expected 206, is "
       << last_msg_->contents[193];
-  EXPECT_EQ(last_msg_->contents[194], 255)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[194])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[194])),
+            255)
       << "incorrect value for contents[194], expected 255, is "
       << last_msg_->contents[194];
-  EXPECT_EQ(last_msg_->contents[195], 211)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[195])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[195])),
+            211)
       << "incorrect value for contents[195], expected 211, is "
       << last_msg_->contents[195];
-  EXPECT_EQ(last_msg_->contents[196], 225)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[196])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[196])),
+            225)
       << "incorrect value for contents[196], expected 225, is "
       << last_msg_->contents[196];
-  EXPECT_EQ(last_msg_->contents[197], 142)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[197])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[197])),
+            142)
       << "incorrect value for contents[197], expected 142, is "
       << last_msg_->contents[197];
-  EXPECT_EQ(last_msg_->contents[198], 191)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[198])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[198])),
+            191)
       << "incorrect value for contents[198], expected 191, is "
       << last_msg_->contents[198];
-  EXPECT_EQ(last_msg_->contents[199], 133)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[199])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[199])),
+            133)
       << "incorrect value for contents[199], expected 133, is "
       << last_msg_->contents[199];
-  EXPECT_EQ(last_msg_->contents[200], 81)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[200])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[200])),
+            81)
       << "incorrect value for contents[200], expected 81, is "
       << last_msg_->contents[200];
-  EXPECT_EQ(last_msg_->contents[201], 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[201])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[201])),
+            15)
       << "incorrect value for contents[201], expected 15, is "
       << last_msg_->contents[201];
-  EXPECT_EQ(last_msg_->contents[202], 248)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[202])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[202])),
+            248)
       << "incorrect value for contents[202], expected 248, is "
       << last_msg_->contents[202];
-  EXPECT_EQ(last_msg_->contents[203], 193)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[203])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[203])),
+            193)
       << "incorrect value for contents[203], expected 193, is "
       << last_msg_->contents[203];
-  EXPECT_EQ(last_msg_->contents[204], 66)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[204])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[204])),
+            66)
       << "incorrect value for contents[204], expected 66, is "
       << last_msg_->contents[204];
-  EXPECT_EQ(last_msg_->contents[205], 191)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[205])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[205])),
+            191)
       << "incorrect value for contents[205], expected 191, is "
       << last_msg_->contents[205];
-  EXPECT_EQ(last_msg_->contents[206], 244)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[206])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[206])),
+            244)
       << "incorrect value for contents[206], expected 244, is "
       << last_msg_->contents[206];
-  EXPECT_EQ(last_msg_->contents[207], 221)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[207])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[207])),
+            221)
       << "incorrect value for contents[207], expected 221, is "
       << last_msg_->contents[207];
-  EXPECT_EQ(last_msg_->contents[208], 248)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[208])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[208])),
+            248)
       << "incorrect value for contents[208], expected 248, is "
       << last_msg_->contents[208];
-  EXPECT_EQ(last_msg_->contents[209], 199)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[209])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[209])),
+            199)
       << "incorrect value for contents[209], expected 199, is "
       << last_msg_->contents[209];
-  EXPECT_EQ(last_msg_->contents[210], 241)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[210])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[210])),
+            241)
       << "incorrect value for contents[210], expected 241, is "
       << last_msg_->contents[210];
-  EXPECT_EQ(last_msg_->contents[211], 112)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[211])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[211])),
+            112)
       << "incorrect value for contents[211], expected 112, is "
       << last_msg_->contents[211];
-  EXPECT_EQ(last_msg_->contents[212], 51)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[212])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[212])),
+            51)
       << "incorrect value for contents[212], expected 51, is "
       << last_msg_->contents[212];
-  EXPECT_EQ(last_msg_->contents[213], 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[213])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[213])),
+            1)
       << "incorrect value for contents[213], expected 1, is "
       << last_msg_->contents[213];
-  EXPECT_EQ(last_msg_->contents[214], 180)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[214])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[214])),
+            180)
       << "incorrect value for contents[214], expected 180, is "
       << last_msg_->contents[214];
-  EXPECT_EQ(last_msg_->contents[215], 180)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[215])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[215])),
+            180)
       << "incorrect value for contents[215], expected 180, is "
       << last_msg_->contents[215];
-  EXPECT_EQ(last_msg_->contents[216], 125)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[216])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[216])),
+            125)
       << "incorrect value for contents[216], expected 125, is "
       << last_msg_->contents[216];
-  EXPECT_EQ(last_msg_->contents[217], 97)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[217])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[217])),
+            97)
       << "incorrect value for contents[217], expected 97, is "
       << last_msg_->contents[217];
-  EXPECT_EQ(last_msg_->contents[218], 145)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[218])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[218])),
+            145)
       << "incorrect value for contents[218], expected 145, is "
       << last_msg_->contents[218];
-  EXPECT_EQ(last_msg_->contents[219], 25)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[219])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[219])),
+            25)
       << "incorrect value for contents[219], expected 25, is "
       << last_msg_->contents[219];
-  EXPECT_EQ(last_msg_->contents[220], 72)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[220])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[220])),
+            72)
       << "incorrect value for contents[220], expected 72, is "
       << last_msg_->contents[220];
-  EXPECT_EQ(last_msg_->contents[221], 210)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[221])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[221])),
+            210)
       << "incorrect value for contents[221], expected 210, is "
       << last_msg_->contents[221];
-  EXPECT_EQ(last_msg_->contents[222], 215)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[222])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[222])),
+            215)
       << "incorrect value for contents[222], expected 215, is "
       << last_msg_->contents[222];
-  EXPECT_EQ(last_msg_->contents[223], 208)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[223])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[223])),
+            208)
       << "incorrect value for contents[223], expected 208, is "
       << last_msg_->contents[223];
-  EXPECT_EQ(last_msg_->contents[224], 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[224])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[224])),
+            15)
       << "incorrect value for contents[224], expected 15, is "
       << last_msg_->contents[224];
-  EXPECT_EQ(last_msg_->contents[225], 126)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[225])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[225])),
+            126)
       << "incorrect value for contents[225], expected 126, is "
       << last_msg_->contents[225];
-  EXPECT_EQ(last_msg_->contents[226], 56)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[226])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[226])),
+            56)
       << "incorrect value for contents[226], expected 56, is "
       << last_msg_->contents[226];
-  EXPECT_EQ(last_msg_->contents[227], 38)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[227])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[227])),
+            38)
       << "incorrect value for contents[227], expected 38, is "
       << last_msg_->contents[227];
-  EXPECT_EQ(last_msg_->contents[228], 65)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[228])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[228])),
+            65)
       << "incorrect value for contents[228], expected 65, is "
       << last_msg_->contents[228];
-  EXPECT_EQ(last_msg_->contents[229], 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[229])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[229])),
+            4)
       << "incorrect value for contents[229], expected 4, is "
       << last_msg_->contents[229];
-  EXPECT_EQ(last_msg_->contents[230], 64)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[230])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[230])),
+            64)
       << "incorrect value for contents[230], expected 64, is "
       << last_msg_->contents[230];
-  EXPECT_EQ(last_msg_->contents[231], 19)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[231])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[231])),
+            19)
       << "incorrect value for contents[231], expected 19, is "
       << last_msg_->contents[231];
-  EXPECT_EQ(last_msg_->contents[232], 74)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[232])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[232])),
+            74)
       << "incorrect value for contents[232], expected 74, is "
       << last_msg_->contents[232];
-  EXPECT_EQ(last_msg_->contents[233], 223)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[233])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[233])),
+            223)
       << "incorrect value for contents[233], expected 223, is "
       << last_msg_->contents[233];
-  EXPECT_EQ(last_msg_->contents[234], 111)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[234])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[234])),
+            111)
       << "incorrect value for contents[234], expected 111, is "
       << last_msg_->contents[234];
-  EXPECT_EQ(last_msg_->contents[235], 109)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[235])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[235])),
+            109)
       << "incorrect value for contents[235], expected 109, is "
       << last_msg_->contents[235];
-  EXPECT_EQ(last_msg_->contents[236], 52)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[236])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[236])),
+            52)
       << "incorrect value for contents[236], expected 52, is "
       << last_msg_->contents[236];
-  EXPECT_EQ(last_msg_->contents[237], 43)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[237])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[237])),
+            43)
       << "incorrect value for contents[237], expected 43, is "
       << last_msg_->contents[237];
-  EXPECT_EQ(last_msg_->contents[238], 167)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[238])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[238])),
+            167)
       << "incorrect value for contents[238], expected 167, is "
       << last_msg_->contents[238];
-  EXPECT_EQ(last_msg_->contents[239], 186)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[239])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[239])),
+            186)
       << "incorrect value for contents[239], expected 186, is "
       << last_msg_->contents[239];
-  EXPECT_EQ(last_msg_->contents[240], 202)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[240])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[240])),
+            202)
       << "incorrect value for contents[240], expected 202, is "
       << last_msg_->contents[240];
-  EXPECT_EQ(last_msg_->contents[241], 111)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[241])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[241])),
+            111)
       << "incorrect value for contents[241], expected 111, is "
       << last_msg_->contents[241];
-  EXPECT_EQ(last_msg_->contents[242], 11)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[242])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[242])),
+            11)
       << "incorrect value for contents[242], expected 11, is "
       << last_msg_->contents[242];
-  EXPECT_EQ(last_msg_->contents[243], 91)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[243])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[243])),
+            91)
       << "incorrect value for contents[243], expected 91, is "
       << last_msg_->contents[243];
-  EXPECT_EQ(last_msg_->contents[244], 21)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[244])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[244])),
+            21)
       << "incorrect value for contents[244], expected 21, is "
       << last_msg_->contents[244];
-  EXPECT_EQ(last_msg_->contents[245], 236)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[245])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[245])),
+            236)
       << "incorrect value for contents[245], expected 236, is "
       << last_msg_->contents[245];
-  EXPECT_EQ(last_msg_->contents[246], 234)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[246])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[246])),
+            234)
       << "incorrect value for contents[246], expected 234, is "
       << last_msg_->contents[246];
-  EXPECT_EQ(last_msg_->contents[247], 196)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[247])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[247])),
+            196)
       << "incorrect value for contents[247], expected 196, is "
       << last_msg_->contents[247];
-  EXPECT_EQ(last_msg_->contents[248], 36)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[248])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[248])),
+            36)
       << "incorrect value for contents[248], expected 36, is "
       << last_msg_->contents[248];
-  EXPECT_EQ(last_msg_->contents[249], 171)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[249])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[249])),
+            171)
       << "incorrect value for contents[249], expected 171, is "
       << last_msg_->contents[249];
-  EXPECT_EQ(last_msg_->contents[250], 147)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[250])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[250])),
+            147)
       << "incorrect value for contents[250], expected 147, is "
       << last_msg_->contents[250];
-  EXPECT_EQ(last_msg_->sequence, 259241795)
+  EXPECT_EQ(get_as<decltype(last_msg_->sequence)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sequence)),
+            259241795)
       << "incorrect value for sequence, expected 259241795, is "
       << last_msg_->sequence;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_file_io_MsgFileioRemove.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_file_io_MsgFileioRemove.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/file_io.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_file_io_MsgFileioRemove0
     : public ::testing::Test,
       public sbp::LegacyState,

--- a/c/test/legacy/cpp/auto_check_sbp_file_io_MsgFileioWriteResp.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_file_io_MsgFileioWriteResp.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/file_io.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_file_io_MsgFileioWriteResp0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -112,7 +119,9 @@ TEST_F(Test_legacy_auto_check_sbp_file_io_MsgFileioWriteResp0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->sequence, 202)
+  EXPECT_EQ(get_as<decltype(last_msg_->sequence)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sequence)),
+            202)
       << "incorrect value for sequence, expected 202, is "
       << last_msg_->sequence;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_flash_MsgFlashDone.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_flash_MsgFlashDone.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/flash.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_flash_MsgFlashDone0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -110,7 +117,9 @@ TEST_F(Test_legacy_auto_check_sbp_flash_MsgFlashDone0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->response, 82)
+  EXPECT_EQ(get_as<decltype(last_msg_->response)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->response)),
+            82)
       << "incorrect value for response, expected 82, is "
       << last_msg_->response;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_flash_MsgFlashErase.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_flash_MsgFlashErase.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/flash.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_flash_MsgFlashErase0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -111,9 +118,13 @@ TEST_F(Test_legacy_auto_check_sbp_flash_MsgFlashErase0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->sector_num, 2222371310)
+  EXPECT_EQ(get_as<decltype(last_msg_->sector_num)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sector_num)),
+            2222371310)
       << "incorrect value for sector_num, expected 2222371310, is "
       << last_msg_->sector_num;
-  EXPECT_EQ(last_msg_->target, 74)
+  EXPECT_EQ(get_as<decltype(last_msg_->target)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->target)),
+            74)
       << "incorrect value for target, expected 74, is " << last_msg_->target;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_flash_MsgFlashProgram.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_flash_MsgFlashProgram.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/flash.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_flash_MsgFlashProgram0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -1393,753 +1400,1263 @@ TEST_F(Test_legacy_auto_check_sbp_flash_MsgFlashProgram0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->addr_len, 250)
+  EXPECT_EQ(get_as<decltype(last_msg_->addr_len)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->addr_len)),
+            250)
       << "incorrect value for addr_len, expected 250, is "
       << last_msg_->addr_len;
-  EXPECT_EQ(last_msg_->addr_start[0], 87)
+  EXPECT_EQ(get_as<decltype(last_msg_->addr_start[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->addr_start[0])),
+            87)
       << "incorrect value for addr_start[0], expected 87, is "
       << last_msg_->addr_start[0];
-  EXPECT_EQ(last_msg_->addr_start[1], 52)
+  EXPECT_EQ(get_as<decltype(last_msg_->addr_start[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->addr_start[1])),
+            52)
       << "incorrect value for addr_start[1], expected 52, is "
       << last_msg_->addr_start[1];
-  EXPECT_EQ(last_msg_->addr_start[2], 244)
+  EXPECT_EQ(get_as<decltype(last_msg_->addr_start[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->addr_start[2])),
+            244)
       << "incorrect value for addr_start[2], expected 244, is "
       << last_msg_->addr_start[2];
-  EXPECT_EQ(last_msg_->data[0], 176)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[0])),
+            176)
       << "incorrect value for data[0], expected 176, is " << last_msg_->data[0];
-  EXPECT_EQ(last_msg_->data[1], 222)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[1])),
+            222)
       << "incorrect value for data[1], expected 222, is " << last_msg_->data[1];
-  EXPECT_EQ(last_msg_->data[2], 235)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[2])),
+            235)
       << "incorrect value for data[2], expected 235, is " << last_msg_->data[2];
-  EXPECT_EQ(last_msg_->data[3], 106)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[3])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[3])),
+            106)
       << "incorrect value for data[3], expected 106, is " << last_msg_->data[3];
-  EXPECT_EQ(last_msg_->data[4], 144)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[4])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[4])),
+            144)
       << "incorrect value for data[4], expected 144, is " << last_msg_->data[4];
-  EXPECT_EQ(last_msg_->data[5], 29)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[5])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[5])),
+            29)
       << "incorrect value for data[5], expected 29, is " << last_msg_->data[5];
-  EXPECT_EQ(last_msg_->data[6], 141)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[6])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[6])),
+            141)
       << "incorrect value for data[6], expected 141, is " << last_msg_->data[6];
-  EXPECT_EQ(last_msg_->data[7], 255)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[7])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[7])),
+            255)
       << "incorrect value for data[7], expected 255, is " << last_msg_->data[7];
-  EXPECT_EQ(last_msg_->data[8], 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[8])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[8])),
+            3)
       << "incorrect value for data[8], expected 3, is " << last_msg_->data[8];
-  EXPECT_EQ(last_msg_->data[9], 16)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[9])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[9])),
+            16)
       << "incorrect value for data[9], expected 16, is " << last_msg_->data[9];
-  EXPECT_EQ(last_msg_->data[10], 192)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[10])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[10])),
+            192)
       << "incorrect value for data[10], expected 192, is "
       << last_msg_->data[10];
-  EXPECT_EQ(last_msg_->data[11], 237)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[11])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[11])),
+            237)
       << "incorrect value for data[11], expected 237, is "
       << last_msg_->data[11];
-  EXPECT_EQ(last_msg_->data[12], 172)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[12])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[12])),
+            172)
       << "incorrect value for data[12], expected 172, is "
       << last_msg_->data[12];
-  EXPECT_EQ(last_msg_->data[13], 254)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[13])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[13])),
+            254)
       << "incorrect value for data[13], expected 254, is "
       << last_msg_->data[13];
-  EXPECT_EQ(last_msg_->data[14], 213)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[14])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[14])),
+            213)
       << "incorrect value for data[14], expected 213, is "
       << last_msg_->data[14];
-  EXPECT_EQ(last_msg_->data[15], 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[15])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[15])),
+            4)
       << "incorrect value for data[15], expected 4, is " << last_msg_->data[15];
-  EXPECT_EQ(last_msg_->data[16], 220)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[16])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[16])),
+            220)
       << "incorrect value for data[16], expected 220, is "
       << last_msg_->data[16];
-  EXPECT_EQ(last_msg_->data[17], 98)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[17])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[17])),
+            98)
       << "incorrect value for data[17], expected 98, is "
       << last_msg_->data[17];
-  EXPECT_EQ(last_msg_->data[18], 34)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[18])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[18])),
+            34)
       << "incorrect value for data[18], expected 34, is "
       << last_msg_->data[18];
-  EXPECT_EQ(last_msg_->data[19], 222)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[19])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[19])),
+            222)
       << "incorrect value for data[19], expected 222, is "
       << last_msg_->data[19];
-  EXPECT_EQ(last_msg_->data[20], 230)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[20])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[20])),
+            230)
       << "incorrect value for data[20], expected 230, is "
       << last_msg_->data[20];
-  EXPECT_EQ(last_msg_->data[21], 214)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[21])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[21])),
+            214)
       << "incorrect value for data[21], expected 214, is "
       << last_msg_->data[21];
-  EXPECT_EQ(last_msg_->data[22], 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[22])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[22])),
+            6)
       << "incorrect value for data[22], expected 6, is " << last_msg_->data[22];
-  EXPECT_EQ(last_msg_->data[23], 217)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[23])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[23])),
+            217)
       << "incorrect value for data[23], expected 217, is "
       << last_msg_->data[23];
-  EXPECT_EQ(last_msg_->data[24], 172)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[24])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[24])),
+            172)
       << "incorrect value for data[24], expected 172, is "
       << last_msg_->data[24];
-  EXPECT_EQ(last_msg_->data[25], 122)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[25])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[25])),
+            122)
       << "incorrect value for data[25], expected 122, is "
       << last_msg_->data[25];
-  EXPECT_EQ(last_msg_->data[26], 46)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[26])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[26])),
+            46)
       << "incorrect value for data[26], expected 46, is "
       << last_msg_->data[26];
-  EXPECT_EQ(last_msg_->data[27], 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[27])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[27])),
+            13)
       << "incorrect value for data[27], expected 13, is "
       << last_msg_->data[27];
-  EXPECT_EQ(last_msg_->data[28], 38)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[28])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[28])),
+            38)
       << "incorrect value for data[28], expected 38, is "
       << last_msg_->data[28];
-  EXPECT_EQ(last_msg_->data[29], 240)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[29])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[29])),
+            240)
       << "incorrect value for data[29], expected 240, is "
       << last_msg_->data[29];
-  EXPECT_EQ(last_msg_->data[30], 236)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[30])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[30])),
+            236)
       << "incorrect value for data[30], expected 236, is "
       << last_msg_->data[30];
-  EXPECT_EQ(last_msg_->data[31], 60)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[31])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[31])),
+            60)
       << "incorrect value for data[31], expected 60, is "
       << last_msg_->data[31];
-  EXPECT_EQ(last_msg_->data[32], 121)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[32])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[32])),
+            121)
       << "incorrect value for data[32], expected 121, is "
       << last_msg_->data[32];
-  EXPECT_EQ(last_msg_->data[33], 47)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[33])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[33])),
+            47)
       << "incorrect value for data[33], expected 47, is "
       << last_msg_->data[33];
-  EXPECT_EQ(last_msg_->data[34], 252)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[34])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[34])),
+            252)
       << "incorrect value for data[34], expected 252, is "
       << last_msg_->data[34];
-  EXPECT_EQ(last_msg_->data[35], 163)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[35])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[35])),
+            163)
       << "incorrect value for data[35], expected 163, is "
       << last_msg_->data[35];
-  EXPECT_EQ(last_msg_->data[36], 141)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[36])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[36])),
+            141)
       << "incorrect value for data[36], expected 141, is "
       << last_msg_->data[36];
-  EXPECT_EQ(last_msg_->data[37], 222)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[37])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[37])),
+            222)
       << "incorrect value for data[37], expected 222, is "
       << last_msg_->data[37];
-  EXPECT_EQ(last_msg_->data[38], 29)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[38])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[38])),
+            29)
       << "incorrect value for data[38], expected 29, is "
       << last_msg_->data[38];
-  EXPECT_EQ(last_msg_->data[39], 168)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[39])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[39])),
+            168)
       << "incorrect value for data[39], expected 168, is "
       << last_msg_->data[39];
-  EXPECT_EQ(last_msg_->data[40], 214)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[40])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[40])),
+            214)
       << "incorrect value for data[40], expected 214, is "
       << last_msg_->data[40];
-  EXPECT_EQ(last_msg_->data[41], 118)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[41])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[41])),
+            118)
       << "incorrect value for data[41], expected 118, is "
       << last_msg_->data[41];
-  EXPECT_EQ(last_msg_->data[42], 55)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[42])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[42])),
+            55)
       << "incorrect value for data[42], expected 55, is "
       << last_msg_->data[42];
-  EXPECT_EQ(last_msg_->data[43], 201)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[43])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[43])),
+            201)
       << "incorrect value for data[43], expected 201, is "
       << last_msg_->data[43];
-  EXPECT_EQ(last_msg_->data[44], 233)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[44])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[44])),
+            233)
       << "incorrect value for data[44], expected 233, is "
       << last_msg_->data[44];
-  EXPECT_EQ(last_msg_->data[45], 21)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[45])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[45])),
+            21)
       << "incorrect value for data[45], expected 21, is "
       << last_msg_->data[45];
-  EXPECT_EQ(last_msg_->data[46], 214)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[46])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[46])),
+            214)
       << "incorrect value for data[46], expected 214, is "
       << last_msg_->data[46];
-  EXPECT_EQ(last_msg_->data[47], 57)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[47])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[47])),
+            57)
       << "incorrect value for data[47], expected 57, is "
       << last_msg_->data[47];
-  EXPECT_EQ(last_msg_->data[48], 245)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[48])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[48])),
+            245)
       << "incorrect value for data[48], expected 245, is "
       << last_msg_->data[48];
-  EXPECT_EQ(last_msg_->data[49], 246)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[49])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[49])),
+            246)
       << "incorrect value for data[49], expected 246, is "
       << last_msg_->data[49];
-  EXPECT_EQ(last_msg_->data[50], 19)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[50])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[50])),
+            19)
       << "incorrect value for data[50], expected 19, is "
       << last_msg_->data[50];
-  EXPECT_EQ(last_msg_->data[51], 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[51])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[51])),
+            3)
       << "incorrect value for data[51], expected 3, is " << last_msg_->data[51];
-  EXPECT_EQ(last_msg_->data[52], 121)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[52])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[52])),
+            121)
       << "incorrect value for data[52], expected 121, is "
       << last_msg_->data[52];
-  EXPECT_EQ(last_msg_->data[53], 49)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[53])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[53])),
+            49)
       << "incorrect value for data[53], expected 49, is "
       << last_msg_->data[53];
-  EXPECT_EQ(last_msg_->data[54], 231)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[54])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[54])),
+            231)
       << "incorrect value for data[54], expected 231, is "
       << last_msg_->data[54];
-  EXPECT_EQ(last_msg_->data[55], 37)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[55])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[55])),
+            37)
       << "incorrect value for data[55], expected 37, is "
       << last_msg_->data[55];
-  EXPECT_EQ(last_msg_->data[56], 186)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[56])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[56])),
+            186)
       << "incorrect value for data[56], expected 186, is "
       << last_msg_->data[56];
-  EXPECT_EQ(last_msg_->data[57], 58)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[57])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[57])),
+            58)
       << "incorrect value for data[57], expected 58, is "
       << last_msg_->data[57];
-  EXPECT_EQ(last_msg_->data[58], 238)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[58])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[58])),
+            238)
       << "incorrect value for data[58], expected 238, is "
       << last_msg_->data[58];
-  EXPECT_EQ(last_msg_->data[59], 98)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[59])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[59])),
+            98)
       << "incorrect value for data[59], expected 98, is "
       << last_msg_->data[59];
-  EXPECT_EQ(last_msg_->data[60], 39)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[60])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[60])),
+            39)
       << "incorrect value for data[60], expected 39, is "
       << last_msg_->data[60];
-  EXPECT_EQ(last_msg_->data[61], 70)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[61])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[61])),
+            70)
       << "incorrect value for data[61], expected 70, is "
       << last_msg_->data[61];
-  EXPECT_EQ(last_msg_->data[62], 232)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[62])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[62])),
+            232)
       << "incorrect value for data[62], expected 232, is "
       << last_msg_->data[62];
-  EXPECT_EQ(last_msg_->data[63], 133)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[63])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[63])),
+            133)
       << "incorrect value for data[63], expected 133, is "
       << last_msg_->data[63];
-  EXPECT_EQ(last_msg_->data[64], 25)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[64])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[64])),
+            25)
       << "incorrect value for data[64], expected 25, is "
       << last_msg_->data[64];
-  EXPECT_EQ(last_msg_->data[65], 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[65])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[65])),
+            10)
       << "incorrect value for data[65], expected 10, is "
       << last_msg_->data[65];
-  EXPECT_EQ(last_msg_->data[66], 134)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[66])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[66])),
+            134)
       << "incorrect value for data[66], expected 134, is "
       << last_msg_->data[66];
-  EXPECT_EQ(last_msg_->data[67], 129)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[67])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[67])),
+            129)
       << "incorrect value for data[67], expected 129, is "
       << last_msg_->data[67];
-  EXPECT_EQ(last_msg_->data[68], 69)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[68])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[68])),
+            69)
       << "incorrect value for data[68], expected 69, is "
       << last_msg_->data[68];
-  EXPECT_EQ(last_msg_->data[69], 228)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[69])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[69])),
+            228)
       << "incorrect value for data[69], expected 228, is "
       << last_msg_->data[69];
-  EXPECT_EQ(last_msg_->data[70], 134)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[70])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[70])),
+            134)
       << "incorrect value for data[70], expected 134, is "
       << last_msg_->data[70];
-  EXPECT_EQ(last_msg_->data[71], 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[71])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[71])),
+            9)
       << "incorrect value for data[71], expected 9, is " << last_msg_->data[71];
-  EXPECT_EQ(last_msg_->data[72], 88)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[72])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[72])),
+            88)
       << "incorrect value for data[72], expected 88, is "
       << last_msg_->data[72];
-  EXPECT_EQ(last_msg_->data[73], 183)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[73])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[73])),
+            183)
       << "incorrect value for data[73], expected 183, is "
       << last_msg_->data[73];
-  EXPECT_EQ(last_msg_->data[74], 133)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[74])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[74])),
+            133)
       << "incorrect value for data[74], expected 133, is "
       << last_msg_->data[74];
-  EXPECT_EQ(last_msg_->data[75], 171)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[75])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[75])),
+            171)
       << "incorrect value for data[75], expected 171, is "
       << last_msg_->data[75];
-  EXPECT_EQ(last_msg_->data[76], 255)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[76])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[76])),
+            255)
       << "incorrect value for data[76], expected 255, is "
       << last_msg_->data[76];
-  EXPECT_EQ(last_msg_->data[77], 166)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[77])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[77])),
+            166)
       << "incorrect value for data[77], expected 166, is "
       << last_msg_->data[77];
-  EXPECT_EQ(last_msg_->data[78], 100)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[78])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[78])),
+            100)
       << "incorrect value for data[78], expected 100, is "
       << last_msg_->data[78];
-  EXPECT_EQ(last_msg_->data[79], 152)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[79])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[79])),
+            152)
       << "incorrect value for data[79], expected 152, is "
       << last_msg_->data[79];
-  EXPECT_EQ(last_msg_->data[80], 231)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[80])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[80])),
+            231)
       << "incorrect value for data[80], expected 231, is "
       << last_msg_->data[80];
-  EXPECT_EQ(last_msg_->data[81], 92)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[81])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[81])),
+            92)
       << "incorrect value for data[81], expected 92, is "
       << last_msg_->data[81];
-  EXPECT_EQ(last_msg_->data[82], 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[82])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[82])),
+            9)
       << "incorrect value for data[82], expected 9, is " << last_msg_->data[82];
-  EXPECT_EQ(last_msg_->data[83], 196)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[83])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[83])),
+            196)
       << "incorrect value for data[83], expected 196, is "
       << last_msg_->data[83];
-  EXPECT_EQ(last_msg_->data[84], 106)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[84])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[84])),
+            106)
       << "incorrect value for data[84], expected 106, is "
       << last_msg_->data[84];
-  EXPECT_EQ(last_msg_->data[85], 246)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[85])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[85])),
+            246)
       << "incorrect value for data[85], expected 246, is "
       << last_msg_->data[85];
-  EXPECT_EQ(last_msg_->data[86], 29)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[86])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[86])),
+            29)
       << "incorrect value for data[86], expected 29, is "
       << last_msg_->data[86];
-  EXPECT_EQ(last_msg_->data[87], 145)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[87])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[87])),
+            145)
       << "incorrect value for data[87], expected 145, is "
       << last_msg_->data[87];
-  EXPECT_EQ(last_msg_->data[88], 156)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[88])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[88])),
+            156)
       << "incorrect value for data[88], expected 156, is "
       << last_msg_->data[88];
-  EXPECT_EQ(last_msg_->data[89], 151)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[89])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[89])),
+            151)
       << "incorrect value for data[89], expected 151, is "
       << last_msg_->data[89];
-  EXPECT_EQ(last_msg_->data[90], 32)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[90])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[90])),
+            32)
       << "incorrect value for data[90], expected 32, is "
       << last_msg_->data[90];
-  EXPECT_EQ(last_msg_->data[91], 67)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[91])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[91])),
+            67)
       << "incorrect value for data[91], expected 67, is "
       << last_msg_->data[91];
-  EXPECT_EQ(last_msg_->data[92], 188)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[92])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[92])),
+            188)
       << "incorrect value for data[92], expected 188, is "
       << last_msg_->data[92];
-  EXPECT_EQ(last_msg_->data[93], 63)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[93])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[93])),
+            63)
       << "incorrect value for data[93], expected 63, is "
       << last_msg_->data[93];
-  EXPECT_EQ(last_msg_->data[94], 233)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[94])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[94])),
+            233)
       << "incorrect value for data[94], expected 233, is "
       << last_msg_->data[94];
-  EXPECT_EQ(last_msg_->data[95], 142)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[95])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[95])),
+            142)
       << "incorrect value for data[95], expected 142, is "
       << last_msg_->data[95];
-  EXPECT_EQ(last_msg_->data[96], 174)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[96])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[96])),
+            174)
       << "incorrect value for data[96], expected 174, is "
       << last_msg_->data[96];
-  EXPECT_EQ(last_msg_->data[97], 139)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[97])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[97])),
+            139)
       << "incorrect value for data[97], expected 139, is "
       << last_msg_->data[97];
-  EXPECT_EQ(last_msg_->data[98], 154)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[98])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[98])),
+            154)
       << "incorrect value for data[98], expected 154, is "
       << last_msg_->data[98];
-  EXPECT_EQ(last_msg_->data[99], 127)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[99])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[99])),
+            127)
       << "incorrect value for data[99], expected 127, is "
       << last_msg_->data[99];
-  EXPECT_EQ(last_msg_->data[100], 35)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[100])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[100])),
+            35)
       << "incorrect value for data[100], expected 35, is "
       << last_msg_->data[100];
-  EXPECT_EQ(last_msg_->data[101], 60)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[101])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[101])),
+            60)
       << "incorrect value for data[101], expected 60, is "
       << last_msg_->data[101];
-  EXPECT_EQ(last_msg_->data[102], 56)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[102])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[102])),
+            56)
       << "incorrect value for data[102], expected 56, is "
       << last_msg_->data[102];
-  EXPECT_EQ(last_msg_->data[103], 187)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[103])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[103])),
+            187)
       << "incorrect value for data[103], expected 187, is "
       << last_msg_->data[103];
-  EXPECT_EQ(last_msg_->data[104], 121)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[104])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[104])),
+            121)
       << "incorrect value for data[104], expected 121, is "
       << last_msg_->data[104];
-  EXPECT_EQ(last_msg_->data[105], 103)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[105])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[105])),
+            103)
       << "incorrect value for data[105], expected 103, is "
       << last_msg_->data[105];
-  EXPECT_EQ(last_msg_->data[106], 135)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[106])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[106])),
+            135)
       << "incorrect value for data[106], expected 135, is "
       << last_msg_->data[106];
-  EXPECT_EQ(last_msg_->data[107], 152)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[107])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[107])),
+            152)
       << "incorrect value for data[107], expected 152, is "
       << last_msg_->data[107];
-  EXPECT_EQ(last_msg_->data[108], 182)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[108])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[108])),
+            182)
       << "incorrect value for data[108], expected 182, is "
       << last_msg_->data[108];
-  EXPECT_EQ(last_msg_->data[109], 88)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[109])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[109])),
+            88)
       << "incorrect value for data[109], expected 88, is "
       << last_msg_->data[109];
-  EXPECT_EQ(last_msg_->data[110], 160)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[110])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[110])),
+            160)
       << "incorrect value for data[110], expected 160, is "
       << last_msg_->data[110];
-  EXPECT_EQ(last_msg_->data[111], 255)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[111])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[111])),
+            255)
       << "incorrect value for data[111], expected 255, is "
       << last_msg_->data[111];
-  EXPECT_EQ(last_msg_->data[112], 227)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[112])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[112])),
+            227)
       << "incorrect value for data[112], expected 227, is "
       << last_msg_->data[112];
-  EXPECT_EQ(last_msg_->data[113], 240)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[113])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[113])),
+            240)
       << "incorrect value for data[113], expected 240, is "
       << last_msg_->data[113];
-  EXPECT_EQ(last_msg_->data[114], 54)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[114])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[114])),
+            54)
       << "incorrect value for data[114], expected 54, is "
       << last_msg_->data[114];
-  EXPECT_EQ(last_msg_->data[115], 100)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[115])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[115])),
+            100)
       << "incorrect value for data[115], expected 100, is "
       << last_msg_->data[115];
-  EXPECT_EQ(last_msg_->data[116], 91)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[116])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[116])),
+            91)
       << "incorrect value for data[116], expected 91, is "
       << last_msg_->data[116];
-  EXPECT_EQ(last_msg_->data[117], 31)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[117])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[117])),
+            31)
       << "incorrect value for data[117], expected 31, is "
       << last_msg_->data[117];
-  EXPECT_EQ(last_msg_->data[118], 141)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[118])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[118])),
+            141)
       << "incorrect value for data[118], expected 141, is "
       << last_msg_->data[118];
-  EXPECT_EQ(last_msg_->data[119], 102)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[119])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[119])),
+            102)
       << "incorrect value for data[119], expected 102, is "
       << last_msg_->data[119];
-  EXPECT_EQ(last_msg_->data[120], 130)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[120])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[120])),
+            130)
       << "incorrect value for data[120], expected 130, is "
       << last_msg_->data[120];
-  EXPECT_EQ(last_msg_->data[121], 254)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[121])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[121])),
+            254)
       << "incorrect value for data[121], expected 254, is "
       << last_msg_->data[121];
-  EXPECT_EQ(last_msg_->data[122], 54)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[122])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[122])),
+            54)
       << "incorrect value for data[122], expected 54, is "
       << last_msg_->data[122];
-  EXPECT_EQ(last_msg_->data[123], 227)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[123])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[123])),
+            227)
       << "incorrect value for data[123], expected 227, is "
       << last_msg_->data[123];
-  EXPECT_EQ(last_msg_->data[124], 229)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[124])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[124])),
+            229)
       << "incorrect value for data[124], expected 229, is "
       << last_msg_->data[124];
-  EXPECT_EQ(last_msg_->data[125], 62)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[125])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[125])),
+            62)
       << "incorrect value for data[125], expected 62, is "
       << last_msg_->data[125];
-  EXPECT_EQ(last_msg_->data[126], 53)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[126])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[126])),
+            53)
       << "incorrect value for data[126], expected 53, is "
       << last_msg_->data[126];
-  EXPECT_EQ(last_msg_->data[127], 225)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[127])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[127])),
+            225)
       << "incorrect value for data[127], expected 225, is "
       << last_msg_->data[127];
-  EXPECT_EQ(last_msg_->data[128], 143)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[128])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[128])),
+            143)
       << "incorrect value for data[128], expected 143, is "
       << last_msg_->data[128];
-  EXPECT_EQ(last_msg_->data[129], 88)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[129])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[129])),
+            88)
       << "incorrect value for data[129], expected 88, is "
       << last_msg_->data[129];
-  EXPECT_EQ(last_msg_->data[130], 139)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[130])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[130])),
+            139)
       << "incorrect value for data[130], expected 139, is "
       << last_msg_->data[130];
-  EXPECT_EQ(last_msg_->data[131], 126)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[131])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[131])),
+            126)
       << "incorrect value for data[131], expected 126, is "
       << last_msg_->data[131];
-  EXPECT_EQ(last_msg_->data[132], 235)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[132])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[132])),
+            235)
       << "incorrect value for data[132], expected 235, is "
       << last_msg_->data[132];
-  EXPECT_EQ(last_msg_->data[133], 235)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[133])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[133])),
+            235)
       << "incorrect value for data[133], expected 235, is "
       << last_msg_->data[133];
-  EXPECT_EQ(last_msg_->data[134], 35)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[134])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[134])),
+            35)
       << "incorrect value for data[134], expected 35, is "
       << last_msg_->data[134];
-  EXPECT_EQ(last_msg_->data[135], 54)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[135])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[135])),
+            54)
       << "incorrect value for data[135], expected 54, is "
       << last_msg_->data[135];
-  EXPECT_EQ(last_msg_->data[136], 134)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[136])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[136])),
+            134)
       << "incorrect value for data[136], expected 134, is "
       << last_msg_->data[136];
-  EXPECT_EQ(last_msg_->data[137], 163)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[137])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[137])),
+            163)
       << "incorrect value for data[137], expected 163, is "
       << last_msg_->data[137];
-  EXPECT_EQ(last_msg_->data[138], 92)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[138])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[138])),
+            92)
       << "incorrect value for data[138], expected 92, is "
       << last_msg_->data[138];
-  EXPECT_EQ(last_msg_->data[139], 57)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[139])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[139])),
+            57)
       << "incorrect value for data[139], expected 57, is "
       << last_msg_->data[139];
-  EXPECT_EQ(last_msg_->data[140], 87)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[140])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[140])),
+            87)
       << "incorrect value for data[140], expected 87, is "
       << last_msg_->data[140];
-  EXPECT_EQ(last_msg_->data[141], 130)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[141])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[141])),
+            130)
       << "incorrect value for data[141], expected 130, is "
       << last_msg_->data[141];
-  EXPECT_EQ(last_msg_->data[142], 178)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[142])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[142])),
+            178)
       << "incorrect value for data[142], expected 178, is "
       << last_msg_->data[142];
-  EXPECT_EQ(last_msg_->data[143], 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[143])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[143])),
+            22)
       << "incorrect value for data[143], expected 22, is "
       << last_msg_->data[143];
-  EXPECT_EQ(last_msg_->data[144], 158)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[144])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[144])),
+            158)
       << "incorrect value for data[144], expected 158, is "
       << last_msg_->data[144];
-  EXPECT_EQ(last_msg_->data[145], 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[145])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[145])),
+            18)
       << "incorrect value for data[145], expected 18, is "
       << last_msg_->data[145];
-  EXPECT_EQ(last_msg_->data[146], 237)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[146])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[146])),
+            237)
       << "incorrect value for data[146], expected 237, is "
       << last_msg_->data[146];
-  EXPECT_EQ(last_msg_->data[147], 209)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[147])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[147])),
+            209)
       << "incorrect value for data[147], expected 209, is "
       << last_msg_->data[147];
-  EXPECT_EQ(last_msg_->data[148], 187)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[148])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[148])),
+            187)
       << "incorrect value for data[148], expected 187, is "
       << last_msg_->data[148];
-  EXPECT_EQ(last_msg_->data[149], 226)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[149])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[149])),
+            226)
       << "incorrect value for data[149], expected 226, is "
       << last_msg_->data[149];
-  EXPECT_EQ(last_msg_->data[150], 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[150])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[150])),
+            1)
       << "incorrect value for data[150], expected 1, is "
       << last_msg_->data[150];
-  EXPECT_EQ(last_msg_->data[151], 46)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[151])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[151])),
+            46)
       << "incorrect value for data[151], expected 46, is "
       << last_msg_->data[151];
-  EXPECT_EQ(last_msg_->data[152], 64)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[152])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[152])),
+            64)
       << "incorrect value for data[152], expected 64, is "
       << last_msg_->data[152];
-  EXPECT_EQ(last_msg_->data[153], 226)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[153])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[153])),
+            226)
       << "incorrect value for data[153], expected 226, is "
       << last_msg_->data[153];
-  EXPECT_EQ(last_msg_->data[154], 235)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[154])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[154])),
+            235)
       << "incorrect value for data[154], expected 235, is "
       << last_msg_->data[154];
-  EXPECT_EQ(last_msg_->data[155], 213)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[155])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[155])),
+            213)
       << "incorrect value for data[155], expected 213, is "
       << last_msg_->data[155];
-  EXPECT_EQ(last_msg_->data[156], 186)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[156])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[156])),
+            186)
       << "incorrect value for data[156], expected 186, is "
       << last_msg_->data[156];
-  EXPECT_EQ(last_msg_->data[157], 159)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[157])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[157])),
+            159)
       << "incorrect value for data[157], expected 159, is "
       << last_msg_->data[157];
-  EXPECT_EQ(last_msg_->data[158], 221)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[158])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[158])),
+            221)
       << "incorrect value for data[158], expected 221, is "
       << last_msg_->data[158];
-  EXPECT_EQ(last_msg_->data[159], 186)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[159])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[159])),
+            186)
       << "incorrect value for data[159], expected 186, is "
       << last_msg_->data[159];
-  EXPECT_EQ(last_msg_->data[160], 25)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[160])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[160])),
+            25)
       << "incorrect value for data[160], expected 25, is "
       << last_msg_->data[160];
-  EXPECT_EQ(last_msg_->data[161], 115)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[161])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[161])),
+            115)
       << "incorrect value for data[161], expected 115, is "
       << last_msg_->data[161];
-  EXPECT_EQ(last_msg_->data[162], 84)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[162])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[162])),
+            84)
       << "incorrect value for data[162], expected 84, is "
       << last_msg_->data[162];
-  EXPECT_EQ(last_msg_->data[163], 131)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[163])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[163])),
+            131)
       << "incorrect value for data[163], expected 131, is "
       << last_msg_->data[163];
-  EXPECT_EQ(last_msg_->data[164], 167)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[164])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[164])),
+            167)
       << "incorrect value for data[164], expected 167, is "
       << last_msg_->data[164];
-  EXPECT_EQ(last_msg_->data[165], 201)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[165])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[165])),
+            201)
       << "incorrect value for data[165], expected 201, is "
       << last_msg_->data[165];
-  EXPECT_EQ(last_msg_->data[166], 104)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[166])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[166])),
+            104)
       << "incorrect value for data[166], expected 104, is "
       << last_msg_->data[166];
-  EXPECT_EQ(last_msg_->data[167], 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[167])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[167])),
+            1)
       << "incorrect value for data[167], expected 1, is "
       << last_msg_->data[167];
-  EXPECT_EQ(last_msg_->data[168], 200)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[168])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[168])),
+            200)
       << "incorrect value for data[168], expected 200, is "
       << last_msg_->data[168];
-  EXPECT_EQ(last_msg_->data[169], 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[169])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[169])),
+            13)
       << "incorrect value for data[169], expected 13, is "
       << last_msg_->data[169];
-  EXPECT_EQ(last_msg_->data[170], 50)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[170])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[170])),
+            50)
       << "incorrect value for data[170], expected 50, is "
       << last_msg_->data[170];
-  EXPECT_EQ(last_msg_->data[171], 71)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[171])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[171])),
+            71)
       << "incorrect value for data[171], expected 71, is "
       << last_msg_->data[171];
-  EXPECT_EQ(last_msg_->data[172], 73)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[172])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[172])),
+            73)
       << "incorrect value for data[172], expected 73, is "
       << last_msg_->data[172];
-  EXPECT_EQ(last_msg_->data[173], 193)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[173])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[173])),
+            193)
       << "incorrect value for data[173], expected 193, is "
       << last_msg_->data[173];
-  EXPECT_EQ(last_msg_->data[174], 201)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[174])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[174])),
+            201)
       << "incorrect value for data[174], expected 201, is "
       << last_msg_->data[174];
-  EXPECT_EQ(last_msg_->data[175], 250)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[175])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[175])),
+            250)
       << "incorrect value for data[175], expected 250, is "
       << last_msg_->data[175];
-  EXPECT_EQ(last_msg_->data[176], 172)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[176])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[176])),
+            172)
       << "incorrect value for data[176], expected 172, is "
       << last_msg_->data[176];
-  EXPECT_EQ(last_msg_->data[177], 193)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[177])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[177])),
+            193)
       << "incorrect value for data[177], expected 193, is "
       << last_msg_->data[177];
-  EXPECT_EQ(last_msg_->data[178], 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[178])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[178])),
+            13)
       << "incorrect value for data[178], expected 13, is "
       << last_msg_->data[178];
-  EXPECT_EQ(last_msg_->data[179], 20)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[179])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[179])),
+            20)
       << "incorrect value for data[179], expected 20, is "
       << last_msg_->data[179];
-  EXPECT_EQ(last_msg_->data[180], 238)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[180])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[180])),
+            238)
       << "incorrect value for data[180], expected 238, is "
       << last_msg_->data[180];
-  EXPECT_EQ(last_msg_->data[181], 130)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[181])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[181])),
+            130)
       << "incorrect value for data[181], expected 130, is "
       << last_msg_->data[181];
-  EXPECT_EQ(last_msg_->data[182], 243)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[182])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[182])),
+            243)
       << "incorrect value for data[182], expected 243, is "
       << last_msg_->data[182];
-  EXPECT_EQ(last_msg_->data[183], 68)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[183])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[183])),
+            68)
       << "incorrect value for data[183], expected 68, is "
       << last_msg_->data[183];
-  EXPECT_EQ(last_msg_->data[184], 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[184])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[184])),
+            4)
       << "incorrect value for data[184], expected 4, is "
       << last_msg_->data[184];
-  EXPECT_EQ(last_msg_->data[185], 72)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[185])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[185])),
+            72)
       << "incorrect value for data[185], expected 72, is "
       << last_msg_->data[185];
-  EXPECT_EQ(last_msg_->data[186], 46)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[186])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[186])),
+            46)
       << "incorrect value for data[186], expected 46, is "
       << last_msg_->data[186];
-  EXPECT_EQ(last_msg_->data[187], 194)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[187])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[187])),
+            194)
       << "incorrect value for data[187], expected 194, is "
       << last_msg_->data[187];
-  EXPECT_EQ(last_msg_->data[188], 113)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[188])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[188])),
+            113)
       << "incorrect value for data[188], expected 113, is "
       << last_msg_->data[188];
-  EXPECT_EQ(last_msg_->data[189], 255)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[189])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[189])),
+            255)
       << "incorrect value for data[189], expected 255, is "
       << last_msg_->data[189];
-  EXPECT_EQ(last_msg_->data[190], 238)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[190])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[190])),
+            238)
       << "incorrect value for data[190], expected 238, is "
       << last_msg_->data[190];
-  EXPECT_EQ(last_msg_->data[191], 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[191])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[191])),
+            15)
       << "incorrect value for data[191], expected 15, is "
       << last_msg_->data[191];
-  EXPECT_EQ(last_msg_->data[192], 230)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[192])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[192])),
+            230)
       << "incorrect value for data[192], expected 230, is "
       << last_msg_->data[192];
-  EXPECT_EQ(last_msg_->data[193], 64)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[193])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[193])),
+            64)
       << "incorrect value for data[193], expected 64, is "
       << last_msg_->data[193];
-  EXPECT_EQ(last_msg_->data[194], 178)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[194])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[194])),
+            178)
       << "incorrect value for data[194], expected 178, is "
       << last_msg_->data[194];
-  EXPECT_EQ(last_msg_->data[195], 127)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[195])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[195])),
+            127)
       << "incorrect value for data[195], expected 127, is "
       << last_msg_->data[195];
-  EXPECT_EQ(last_msg_->data[196], 217)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[196])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[196])),
+            217)
       << "incorrect value for data[196], expected 217, is "
       << last_msg_->data[196];
-  EXPECT_EQ(last_msg_->data[197], 92)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[197])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[197])),
+            92)
       << "incorrect value for data[197], expected 92, is "
       << last_msg_->data[197];
-  EXPECT_EQ(last_msg_->data[198], 160)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[198])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[198])),
+            160)
       << "incorrect value for data[198], expected 160, is "
       << last_msg_->data[198];
-  EXPECT_EQ(last_msg_->data[199], 201)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[199])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[199])),
+            201)
       << "incorrect value for data[199], expected 201, is "
       << last_msg_->data[199];
-  EXPECT_EQ(last_msg_->data[200], 118)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[200])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[200])),
+            118)
       << "incorrect value for data[200], expected 118, is "
       << last_msg_->data[200];
-  EXPECT_EQ(last_msg_->data[201], 163)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[201])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[201])),
+            163)
       << "incorrect value for data[201], expected 163, is "
       << last_msg_->data[201];
-  EXPECT_EQ(last_msg_->data[202], 144)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[202])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[202])),
+            144)
       << "incorrect value for data[202], expected 144, is "
       << last_msg_->data[202];
-  EXPECT_EQ(last_msg_->data[203], 58)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[203])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[203])),
+            58)
       << "incorrect value for data[203], expected 58, is "
       << last_msg_->data[203];
-  EXPECT_EQ(last_msg_->data[204], 28)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[204])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[204])),
+            28)
       << "incorrect value for data[204], expected 28, is "
       << last_msg_->data[204];
-  EXPECT_EQ(last_msg_->data[205], 174)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[205])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[205])),
+            174)
       << "incorrect value for data[205], expected 174, is "
       << last_msg_->data[205];
-  EXPECT_EQ(last_msg_->data[206], 65)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[206])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[206])),
+            65)
       << "incorrect value for data[206], expected 65, is "
       << last_msg_->data[206];
-  EXPECT_EQ(last_msg_->data[207], 73)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[207])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[207])),
+            73)
       << "incorrect value for data[207], expected 73, is "
       << last_msg_->data[207];
-  EXPECT_EQ(last_msg_->data[208], 45)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[208])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[208])),
+            45)
       << "incorrect value for data[208], expected 45, is "
       << last_msg_->data[208];
-  EXPECT_EQ(last_msg_->data[209], 123)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[209])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[209])),
+            123)
       << "incorrect value for data[209], expected 123, is "
       << last_msg_->data[209];
-  EXPECT_EQ(last_msg_->data[210], 118)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[210])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[210])),
+            118)
       << "incorrect value for data[210], expected 118, is "
       << last_msg_->data[210];
-  EXPECT_EQ(last_msg_->data[211], 83)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[211])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[211])),
+            83)
       << "incorrect value for data[211], expected 83, is "
       << last_msg_->data[211];
-  EXPECT_EQ(last_msg_->data[212], 107)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[212])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[212])),
+            107)
       << "incorrect value for data[212], expected 107, is "
       << last_msg_->data[212];
-  EXPECT_EQ(last_msg_->data[213], 239)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[213])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[213])),
+            239)
       << "incorrect value for data[213], expected 239, is "
       << last_msg_->data[213];
-  EXPECT_EQ(last_msg_->data[214], 168)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[214])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[214])),
+            168)
       << "incorrect value for data[214], expected 168, is "
       << last_msg_->data[214];
-  EXPECT_EQ(last_msg_->data[215], 32)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[215])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[215])),
+            32)
       << "incorrect value for data[215], expected 32, is "
       << last_msg_->data[215];
-  EXPECT_EQ(last_msg_->data[216], 212)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[216])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[216])),
+            212)
       << "incorrect value for data[216], expected 212, is "
       << last_msg_->data[216];
-  EXPECT_EQ(last_msg_->data[217], 191)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[217])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[217])),
+            191)
       << "incorrect value for data[217], expected 191, is "
       << last_msg_->data[217];
-  EXPECT_EQ(last_msg_->data[218], 81)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[218])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[218])),
+            81)
       << "incorrect value for data[218], expected 81, is "
       << last_msg_->data[218];
-  EXPECT_EQ(last_msg_->data[219], 93)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[219])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[219])),
+            93)
       << "incorrect value for data[219], expected 93, is "
       << last_msg_->data[219];
-  EXPECT_EQ(last_msg_->data[220], 186)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[220])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[220])),
+            186)
       << "incorrect value for data[220], expected 186, is "
       << last_msg_->data[220];
-  EXPECT_EQ(last_msg_->data[221], 223)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[221])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[221])),
+            223)
       << "incorrect value for data[221], expected 223, is "
       << last_msg_->data[221];
-  EXPECT_EQ(last_msg_->data[222], 32)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[222])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[222])),
+            32)
       << "incorrect value for data[222], expected 32, is "
       << last_msg_->data[222];
-  EXPECT_EQ(last_msg_->data[223], 19)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[223])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[223])),
+            19)
       << "incorrect value for data[223], expected 19, is "
       << last_msg_->data[223];
-  EXPECT_EQ(last_msg_->data[224], 58)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[224])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[224])),
+            58)
       << "incorrect value for data[224], expected 58, is "
       << last_msg_->data[224];
-  EXPECT_EQ(last_msg_->data[225], 137)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[225])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[225])),
+            137)
       << "incorrect value for data[225], expected 137, is "
       << last_msg_->data[225];
-  EXPECT_EQ(last_msg_->data[226], 72)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[226])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[226])),
+            72)
       << "incorrect value for data[226], expected 72, is "
       << last_msg_->data[226];
-  EXPECT_EQ(last_msg_->data[227], 217)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[227])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[227])),
+            217)
       << "incorrect value for data[227], expected 217, is "
       << last_msg_->data[227];
-  EXPECT_EQ(last_msg_->data[228], 151)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[228])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[228])),
+            151)
       << "incorrect value for data[228], expected 151, is "
       << last_msg_->data[228];
-  EXPECT_EQ(last_msg_->data[229], 251)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[229])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[229])),
+            251)
       << "incorrect value for data[229], expected 251, is "
       << last_msg_->data[229];
-  EXPECT_EQ(last_msg_->data[230], 83)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[230])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[230])),
+            83)
       << "incorrect value for data[230], expected 83, is "
       << last_msg_->data[230];
-  EXPECT_EQ(last_msg_->data[231], 20)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[231])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[231])),
+            20)
       << "incorrect value for data[231], expected 20, is "
       << last_msg_->data[231];
-  EXPECT_EQ(last_msg_->data[232], 113)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[232])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[232])),
+            113)
       << "incorrect value for data[232], expected 113, is "
       << last_msg_->data[232];
-  EXPECT_EQ(last_msg_->data[233], 37)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[233])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[233])),
+            37)
       << "incorrect value for data[233], expected 37, is "
       << last_msg_->data[233];
-  EXPECT_EQ(last_msg_->data[234], 151)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[234])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[234])),
+            151)
       << "incorrect value for data[234], expected 151, is "
       << last_msg_->data[234];
-  EXPECT_EQ(last_msg_->data[235], 34)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[235])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[235])),
+            34)
       << "incorrect value for data[235], expected 34, is "
       << last_msg_->data[235];
-  EXPECT_EQ(last_msg_->data[236], 37)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[236])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[236])),
+            37)
       << "incorrect value for data[236], expected 37, is "
       << last_msg_->data[236];
-  EXPECT_EQ(last_msg_->data[237], 71)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[237])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[237])),
+            71)
       << "incorrect value for data[237], expected 71, is "
       << last_msg_->data[237];
-  EXPECT_EQ(last_msg_->data[238], 95)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[238])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[238])),
+            95)
       << "incorrect value for data[238], expected 95, is "
       << last_msg_->data[238];
-  EXPECT_EQ(last_msg_->data[239], 105)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[239])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[239])),
+            105)
       << "incorrect value for data[239], expected 105, is "
       << last_msg_->data[239];
-  EXPECT_EQ(last_msg_->data[240], 235)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[240])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[240])),
+            235)
       << "incorrect value for data[240], expected 235, is "
       << last_msg_->data[240];
-  EXPECT_EQ(last_msg_->data[241], 144)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[241])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[241])),
+            144)
       << "incorrect value for data[241], expected 144, is "
       << last_msg_->data[241];
-  EXPECT_EQ(last_msg_->data[242], 164)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[242])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[242])),
+            164)
       << "incorrect value for data[242], expected 164, is "
       << last_msg_->data[242];
-  EXPECT_EQ(last_msg_->data[243], 83)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[243])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[243])),
+            83)
       << "incorrect value for data[243], expected 83, is "
       << last_msg_->data[243];
-  EXPECT_EQ(last_msg_->data[244], 197)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[244])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[244])),
+            197)
       << "incorrect value for data[244], expected 197, is "
       << last_msg_->data[244];
-  EXPECT_EQ(last_msg_->data[245], 254)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[245])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[245])),
+            254)
       << "incorrect value for data[245], expected 254, is "
       << last_msg_->data[245];
-  EXPECT_EQ(last_msg_->data[246], 183)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[246])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[246])),
+            183)
       << "incorrect value for data[246], expected 183, is "
       << last_msg_->data[246];
-  EXPECT_EQ(last_msg_->data[247], 223)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[247])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[247])),
+            223)
       << "incorrect value for data[247], expected 223, is "
       << last_msg_->data[247];
-  EXPECT_EQ(last_msg_->data[248], 91)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[248])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[248])),
+            91)
       << "incorrect value for data[248], expected 91, is "
       << last_msg_->data[248];
-  EXPECT_EQ(last_msg_->data[249], 19)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[249])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[249])),
+            19)
       << "incorrect value for data[249], expected 19, is "
       << last_msg_->data[249];
-  EXPECT_EQ(last_msg_->target, 212)
+  EXPECT_EQ(get_as<decltype(last_msg_->target)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->target)),
+            212)
       << "incorrect value for target, expected 212, is " << last_msg_->target;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_flash_MsgFlashReadReq.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_flash_MsgFlashReadReq.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/flash.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_flash_MsgFlashReadReq0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -126,18 +133,28 @@ TEST_F(Test_legacy_auto_check_sbp_flash_MsgFlashReadReq0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->addr_len, 71)
+  EXPECT_EQ(get_as<decltype(last_msg_->addr_len)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->addr_len)),
+            71)
       << "incorrect value for addr_len, expected 71, is "
       << last_msg_->addr_len;
-  EXPECT_EQ(last_msg_->addr_start[0], 28)
+  EXPECT_EQ(get_as<decltype(last_msg_->addr_start[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->addr_start[0])),
+            28)
       << "incorrect value for addr_start[0], expected 28, is "
       << last_msg_->addr_start[0];
-  EXPECT_EQ(last_msg_->addr_start[1], 75)
+  EXPECT_EQ(get_as<decltype(last_msg_->addr_start[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->addr_start[1])),
+            75)
       << "incorrect value for addr_start[1], expected 75, is "
       << last_msg_->addr_start[1];
-  EXPECT_EQ(last_msg_->addr_start[2], 244)
+  EXPECT_EQ(get_as<decltype(last_msg_->addr_start[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->addr_start[2])),
+            244)
       << "incorrect value for addr_start[2], expected 244, is "
       << last_msg_->addr_start[2];
-  EXPECT_EQ(last_msg_->target, 241)
+  EXPECT_EQ(get_as<decltype(last_msg_->target)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->target)),
+            241)
       << "incorrect value for target, expected 241, is " << last_msg_->target;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_flash_MsgFlashReadResp.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_flash_MsgFlashReadResp.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/flash.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_flash_MsgFlashReadResp0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -126,18 +133,28 @@ TEST_F(Test_legacy_auto_check_sbp_flash_MsgFlashReadResp0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->addr_len, 124)
+  EXPECT_EQ(get_as<decltype(last_msg_->addr_len)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->addr_len)),
+            124)
       << "incorrect value for addr_len, expected 124, is "
       << last_msg_->addr_len;
-  EXPECT_EQ(last_msg_->addr_start[0], 155)
+  EXPECT_EQ(get_as<decltype(last_msg_->addr_start[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->addr_start[0])),
+            155)
       << "incorrect value for addr_start[0], expected 155, is "
       << last_msg_->addr_start[0];
-  EXPECT_EQ(last_msg_->addr_start[1], 52)
+  EXPECT_EQ(get_as<decltype(last_msg_->addr_start[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->addr_start[1])),
+            52)
       << "incorrect value for addr_start[1], expected 52, is "
       << last_msg_->addr_start[1];
-  EXPECT_EQ(last_msg_->addr_start[2], 172)
+  EXPECT_EQ(get_as<decltype(last_msg_->addr_start[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->addr_start[2])),
+            172)
       << "incorrect value for addr_start[2], expected 172, is "
       << last_msg_->addr_start[2];
-  EXPECT_EQ(last_msg_->target, 136)
+  EXPECT_EQ(get_as<decltype(last_msg_->target)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->target)),
+            136)
       << "incorrect value for target, expected 136, is " << last_msg_->target;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_flash_MsgM25FlashWriteStatus.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_flash_MsgM25FlashWriteStatus.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/flash.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_flash_MsgM25FlashWriteStatus0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -116,7 +123,9 @@ TEST_F(Test_legacy_auto_check_sbp_flash_MsgM25FlashWriteStatus0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->status[0], 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->status[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->status[0])),
+            5)
       << "incorrect value for status[0], expected 5, is "
       << last_msg_->status[0];
 }

--- a/c/test/legacy/cpp/auto_check_sbp_flash_MsgStmFlashLockSector.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_flash_MsgStmFlashLockSector.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/flash.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_flash_MsgStmFlashLockSector0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -112,7 +119,9 @@ TEST_F(Test_legacy_auto_check_sbp_flash_MsgStmFlashLockSector0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->sector, 1137047457)
+  EXPECT_EQ(get_as<decltype(last_msg_->sector)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sector)),
+            1137047457)
       << "incorrect value for sector, expected 1137047457, is "
       << last_msg_->sector;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_flash_MsgStmFlashUnlockSector.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_flash_MsgStmFlashUnlockSector.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/flash.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_flash_MsgStmFlashUnlockSector0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -112,7 +119,9 @@ TEST_F(Test_legacy_auto_check_sbp_flash_MsgStmFlashUnlockSector0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->sector, 837226527)
+  EXPECT_EQ(get_as<decltype(last_msg_->sector)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sector)),
+            837226527)
       << "incorrect value for sector, expected 837226527, is "
       << last_msg_->sector;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_flash_MsgStmUniqueIdReq.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_flash_MsgStmUniqueIdReq.cc
@@ -29,3 +29,10 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/flash.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}

--- a/c/test/legacy/cpp/auto_check_sbp_flash_MsgStmUniqueIdResp.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_flash_MsgStmUniqueIdResp.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/flash.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_flash_MsgStmUniqueIdResp0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -172,40 +179,64 @@ TEST_F(Test_legacy_auto_check_sbp_flash_MsgStmUniqueIdResp0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->stm_id[0], 196)
+  EXPECT_EQ(get_as<decltype(last_msg_->stm_id[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->stm_id[0])),
+            196)
       << "incorrect value for stm_id[0], expected 196, is "
       << last_msg_->stm_id[0];
-  EXPECT_EQ(last_msg_->stm_id[1], 16)
+  EXPECT_EQ(get_as<decltype(last_msg_->stm_id[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->stm_id[1])),
+            16)
       << "incorrect value for stm_id[1], expected 16, is "
       << last_msg_->stm_id[1];
-  EXPECT_EQ(last_msg_->stm_id[2], 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->stm_id[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->stm_id[2])),
+            15)
       << "incorrect value for stm_id[2], expected 15, is "
       << last_msg_->stm_id[2];
-  EXPECT_EQ(last_msg_->stm_id[3], 163)
+  EXPECT_EQ(get_as<decltype(last_msg_->stm_id[3])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->stm_id[3])),
+            163)
       << "incorrect value for stm_id[3], expected 163, is "
       << last_msg_->stm_id[3];
-  EXPECT_EQ(last_msg_->stm_id[4], 85)
+  EXPECT_EQ(get_as<decltype(last_msg_->stm_id[4])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->stm_id[4])),
+            85)
       << "incorrect value for stm_id[4], expected 85, is "
       << last_msg_->stm_id[4];
-  EXPECT_EQ(last_msg_->stm_id[5], 221)
+  EXPECT_EQ(get_as<decltype(last_msg_->stm_id[5])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->stm_id[5])),
+            221)
       << "incorrect value for stm_id[5], expected 221, is "
       << last_msg_->stm_id[5];
-  EXPECT_EQ(last_msg_->stm_id[6], 119)
+  EXPECT_EQ(get_as<decltype(last_msg_->stm_id[6])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->stm_id[6])),
+            119)
       << "incorrect value for stm_id[6], expected 119, is "
       << last_msg_->stm_id[6];
-  EXPECT_EQ(last_msg_->stm_id[7], 102)
+  EXPECT_EQ(get_as<decltype(last_msg_->stm_id[7])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->stm_id[7])),
+            102)
       << "incorrect value for stm_id[7], expected 102, is "
       << last_msg_->stm_id[7];
-  EXPECT_EQ(last_msg_->stm_id[8], 32)
+  EXPECT_EQ(get_as<decltype(last_msg_->stm_id[8])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->stm_id[8])),
+            32)
       << "incorrect value for stm_id[8], expected 32, is "
       << last_msg_->stm_id[8];
-  EXPECT_EQ(last_msg_->stm_id[9], 194)
+  EXPECT_EQ(get_as<decltype(last_msg_->stm_id[9])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->stm_id[9])),
+            194)
       << "incorrect value for stm_id[9], expected 194, is "
       << last_msg_->stm_id[9];
-  EXPECT_EQ(last_msg_->stm_id[10], 56)
+  EXPECT_EQ(get_as<decltype(last_msg_->stm_id[10])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->stm_id[10])),
+            56)
       << "incorrect value for stm_id[10], expected 56, is "
       << last_msg_->stm_id[10];
-  EXPECT_EQ(last_msg_->stm_id[11], 144)
+  EXPECT_EQ(get_as<decltype(last_msg_->stm_id[11])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->stm_id[11])),
+            144)
       << "incorrect value for stm_id[11], expected 144, is "
       << last_msg_->stm_id[11];
 }

--- a/c/test/legacy/cpp/auto_check_sbp_imu_MsgImuAux.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_imu_MsgImuAux.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/imu.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_imu_MsgImuAux0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -112,11 +119,17 @@ TEST_F(Test_legacy_auto_check_sbp_imu_MsgImuAux0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 4660);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->imu_conf, 66)
+  EXPECT_EQ(get_as<decltype(last_msg_->imu_conf)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->imu_conf)),
+            66)
       << "incorrect value for imu_conf, expected 66, is "
       << last_msg_->imu_conf;
-  EXPECT_EQ(last_msg_->imu_type, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->imu_type)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->imu_type)),
+            1)
       << "incorrect value for imu_type, expected 1, is " << last_msg_->imu_type;
-  EXPECT_EQ(last_msg_->temp, 2804)
+  EXPECT_EQ(get_as<decltype(last_msg_->temp)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->temp)),
+            2804)
       << "incorrect value for temp, expected 2804, is " << last_msg_->temp;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_imu_MsgImuRaw.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_imu_MsgImuRaw.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/imu.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_imu_MsgImuRaw0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -118,20 +125,36 @@ TEST_F(Test_legacy_auto_check_sbp_imu_MsgImuRaw0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 4660);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->acc_x, 96)
+  EXPECT_EQ(get_as<decltype(last_msg_->acc_x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->acc_x)),
+            96)
       << "incorrect value for acc_x, expected 96, is " << last_msg_->acc_x;
-  EXPECT_EQ(last_msg_->acc_y, -33)
+  EXPECT_EQ(get_as<decltype(last_msg_->acc_y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->acc_y)),
+            -33)
       << "incorrect value for acc_y, expected -33, is " << last_msg_->acc_y;
-  EXPECT_EQ(last_msg_->acc_z, 4140)
+  EXPECT_EQ(get_as<decltype(last_msg_->acc_z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->acc_z)),
+            4140)
       << "incorrect value for acc_z, expected 4140, is " << last_msg_->acc_z;
-  EXPECT_EQ(last_msg_->gyr_x, 60)
+  EXPECT_EQ(get_as<decltype(last_msg_->gyr_x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->gyr_x)),
+            60)
       << "incorrect value for gyr_x, expected 60, is " << last_msg_->gyr_x;
-  EXPECT_EQ(last_msg_->gyr_y, -304)
+  EXPECT_EQ(get_as<decltype(last_msg_->gyr_y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->gyr_y)),
+            -304)
       << "incorrect value for gyr_y, expected -304, is " << last_msg_->gyr_y;
-  EXPECT_EQ(last_msg_->gyr_z, -18)
+  EXPECT_EQ(get_as<decltype(last_msg_->gyr_z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->gyr_z)),
+            -18)
       << "incorrect value for gyr_z, expected -18, is " << last_msg_->gyr_z;
-  EXPECT_EQ(last_msg_->tow, 3221225754)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            3221225754)
       << "incorrect value for tow, expected 3221225754, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->tow_f, 206)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow_f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow_f)),
+            206)
       << "incorrect value for tow_f, expected 206, is " << last_msg_->tow_f;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_integrity_MsgAcknowledge.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_integrity_MsgAcknowledge.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/integrity.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_integrity_MsgAcknowledge0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -115,22 +122,36 @@ TEST_F(Test_legacy_auto_check_sbp_integrity_MsgAcknowledge0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 42);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->area_id, 123456)
+  EXPECT_EQ(get_as<decltype(last_msg_->area_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->area_id)),
+            123456)
       << "incorrect value for area_id, expected 123456, is "
       << last_msg_->area_id;
-  EXPECT_EQ(last_msg_->correction_mask_on_demand, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->correction_mask_on_demand)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->correction_mask_on_demand)),
+            1)
       << "incorrect value for correction_mask_on_demand, expected 1, is "
       << last_msg_->correction_mask_on_demand;
-  EXPECT_EQ(last_msg_->correction_mask_stream, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->correction_mask_stream)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->correction_mask_stream)),
+            1)
       << "incorrect value for correction_mask_stream, expected 1, is "
       << last_msg_->correction_mask_stream;
-  EXPECT_EQ(last_msg_->request_id, 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->request_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->request_id)),
+            30)
       << "incorrect value for request_id, expected 30, is "
       << last_msg_->request_id;
-  EXPECT_EQ(last_msg_->response_code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->response_code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->response_code)),
+            0)
       << "incorrect value for response_code, expected 0, is "
       << last_msg_->response_code;
-  EXPECT_EQ(last_msg_->solution_id, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->solution_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->solution_id)),
+            2)
       << "incorrect value for solution_id, expected 2, is "
       << last_msg_->solution_id;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_integrity_MsgSsrFlagHighLevel.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_integrity_MsgSsrFlagHighLevel.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/integrity.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_integrity_MsgSsrFlagHighLevel0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -157,66 +164,112 @@ TEST_F(Test_legacy_auto_check_sbp_integrity_MsgSsrFlagHighLevel0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->chain_id, 40)
+  EXPECT_EQ(get_as<decltype(last_msg_->chain_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->chain_id)),
+            40)
       << "incorrect value for chain_id, expected 40, is "
       << last_msg_->chain_id;
-  EXPECT_EQ(last_msg_->corr_time.tow, 360)
+  EXPECT_EQ(get_as<decltype(last_msg_->corr_time.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->corr_time.tow)),
+            360)
       << "incorrect value for corr_time.tow, expected 360, is "
       << last_msg_->corr_time.tow;
-  EXPECT_EQ(last_msg_->corr_time.wn, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->corr_time.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->corr_time.wn)),
+            6)
       << "incorrect value for corr_time.wn, expected 6, is "
       << last_msg_->corr_time.wn;
-  EXPECT_EQ(last_msg_->obs_time.tow, 180)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs_time.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs_time.tow)),
+            180)
       << "incorrect value for obs_time.tow, expected 180, is "
       << last_msg_->obs_time.tow;
-  EXPECT_EQ(last_msg_->obs_time.wn, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs_time.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs_time.wn)),
+            3)
       << "incorrect value for obs_time.wn, expected 3, is "
       << last_msg_->obs_time.wn;
-  EXPECT_EQ(last_msg_->reserved[0], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[0])),
+            0)
       << "incorrect value for reserved[0], expected 0, is "
       << last_msg_->reserved[0];
-  EXPECT_EQ(last_msg_->reserved[1], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[1])),
+            0)
       << "incorrect value for reserved[1], expected 0, is "
       << last_msg_->reserved[1];
-  EXPECT_EQ(last_msg_->reserved[2], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[2])),
+            0)
       << "incorrect value for reserved[2], expected 0, is "
       << last_msg_->reserved[2];
-  EXPECT_EQ(last_msg_->reserved[3], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[3])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[3])),
+            0)
       << "incorrect value for reserved[3], expected 0, is "
       << last_msg_->reserved[3];
-  EXPECT_EQ(last_msg_->reserved[4], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[4])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[4])),
+            0)
       << "incorrect value for reserved[4], expected 0, is "
       << last_msg_->reserved[4];
-  EXPECT_EQ(last_msg_->reserved[5], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[5])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[5])),
+            0)
       << "incorrect value for reserved[5], expected 0, is "
       << last_msg_->reserved[5];
-  EXPECT_EQ(last_msg_->ssr_sol_id, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->ssr_sol_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ssr_sol_id)),
+            10)
       << "incorrect value for ssr_sol_id, expected 10, is "
       << last_msg_->ssr_sol_id;
-  EXPECT_EQ(last_msg_->tile_id, 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->tile_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tile_id)),
+            30)
       << "incorrect value for tile_id, expected 30, is " << last_msg_->tile_id;
-  EXPECT_EQ(last_msg_->tile_set_id, 20)
+  EXPECT_EQ(get_as<decltype(last_msg_->tile_set_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tile_set_id)),
+            20)
       << "incorrect value for tile_set_id, expected 20, is "
       << last_msg_->tile_set_id;
-  EXPECT_EQ(last_msg_->use_bds_sat, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->use_bds_sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->use_bds_sat)),
+            3)
       << "incorrect value for use_bds_sat, expected 3, is "
       << last_msg_->use_bds_sat;
-  EXPECT_EQ(last_msg_->use_gal_sat, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->use_gal_sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->use_gal_sat)),
+            2)
       << "incorrect value for use_gal_sat, expected 2, is "
       << last_msg_->use_gal_sat;
-  EXPECT_EQ(last_msg_->use_gps_sat, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->use_gps_sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->use_gps_sat)),
+            1)
       << "incorrect value for use_gps_sat, expected 1, is "
       << last_msg_->use_gps_sat;
-  EXPECT_EQ(last_msg_->use_iono_grid_point_sat_los, 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->use_iono_grid_point_sat_los)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->use_iono_grid_point_sat_los)),
+            7)
       << "incorrect value for use_iono_grid_point_sat_los, expected 7, is "
       << last_msg_->use_iono_grid_point_sat_los;
-  EXPECT_EQ(last_msg_->use_iono_grid_points, 5)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->use_iono_grid_points)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->use_iono_grid_points)),
+      5)
       << "incorrect value for use_iono_grid_points, expected 5, is "
       << last_msg_->use_iono_grid_points;
-  EXPECT_EQ(last_msg_->use_iono_tile_sat_los, 6)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->use_iono_tile_sat_los)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->use_iono_tile_sat_los)),
+      6)
       << "incorrect value for use_iono_tile_sat_los, expected 6, is "
       << last_msg_->use_iono_tile_sat_los;
-  EXPECT_EQ(last_msg_->use_tropo_grid_points, 4)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->use_tropo_grid_points)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->use_tropo_grid_points)),
+      4)
       << "incorrect value for use_tropo_grid_points, expected 4, is "
       << last_msg_->use_tropo_grid_points;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_integrity_MsgSsrFlagIonoGridPointSatLos.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_integrity_MsgSsrFlagIonoGridPointSatLos.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/integrity.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_integrity_MsgSsrFlagIonoGridPointSatLos0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -136,46 +143,82 @@ TEST_F(Test_legacy_auto_check_sbp_integrity_MsgSsrFlagIonoGridPointSatLos0,
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->faulty_los[0].constellation, 11)
+  EXPECT_EQ(get_as<decltype(last_msg_->faulty_los[0].constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->faulty_los[0].constellation)),
+            11)
       << "incorrect value for faulty_los[0].constellation, expected 11, is "
       << last_msg_->faulty_los[0].constellation;
-  EXPECT_EQ(last_msg_->faulty_los[0].satId, 10)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->faulty_los[0].satId)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->faulty_los[0].satId)),
+      10)
       << "incorrect value for faulty_los[0].satId, expected 10, is "
       << last_msg_->faulty_los[0].satId;
-  EXPECT_EQ(last_msg_->faulty_los[1].constellation, 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->faulty_los[1].constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->faulty_los[1].constellation)),
+            14)
       << "incorrect value for faulty_los[1].constellation, expected 14, is "
       << last_msg_->faulty_los[1].constellation;
-  EXPECT_EQ(last_msg_->faulty_los[1].satId, 15)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->faulty_los[1].satId)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->faulty_los[1].satId)),
+      15)
       << "incorrect value for faulty_los[1].satId, expected 15, is "
       << last_msg_->faulty_los[1].satId;
-  EXPECT_EQ(last_msg_->grid_point_id, 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->grid_point_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->grid_point_id)),
+            30)
       << "incorrect value for grid_point_id, expected 30, is "
       << last_msg_->grid_point_id;
-  EXPECT_EQ(last_msg_->header.chain_id, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.chain_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.chain_id)),
+            6)
       << "incorrect value for header.chain_id, expected 6, is "
       << last_msg_->header.chain_id;
-  EXPECT_EQ(last_msg_->header.num_msgs, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.num_msgs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.num_msgs)),
+            1)
       << "incorrect value for header.num_msgs, expected 1, is "
       << last_msg_->header.num_msgs;
-  EXPECT_EQ(last_msg_->header.obs_time.tow, 180)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->header.obs_time.tow)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->header.obs_time.tow)),
+      180)
       << "incorrect value for header.obs_time.tow, expected 180, is "
       << last_msg_->header.obs_time.tow;
-  EXPECT_EQ(last_msg_->header.obs_time.wn, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->header.obs_time.wn)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->header.obs_time.wn)),
+      3)
       << "incorrect value for header.obs_time.wn, expected 3, is "
       << last_msg_->header.obs_time.wn;
-  EXPECT_EQ(last_msg_->header.seq_num, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.seq_num)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.seq_num)),
+            2)
       << "incorrect value for header.seq_num, expected 2, is "
       << last_msg_->header.seq_num;
-  EXPECT_EQ(last_msg_->header.ssr_sol_id, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->header.ssr_sol_id)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->header.ssr_sol_id)),
+      3)
       << "incorrect value for header.ssr_sol_id, expected 3, is "
       << last_msg_->header.ssr_sol_id;
-  EXPECT_EQ(last_msg_->header.tile_id, 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.tile_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.tile_id)),
+            5)
       << "incorrect value for header.tile_id, expected 5, is "
       << last_msg_->header.tile_id;
-  EXPECT_EQ(last_msg_->header.tile_set_id, 4)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->header.tile_set_id)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->header.tile_set_id)),
+      4)
       << "incorrect value for header.tile_set_id, expected 4, is "
       << last_msg_->header.tile_set_id;
-  EXPECT_EQ(last_msg_->n_faulty_los, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_faulty_los)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_faulty_los)),
+            2)
       << "incorrect value for n_faulty_los, expected 2, is "
       << last_msg_->n_faulty_los;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_integrity_MsgSsrFlagIonoGridPoints.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_integrity_MsgSsrFlagIonoGridPoints.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/integrity.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_integrity_MsgSsrFlagIonoGridPoints0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -136,40 +143,71 @@ TEST_F(Test_legacy_auto_check_sbp_integrity_MsgSsrFlagIonoGridPoints0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->faulty_points[0], 10)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->faulty_points[0])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->faulty_points[0])),
+      10)
       << "incorrect value for faulty_points[0], expected 10, is "
       << last_msg_->faulty_points[0];
-  EXPECT_EQ(last_msg_->faulty_points[1], 11)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->faulty_points[1])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->faulty_points[1])),
+      11)
       << "incorrect value for faulty_points[1], expected 11, is "
       << last_msg_->faulty_points[1];
-  EXPECT_EQ(last_msg_->faulty_points[2], 12)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->faulty_points[2])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->faulty_points[2])),
+      12)
       << "incorrect value for faulty_points[2], expected 12, is "
       << last_msg_->faulty_points[2];
-  EXPECT_EQ(last_msg_->header.chain_id, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.chain_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.chain_id)),
+            6)
       << "incorrect value for header.chain_id, expected 6, is "
       << last_msg_->header.chain_id;
-  EXPECT_EQ(last_msg_->header.num_msgs, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.num_msgs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.num_msgs)),
+            1)
       << "incorrect value for header.num_msgs, expected 1, is "
       << last_msg_->header.num_msgs;
-  EXPECT_EQ(last_msg_->header.obs_time.tow, 180)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->header.obs_time.tow)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->header.obs_time.tow)),
+      180)
       << "incorrect value for header.obs_time.tow, expected 180, is "
       << last_msg_->header.obs_time.tow;
-  EXPECT_EQ(last_msg_->header.obs_time.wn, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->header.obs_time.wn)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->header.obs_time.wn)),
+      3)
       << "incorrect value for header.obs_time.wn, expected 3, is "
       << last_msg_->header.obs_time.wn;
-  EXPECT_EQ(last_msg_->header.seq_num, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.seq_num)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.seq_num)),
+            2)
       << "incorrect value for header.seq_num, expected 2, is "
       << last_msg_->header.seq_num;
-  EXPECT_EQ(last_msg_->header.ssr_sol_id, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->header.ssr_sol_id)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->header.ssr_sol_id)),
+      3)
       << "incorrect value for header.ssr_sol_id, expected 3, is "
       << last_msg_->header.ssr_sol_id;
-  EXPECT_EQ(last_msg_->header.tile_id, 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.tile_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.tile_id)),
+            5)
       << "incorrect value for header.tile_id, expected 5, is "
       << last_msg_->header.tile_id;
-  EXPECT_EQ(last_msg_->header.tile_set_id, 4)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->header.tile_set_id)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->header.tile_set_id)),
+      4)
       << "incorrect value for header.tile_set_id, expected 4, is "
       << last_msg_->header.tile_set_id;
-  EXPECT_EQ(last_msg_->n_faulty_points, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_faulty_points)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_faulty_points)),
+            3)
       << "incorrect value for n_faulty_points, expected 3, is "
       << last_msg_->n_faulty_points;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_integrity_MsgSsrFlagIonoTileSatLos.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_integrity_MsgSsrFlagIonoTileSatLos.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/integrity.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_integrity_MsgSsrFlagIonoTileSatLos0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -133,43 +140,77 @@ TEST_F(Test_legacy_auto_check_sbp_integrity_MsgSsrFlagIonoTileSatLos0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->faulty_los[0].constellation, 11)
+  EXPECT_EQ(get_as<decltype(last_msg_->faulty_los[0].constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->faulty_los[0].constellation)),
+            11)
       << "incorrect value for faulty_los[0].constellation, expected 11, is "
       << last_msg_->faulty_los[0].constellation;
-  EXPECT_EQ(last_msg_->faulty_los[0].satId, 10)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->faulty_los[0].satId)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->faulty_los[0].satId)),
+      10)
       << "incorrect value for faulty_los[0].satId, expected 10, is "
       << last_msg_->faulty_los[0].satId;
-  EXPECT_EQ(last_msg_->faulty_los[1].constellation, 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->faulty_los[1].constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->faulty_los[1].constellation)),
+            14)
       << "incorrect value for faulty_los[1].constellation, expected 14, is "
       << last_msg_->faulty_los[1].constellation;
-  EXPECT_EQ(last_msg_->faulty_los[1].satId, 15)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->faulty_los[1].satId)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->faulty_los[1].satId)),
+      15)
       << "incorrect value for faulty_los[1].satId, expected 15, is "
       << last_msg_->faulty_los[1].satId;
-  EXPECT_EQ(last_msg_->header.chain_id, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.chain_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.chain_id)),
+            6)
       << "incorrect value for header.chain_id, expected 6, is "
       << last_msg_->header.chain_id;
-  EXPECT_EQ(last_msg_->header.num_msgs, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.num_msgs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.num_msgs)),
+            1)
       << "incorrect value for header.num_msgs, expected 1, is "
       << last_msg_->header.num_msgs;
-  EXPECT_EQ(last_msg_->header.obs_time.tow, 180)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->header.obs_time.tow)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->header.obs_time.tow)),
+      180)
       << "incorrect value for header.obs_time.tow, expected 180, is "
       << last_msg_->header.obs_time.tow;
-  EXPECT_EQ(last_msg_->header.obs_time.wn, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->header.obs_time.wn)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->header.obs_time.wn)),
+      3)
       << "incorrect value for header.obs_time.wn, expected 3, is "
       << last_msg_->header.obs_time.wn;
-  EXPECT_EQ(last_msg_->header.seq_num, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.seq_num)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.seq_num)),
+            2)
       << "incorrect value for header.seq_num, expected 2, is "
       << last_msg_->header.seq_num;
-  EXPECT_EQ(last_msg_->header.ssr_sol_id, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->header.ssr_sol_id)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->header.ssr_sol_id)),
+      3)
       << "incorrect value for header.ssr_sol_id, expected 3, is "
       << last_msg_->header.ssr_sol_id;
-  EXPECT_EQ(last_msg_->header.tile_id, 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.tile_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.tile_id)),
+            5)
       << "incorrect value for header.tile_id, expected 5, is "
       << last_msg_->header.tile_id;
-  EXPECT_EQ(last_msg_->header.tile_set_id, 4)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->header.tile_set_id)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->header.tile_set_id)),
+      4)
       << "incorrect value for header.tile_set_id, expected 4, is "
       << last_msg_->header.tile_set_id;
-  EXPECT_EQ(last_msg_->n_faulty_los, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_faulty_los)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_faulty_los)),
+            2)
       << "incorrect value for n_faulty_los, expected 2, is "
       << last_msg_->n_faulty_los;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_integrity_MsgSsrFlagSatellites.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_integrity_MsgSsrFlagSatellites.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/integrity.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_integrity_MsgSsrFlagSatellites0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -135,33 +142,55 @@ TEST_F(Test_legacy_auto_check_sbp_integrity_MsgSsrFlagSatellites0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->chain_id, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->chain_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->chain_id)),
+            4)
       << "incorrect value for chain_id, expected 4, is " << last_msg_->chain_id;
-  EXPECT_EQ(last_msg_->const_id, 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->const_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->const_id)),
+            5)
       << "incorrect value for const_id, expected 5, is " << last_msg_->const_id;
-  EXPECT_EQ(last_msg_->faulty_sats[0], 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->faulty_sats[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->faulty_sats[0])),
+            10)
       << "incorrect value for faulty_sats[0], expected 10, is "
       << last_msg_->faulty_sats[0];
-  EXPECT_EQ(last_msg_->faulty_sats[1], 11)
+  EXPECT_EQ(get_as<decltype(last_msg_->faulty_sats[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->faulty_sats[1])),
+            11)
       << "incorrect value for faulty_sats[1], expected 11, is "
       << last_msg_->faulty_sats[1];
-  EXPECT_EQ(last_msg_->faulty_sats[2], 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->faulty_sats[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->faulty_sats[2])),
+            12)
       << "incorrect value for faulty_sats[2], expected 12, is "
       << last_msg_->faulty_sats[2];
-  EXPECT_EQ(last_msg_->n_faulty_sats, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_faulty_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_faulty_sats)),
+            3)
       << "incorrect value for n_faulty_sats, expected 3, is "
       << last_msg_->n_faulty_sats;
-  EXPECT_EQ(last_msg_->num_msgs, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->num_msgs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->num_msgs)),
+            1)
       << "incorrect value for num_msgs, expected 1, is " << last_msg_->num_msgs;
-  EXPECT_EQ(last_msg_->obs_time.tow, 180)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs_time.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs_time.tow)),
+            180)
       << "incorrect value for obs_time.tow, expected 180, is "
       << last_msg_->obs_time.tow;
-  EXPECT_EQ(last_msg_->obs_time.wn, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs_time.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs_time.wn)),
+            3)
       << "incorrect value for obs_time.wn, expected 3, is "
       << last_msg_->obs_time.wn;
-  EXPECT_EQ(last_msg_->seq_num, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->seq_num)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->seq_num)),
+            2)
       << "incorrect value for seq_num, expected 2, is " << last_msg_->seq_num;
-  EXPECT_EQ(last_msg_->ssr_sol_id, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->ssr_sol_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ssr_sol_id)),
+            3)
       << "incorrect value for ssr_sol_id, expected 3, is "
       << last_msg_->ssr_sol_id;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_integrity_MsgSsrFlagTropoGridPoints.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_integrity_MsgSsrFlagTropoGridPoints.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/integrity.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_integrity_MsgSsrFlagTropoGridPoints0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -136,40 +143,71 @@ TEST_F(Test_legacy_auto_check_sbp_integrity_MsgSsrFlagTropoGridPoints0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->faulty_points[0], 10)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->faulty_points[0])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->faulty_points[0])),
+      10)
       << "incorrect value for faulty_points[0], expected 10, is "
       << last_msg_->faulty_points[0];
-  EXPECT_EQ(last_msg_->faulty_points[1], 11)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->faulty_points[1])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->faulty_points[1])),
+      11)
       << "incorrect value for faulty_points[1], expected 11, is "
       << last_msg_->faulty_points[1];
-  EXPECT_EQ(last_msg_->faulty_points[2], 12)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->faulty_points[2])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->faulty_points[2])),
+      12)
       << "incorrect value for faulty_points[2], expected 12, is "
       << last_msg_->faulty_points[2];
-  EXPECT_EQ(last_msg_->header.chain_id, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.chain_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.chain_id)),
+            6)
       << "incorrect value for header.chain_id, expected 6, is "
       << last_msg_->header.chain_id;
-  EXPECT_EQ(last_msg_->header.num_msgs, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.num_msgs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.num_msgs)),
+            1)
       << "incorrect value for header.num_msgs, expected 1, is "
       << last_msg_->header.num_msgs;
-  EXPECT_EQ(last_msg_->header.obs_time.tow, 180)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->header.obs_time.tow)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->header.obs_time.tow)),
+      180)
       << "incorrect value for header.obs_time.tow, expected 180, is "
       << last_msg_->header.obs_time.tow;
-  EXPECT_EQ(last_msg_->header.obs_time.wn, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->header.obs_time.wn)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->header.obs_time.wn)),
+      3)
       << "incorrect value for header.obs_time.wn, expected 3, is "
       << last_msg_->header.obs_time.wn;
-  EXPECT_EQ(last_msg_->header.seq_num, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.seq_num)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.seq_num)),
+            2)
       << "incorrect value for header.seq_num, expected 2, is "
       << last_msg_->header.seq_num;
-  EXPECT_EQ(last_msg_->header.ssr_sol_id, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->header.ssr_sol_id)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->header.ssr_sol_id)),
+      3)
       << "incorrect value for header.ssr_sol_id, expected 3, is "
       << last_msg_->header.ssr_sol_id;
-  EXPECT_EQ(last_msg_->header.tile_id, 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.tile_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.tile_id)),
+            5)
       << "incorrect value for header.tile_id, expected 5, is "
       << last_msg_->header.tile_id;
-  EXPECT_EQ(last_msg_->header.tile_set_id, 4)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->header.tile_set_id)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->header.tile_set_id)),
+      4)
       << "incorrect value for header.tile_set_id, expected 4, is "
       << last_msg_->header.tile_set_id;
-  EXPECT_EQ(last_msg_->n_faulty_points, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_faulty_points)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_faulty_points)),
+            3)
       << "incorrect value for n_faulty_points, expected 3, is "
       << last_msg_->n_faulty_points;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_linux_MsgLinuxCpuState.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_linux_MsgLinuxCpuState.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/linux.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_linux_MsgLinuxCpuState0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -159,15 +166,25 @@ TEST_F(Test_legacy_auto_check_sbp_linux_MsgLinuxCpuState0, Test) {
         << "incorrect value for last_msg_->cmdline, expected string '"
         << check_string << "', is '" << last_msg_->cmdline << "'";
   }
-  EXPECT_EQ(last_msg_->flags, 20)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            20)
       << "incorrect value for flags, expected 20, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->index, 101)
+  EXPECT_EQ(get_as<decltype(last_msg_->index)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->index)),
+            101)
       << "incorrect value for index, expected 101, is " << last_msg_->index;
-  EXPECT_EQ(last_msg_->pcpu, 98)
+  EXPECT_EQ(get_as<decltype(last_msg_->pcpu)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pcpu)),
+            98)
       << "incorrect value for pcpu, expected 98, is " << last_msg_->pcpu;
-  EXPECT_EQ(last_msg_->pid, 50042)
+  EXPECT_EQ(get_as<decltype(last_msg_->pid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pid)),
+            50042)
       << "incorrect value for pid, expected 50042, is " << last_msg_->pid;
-  EXPECT_EQ(last_msg_->time, 3948815319)
+  EXPECT_EQ(get_as<decltype(last_msg_->time)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->time)),
+            3948815319)
       << "incorrect value for time, expected 3948815319, is "
       << last_msg_->time;
   {

--- a/c/test/legacy/cpp/auto_check_sbp_linux_MsgLinuxCpuStateDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_linux_MsgLinuxCpuStateDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/linux.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_linux_MsgLinuxCpuStateDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -158,11 +165,17 @@ TEST_F(Test_legacy_auto_check_sbp_linux_MsgLinuxCpuStateDepA0, Test) {
         << "incorrect value for last_msg_->cmdline, expected string '"
         << check_string << "', is '" << last_msg_->cmdline << "'";
   }
-  EXPECT_EQ(last_msg_->index, 51)
+  EXPECT_EQ(get_as<decltype(last_msg_->index)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->index)),
+            51)
       << "incorrect value for index, expected 51, is " << last_msg_->index;
-  EXPECT_EQ(last_msg_->pcpu, 178)
+  EXPECT_EQ(get_as<decltype(last_msg_->pcpu)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pcpu)),
+            178)
       << "incorrect value for pcpu, expected 178, is " << last_msg_->pcpu;
-  EXPECT_EQ(last_msg_->pid, 64240)
+  EXPECT_EQ(get_as<decltype(last_msg_->pid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pid)),
+            64240)
       << "incorrect value for pid, expected 64240, is " << last_msg_->pid;
   {
     const char check_string[] = {(char)112, (char)114, (char)111, (char)99,

--- a/c/test/legacy/cpp/auto_check_sbp_linux_MsgLinuxMemState.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_linux_MsgLinuxMemState.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/linux.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_linux_MsgLinuxMemState0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -159,15 +166,25 @@ TEST_F(Test_legacy_auto_check_sbp_linux_MsgLinuxMemState0, Test) {
         << "incorrect value for last_msg_->cmdline, expected string '"
         << check_string << "', is '" << last_msg_->cmdline << "'";
   }
-  EXPECT_EQ(last_msg_->flags, 76)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            76)
       << "incorrect value for flags, expected 76, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->index, 154)
+  EXPECT_EQ(get_as<decltype(last_msg_->index)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->index)),
+            154)
       << "incorrect value for index, expected 154, is " << last_msg_->index;
-  EXPECT_EQ(last_msg_->pid, 57279)
+  EXPECT_EQ(get_as<decltype(last_msg_->pid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pid)),
+            57279)
       << "incorrect value for pid, expected 57279, is " << last_msg_->pid;
-  EXPECT_EQ(last_msg_->pmem, 19)
+  EXPECT_EQ(get_as<decltype(last_msg_->pmem)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pmem)),
+            19)
       << "incorrect value for pmem, expected 19, is " << last_msg_->pmem;
-  EXPECT_EQ(last_msg_->time, 3139057143)
+  EXPECT_EQ(get_as<decltype(last_msg_->time)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->time)),
+            3139057143)
       << "incorrect value for time, expected 3139057143, is "
       << last_msg_->time;
   {

--- a/c/test/legacy/cpp/auto_check_sbp_linux_MsgLinuxMemStateDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_linux_MsgLinuxMemStateDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/linux.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_linux_MsgLinuxMemStateDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -158,11 +165,17 @@ TEST_F(Test_legacy_auto_check_sbp_linux_MsgLinuxMemStateDepA0, Test) {
         << "incorrect value for last_msg_->cmdline, expected string '"
         << check_string << "', is '" << last_msg_->cmdline << "'";
   }
-  EXPECT_EQ(last_msg_->index, 247)
+  EXPECT_EQ(get_as<decltype(last_msg_->index)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->index)),
+            247)
       << "incorrect value for index, expected 247, is " << last_msg_->index;
-  EXPECT_EQ(last_msg_->pid, 12381)
+  EXPECT_EQ(get_as<decltype(last_msg_->pid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pid)),
+            12381)
       << "incorrect value for pid, expected 12381, is " << last_msg_->pid;
-  EXPECT_EQ(last_msg_->pmem, 193)
+  EXPECT_EQ(get_as<decltype(last_msg_->pmem)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pmem)),
+            193)
       << "incorrect value for pmem, expected 193, is " << last_msg_->pmem;
   {
     const char check_string[] = {(char)112, (char)114, (char)111, (char)99,

--- a/c/test/legacy/cpp/auto_check_sbp_linux_MsgLinuxProcessFdCount.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_linux_MsgLinuxProcessFdCount.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/linux.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_linux_MsgLinuxProcessFdCount0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -147,11 +154,17 @@ TEST_F(Test_legacy_auto_check_sbp_linux_MsgLinuxProcessFdCount0, Test) {
         << "incorrect value for last_msg_->cmdline, expected string '"
         << check_string << "', is '" << last_msg_->cmdline << "'";
   }
-  EXPECT_EQ(last_msg_->fd_count, 35589)
+  EXPECT_EQ(get_as<decltype(last_msg_->fd_count)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fd_count)),
+            35589)
       << "incorrect value for fd_count, expected 35589, is "
       << last_msg_->fd_count;
-  EXPECT_EQ(last_msg_->index, 164)
+  EXPECT_EQ(get_as<decltype(last_msg_->index)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->index)),
+            164)
       << "incorrect value for index, expected 164, is " << last_msg_->index;
-  EXPECT_EQ(last_msg_->pid, 42429)
+  EXPECT_EQ(get_as<decltype(last_msg_->pid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pid)),
+            42429)
       << "incorrect value for pid, expected 42429, is " << last_msg_->pid;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_linux_MsgLinuxProcessFdSummary.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_linux_MsgLinuxProcessFdSummary.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/linux.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_linux_MsgLinuxProcessFdSummary0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -139,7 +146,9 @@ TEST_F(Test_legacy_auto_check_sbp_linux_MsgLinuxProcessFdSummary0, Test) {
         << "incorrect value for last_msg_->most_opened, expected string '"
         << check_string << "', is '" << last_msg_->most_opened << "'";
   }
-  EXPECT_EQ(last_msg_->sys_fd_count, 1304986387)
+  EXPECT_EQ(get_as<decltype(last_msg_->sys_fd_count)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sys_fd_count)),
+            1304986387)
       << "incorrect value for sys_fd_count, expected 1304986387, is "
       << last_msg_->sys_fd_count;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_linux_MsgLinuxProcessSocketCounts.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_linux_MsgLinuxProcessSocketCounts.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/linux.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_linux_MsgLinuxProcessSocketCounts0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -149,17 +156,27 @@ TEST_F(Test_legacy_auto_check_sbp_linux_MsgLinuxProcessSocketCounts0, Test) {
         << "incorrect value for last_msg_->cmdline, expected string '"
         << check_string << "', is '" << last_msg_->cmdline << "'";
   }
-  EXPECT_EQ(last_msg_->index, 51)
+  EXPECT_EQ(get_as<decltype(last_msg_->index)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->index)),
+            51)
       << "incorrect value for index, expected 51, is " << last_msg_->index;
-  EXPECT_EQ(last_msg_->pid, 28553)
+  EXPECT_EQ(get_as<decltype(last_msg_->pid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pid)),
+            28553)
       << "incorrect value for pid, expected 28553, is " << last_msg_->pid;
-  EXPECT_EQ(last_msg_->socket_count, 30287)
+  EXPECT_EQ(get_as<decltype(last_msg_->socket_count)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->socket_count)),
+            30287)
       << "incorrect value for socket_count, expected 30287, is "
       << last_msg_->socket_count;
-  EXPECT_EQ(last_msg_->socket_states, 29554)
+  EXPECT_EQ(get_as<decltype(last_msg_->socket_states)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->socket_states)),
+            29554)
       << "incorrect value for socket_states, expected 29554, is "
       << last_msg_->socket_states;
-  EXPECT_EQ(last_msg_->socket_types, 35843)
+  EXPECT_EQ(get_as<decltype(last_msg_->socket_types)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->socket_types)),
+            35843)
       << "incorrect value for socket_types, expected 35843, is "
       << last_msg_->socket_types;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_linux_MsgLinuxProcessSocketQueues.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_linux_MsgLinuxProcessSocketQueues.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/linux.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_linux_MsgLinuxProcessSocketQueues0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -193,20 +200,32 @@ TEST_F(Test_legacy_auto_check_sbp_linux_MsgLinuxProcessSocketQueues0, Test) {
         << "incorrect value for last_msg_->cmdline, expected string '"
         << check_string << "', is '" << last_msg_->cmdline << "'";
   }
-  EXPECT_EQ(last_msg_->index, 181)
+  EXPECT_EQ(get_as<decltype(last_msg_->index)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->index)),
+            181)
       << "incorrect value for index, expected 181, is " << last_msg_->index;
-  EXPECT_EQ(last_msg_->pid, 19335)
+  EXPECT_EQ(get_as<decltype(last_msg_->pid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pid)),
+            19335)
       << "incorrect value for pid, expected 19335, is " << last_msg_->pid;
-  EXPECT_EQ(last_msg_->recv_queued, 54265)
+  EXPECT_EQ(get_as<decltype(last_msg_->recv_queued)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->recv_queued)),
+            54265)
       << "incorrect value for recv_queued, expected 54265, is "
       << last_msg_->recv_queued;
-  EXPECT_EQ(last_msg_->send_queued, 64547)
+  EXPECT_EQ(get_as<decltype(last_msg_->send_queued)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->send_queued)),
+            64547)
       << "incorrect value for send_queued, expected 64547, is "
       << last_msg_->send_queued;
-  EXPECT_EQ(last_msg_->socket_states, 57103)
+  EXPECT_EQ(get_as<decltype(last_msg_->socket_states)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->socket_states)),
+            57103)
       << "incorrect value for socket_states, expected 57103, is "
       << last_msg_->socket_states;
-  EXPECT_EQ(last_msg_->socket_types, 27984)
+  EXPECT_EQ(get_as<decltype(last_msg_->socket_types)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->socket_types)),
+            27984)
       << "incorrect value for socket_types, expected 27984, is "
       << last_msg_->socket_types;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_linux_MsgLinuxSocketUsage.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_linux_MsgLinuxSocketUsage.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/linux.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_linux_MsgLinuxSocketUsage0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -311,106 +318,206 @@ TEST_F(Test_legacy_auto_check_sbp_linux_MsgLinuxSocketUsage0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35442);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->avg_queue_depth, 2907030541)
+  EXPECT_EQ(get_as<decltype(last_msg_->avg_queue_depth)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->avg_queue_depth)),
+            2907030541)
       << "incorrect value for avg_queue_depth, expected 2907030541, is "
       << last_msg_->avg_queue_depth;
-  EXPECT_EQ(last_msg_->max_queue_depth, 3048922691)
+  EXPECT_EQ(get_as<decltype(last_msg_->max_queue_depth)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->max_queue_depth)),
+            3048922691)
       << "incorrect value for max_queue_depth, expected 3048922691, is "
       << last_msg_->max_queue_depth;
-  EXPECT_EQ(last_msg_->socket_state_counts[0], 39670)
+  EXPECT_EQ(get_as<decltype(last_msg_->socket_state_counts[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->socket_state_counts[0])),
+            39670)
       << "incorrect value for socket_state_counts[0], expected 39670, is "
       << last_msg_->socket_state_counts[0];
-  EXPECT_EQ(last_msg_->socket_state_counts[1], 4603)
+  EXPECT_EQ(get_as<decltype(last_msg_->socket_state_counts[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->socket_state_counts[1])),
+            4603)
       << "incorrect value for socket_state_counts[1], expected 4603, is "
       << last_msg_->socket_state_counts[1];
-  EXPECT_EQ(last_msg_->socket_state_counts[2], 46048)
+  EXPECT_EQ(get_as<decltype(last_msg_->socket_state_counts[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->socket_state_counts[2])),
+            46048)
       << "incorrect value for socket_state_counts[2], expected 46048, is "
       << last_msg_->socket_state_counts[2];
-  EXPECT_EQ(last_msg_->socket_state_counts[3], 43290)
+  EXPECT_EQ(get_as<decltype(last_msg_->socket_state_counts[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->socket_state_counts[3])),
+            43290)
       << "incorrect value for socket_state_counts[3], expected 43290, is "
       << last_msg_->socket_state_counts[3];
-  EXPECT_EQ(last_msg_->socket_state_counts[4], 23217)
+  EXPECT_EQ(get_as<decltype(last_msg_->socket_state_counts[4])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->socket_state_counts[4])),
+            23217)
       << "incorrect value for socket_state_counts[4], expected 23217, is "
       << last_msg_->socket_state_counts[4];
-  EXPECT_EQ(last_msg_->socket_state_counts[5], 54677)
+  EXPECT_EQ(get_as<decltype(last_msg_->socket_state_counts[5])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->socket_state_counts[5])),
+            54677)
       << "incorrect value for socket_state_counts[5], expected 54677, is "
       << last_msg_->socket_state_counts[5];
-  EXPECT_EQ(last_msg_->socket_state_counts[6], 1750)
+  EXPECT_EQ(get_as<decltype(last_msg_->socket_state_counts[6])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->socket_state_counts[6])),
+            1750)
       << "incorrect value for socket_state_counts[6], expected 1750, is "
       << last_msg_->socket_state_counts[6];
-  EXPECT_EQ(last_msg_->socket_state_counts[7], 16510)
+  EXPECT_EQ(get_as<decltype(last_msg_->socket_state_counts[7])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->socket_state_counts[7])),
+            16510)
       << "incorrect value for socket_state_counts[7], expected 16510, is "
       << last_msg_->socket_state_counts[7];
-  EXPECT_EQ(last_msg_->socket_state_counts[8], 47480)
+  EXPECT_EQ(get_as<decltype(last_msg_->socket_state_counts[8])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->socket_state_counts[8])),
+            47480)
       << "incorrect value for socket_state_counts[8], expected 47480, is "
       << last_msg_->socket_state_counts[8];
-  EXPECT_EQ(last_msg_->socket_state_counts[9], 33620)
+  EXPECT_EQ(get_as<decltype(last_msg_->socket_state_counts[9])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->socket_state_counts[9])),
+            33620)
       << "incorrect value for socket_state_counts[9], expected 33620, is "
       << last_msg_->socket_state_counts[9];
-  EXPECT_EQ(last_msg_->socket_state_counts[10], 28616)
+  EXPECT_EQ(get_as<decltype(last_msg_->socket_state_counts[10])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->socket_state_counts[10])),
+            28616)
       << "incorrect value for socket_state_counts[10], expected 28616, is "
       << last_msg_->socket_state_counts[10];
-  EXPECT_EQ(last_msg_->socket_state_counts[11], 36128)
+  EXPECT_EQ(get_as<decltype(last_msg_->socket_state_counts[11])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->socket_state_counts[11])),
+            36128)
       << "incorrect value for socket_state_counts[11], expected 36128, is "
       << last_msg_->socket_state_counts[11];
-  EXPECT_EQ(last_msg_->socket_state_counts[12], 53721)
+  EXPECT_EQ(get_as<decltype(last_msg_->socket_state_counts[12])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->socket_state_counts[12])),
+            53721)
       << "incorrect value for socket_state_counts[12], expected 53721, is "
       << last_msg_->socket_state_counts[12];
-  EXPECT_EQ(last_msg_->socket_state_counts[13], 3636)
+  EXPECT_EQ(get_as<decltype(last_msg_->socket_state_counts[13])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->socket_state_counts[13])),
+            3636)
       << "incorrect value for socket_state_counts[13], expected 3636, is "
       << last_msg_->socket_state_counts[13];
-  EXPECT_EQ(last_msg_->socket_state_counts[14], 37822)
+  EXPECT_EQ(get_as<decltype(last_msg_->socket_state_counts[14])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->socket_state_counts[14])),
+            37822)
       << "incorrect value for socket_state_counts[14], expected 37822, is "
       << last_msg_->socket_state_counts[14];
-  EXPECT_EQ(last_msg_->socket_state_counts[15], 63135)
+  EXPECT_EQ(get_as<decltype(last_msg_->socket_state_counts[15])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->socket_state_counts[15])),
+            63135)
       << "incorrect value for socket_state_counts[15], expected 63135, is "
       << last_msg_->socket_state_counts[15];
-  EXPECT_EQ(last_msg_->socket_type_counts[0], 31373)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->socket_type_counts[0])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->socket_type_counts[0])),
+      31373)
       << "incorrect value for socket_type_counts[0], expected 31373, is "
       << last_msg_->socket_type_counts[0];
-  EXPECT_EQ(last_msg_->socket_type_counts[1], 30676)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->socket_type_counts[1])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->socket_type_counts[1])),
+      30676)
       << "incorrect value for socket_type_counts[1], expected 30676, is "
       << last_msg_->socket_type_counts[1];
-  EXPECT_EQ(last_msg_->socket_type_counts[2], 7811)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->socket_type_counts[2])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->socket_type_counts[2])),
+      7811)
       << "incorrect value for socket_type_counts[2], expected 7811, is "
       << last_msg_->socket_type_counts[2];
-  EXPECT_EQ(last_msg_->socket_type_counts[3], 12152)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->socket_type_counts[3])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->socket_type_counts[3])),
+      12152)
       << "incorrect value for socket_type_counts[3], expected 12152, is "
       << last_msg_->socket_type_counts[3];
-  EXPECT_EQ(last_msg_->socket_type_counts[4], 27929)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->socket_type_counts[4])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->socket_type_counts[4])),
+      27929)
       << "incorrect value for socket_type_counts[4], expected 27929, is "
       << last_msg_->socket_type_counts[4];
-  EXPECT_EQ(last_msg_->socket_type_counts[5], 16794)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->socket_type_counts[5])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->socket_type_counts[5])),
+      16794)
       << "incorrect value for socket_type_counts[5], expected 16794, is "
       << last_msg_->socket_type_counts[5];
-  EXPECT_EQ(last_msg_->socket_type_counts[6], 42116)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->socket_type_counts[6])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->socket_type_counts[6])),
+      42116)
       << "incorrect value for socket_type_counts[6], expected 42116, is "
       << last_msg_->socket_type_counts[6];
-  EXPECT_EQ(last_msg_->socket_type_counts[7], 7719)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->socket_type_counts[7])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->socket_type_counts[7])),
+      7719)
       << "incorrect value for socket_type_counts[7], expected 7719, is "
       << last_msg_->socket_type_counts[7];
-  EXPECT_EQ(last_msg_->socket_type_counts[8], 44830)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->socket_type_counts[8])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->socket_type_counts[8])),
+      44830)
       << "incorrect value for socket_type_counts[8], expected 44830, is "
       << last_msg_->socket_type_counts[8];
-  EXPECT_EQ(last_msg_->socket_type_counts[9], 11272)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->socket_type_counts[9])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->socket_type_counts[9])),
+      11272)
       << "incorrect value for socket_type_counts[9], expected 11272, is "
       << last_msg_->socket_type_counts[9];
-  EXPECT_EQ(last_msg_->socket_type_counts[10], 28444)
+  EXPECT_EQ(get_as<decltype(last_msg_->socket_type_counts[10])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->socket_type_counts[10])),
+            28444)
       << "incorrect value for socket_type_counts[10], expected 28444, is "
       << last_msg_->socket_type_counts[10];
-  EXPECT_EQ(last_msg_->socket_type_counts[11], 61676)
+  EXPECT_EQ(get_as<decltype(last_msg_->socket_type_counts[11])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->socket_type_counts[11])),
+            61676)
       << "incorrect value for socket_type_counts[11], expected 61676, is "
       << last_msg_->socket_type_counts[11];
-  EXPECT_EQ(last_msg_->socket_type_counts[12], 19120)
+  EXPECT_EQ(get_as<decltype(last_msg_->socket_type_counts[12])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->socket_type_counts[12])),
+            19120)
       << "incorrect value for socket_type_counts[12], expected 19120, is "
       << last_msg_->socket_type_counts[12];
-  EXPECT_EQ(last_msg_->socket_type_counts[13], 33183)
+  EXPECT_EQ(get_as<decltype(last_msg_->socket_type_counts[13])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->socket_type_counts[13])),
+            33183)
       << "incorrect value for socket_type_counts[13], expected 33183, is "
       << last_msg_->socket_type_counts[13];
-  EXPECT_EQ(last_msg_->socket_type_counts[14], 39322)
+  EXPECT_EQ(get_as<decltype(last_msg_->socket_type_counts[14])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->socket_type_counts[14])),
+            39322)
       << "incorrect value for socket_type_counts[14], expected 39322, is "
       << last_msg_->socket_type_counts[14];
-  EXPECT_EQ(last_msg_->socket_type_counts[15], 58786)
+  EXPECT_EQ(get_as<decltype(last_msg_->socket_type_counts[15])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->socket_type_counts[15])),
+            58786)
       << "incorrect value for socket_type_counts[15], expected 58786, is "
       << last_msg_->socket_type_counts[15];
 }

--- a/c/test/legacy/cpp/auto_check_sbp_linux_MsgLinuxSysState.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_linux_MsgLinuxSysState.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/linux.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_linux_MsgLinuxSysState0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -119,24 +126,40 @@ TEST_F(Test_legacy_auto_check_sbp_linux_MsgLinuxSysState0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 42837);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            9)
       << "incorrect value for flags, expected 9, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->mem_total, 53012)
+  EXPECT_EQ(get_as<decltype(last_msg_->mem_total)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->mem_total)),
+            53012)
       << "incorrect value for mem_total, expected 53012, is "
       << last_msg_->mem_total;
-  EXPECT_EQ(last_msg_->pcpu, 125)
+  EXPECT_EQ(get_as<decltype(last_msg_->pcpu)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pcpu)),
+            125)
       << "incorrect value for pcpu, expected 125, is " << last_msg_->pcpu;
-  EXPECT_EQ(last_msg_->pid_count, 47866)
+  EXPECT_EQ(get_as<decltype(last_msg_->pid_count)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pid_count)),
+            47866)
       << "incorrect value for pid_count, expected 47866, is "
       << last_msg_->pid_count;
-  EXPECT_EQ(last_msg_->pmem, 215)
+  EXPECT_EQ(get_as<decltype(last_msg_->pmem)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pmem)),
+            215)
       << "incorrect value for pmem, expected 215, is " << last_msg_->pmem;
-  EXPECT_EQ(last_msg_->procs_starting, 18372)
+  EXPECT_EQ(get_as<decltype(last_msg_->procs_starting)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->procs_starting)),
+            18372)
       << "incorrect value for procs_starting, expected 18372, is "
       << last_msg_->procs_starting;
-  EXPECT_EQ(last_msg_->procs_stopping, 58785)
+  EXPECT_EQ(get_as<decltype(last_msg_->procs_stopping)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->procs_stopping)),
+            58785)
       << "incorrect value for procs_stopping, expected 58785, is "
       << last_msg_->procs_stopping;
-  EXPECT_EQ(last_msg_->time, 90840684)
+  EXPECT_EQ(get_as<decltype(last_msg_->time)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->time)),
+            90840684)
       << "incorrect value for time, expected 90840684, is " << last_msg_->time;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_linux_MsgLinuxSysStateDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_linux_MsgLinuxSysStateDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/linux.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_linux_MsgLinuxSysStateDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -119,20 +126,32 @@ TEST_F(Test_legacy_auto_check_sbp_linux_MsgLinuxSysStateDepA0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 14420);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->mem_total, 41916)
+  EXPECT_EQ(get_as<decltype(last_msg_->mem_total)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->mem_total)),
+            41916)
       << "incorrect value for mem_total, expected 41916, is "
       << last_msg_->mem_total;
-  EXPECT_EQ(last_msg_->pcpu, 211)
+  EXPECT_EQ(get_as<decltype(last_msg_->pcpu)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pcpu)),
+            211)
       << "incorrect value for pcpu, expected 211, is " << last_msg_->pcpu;
-  EXPECT_EQ(last_msg_->pid_count, 51580)
+  EXPECT_EQ(get_as<decltype(last_msg_->pid_count)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pid_count)),
+            51580)
       << "incorrect value for pid_count, expected 51580, is "
       << last_msg_->pid_count;
-  EXPECT_EQ(last_msg_->pmem, 194)
+  EXPECT_EQ(get_as<decltype(last_msg_->pmem)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pmem)),
+            194)
       << "incorrect value for pmem, expected 194, is " << last_msg_->pmem;
-  EXPECT_EQ(last_msg_->procs_starting, 18291)
+  EXPECT_EQ(get_as<decltype(last_msg_->procs_starting)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->procs_starting)),
+            18291)
       << "incorrect value for procs_starting, expected 18291, is "
       << last_msg_->procs_starting;
-  EXPECT_EQ(last_msg_->procs_stopping, 26469)
+  EXPECT_EQ(get_as<decltype(last_msg_->procs_stopping)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->procs_stopping)),
+            26469)
       << "incorrect value for procs_stopping, expected 26469, is "
       << last_msg_->procs_stopping;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_logging_MsgFwd.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_logging_MsgFwd.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/logging.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_logging_MsgFwd0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -192,56 +199,92 @@ TEST_F(Test_legacy_auto_check_sbp_logging_MsgFwd0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->fwd_payload[0], 86)
+  EXPECT_EQ(get_as<decltype(last_msg_->fwd_payload[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fwd_payload[0])),
+            86)
       << "incorrect value for fwd_payload[0], expected 86, is "
       << last_msg_->fwd_payload[0];
-  EXPECT_EQ(last_msg_->fwd_payload[1], 81)
+  EXPECT_EQ(get_as<decltype(last_msg_->fwd_payload[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fwd_payload[1])),
+            81)
       << "incorrect value for fwd_payload[1], expected 81, is "
       << last_msg_->fwd_payload[1];
-  EXPECT_EQ(last_msg_->fwd_payload[2], 68)
+  EXPECT_EQ(get_as<decltype(last_msg_->fwd_payload[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fwd_payload[2])),
+            68)
       << "incorrect value for fwd_payload[2], expected 68, is "
       << last_msg_->fwd_payload[2];
-  EXPECT_EQ(last_msg_->fwd_payload[3], 47)
+  EXPECT_EQ(get_as<decltype(last_msg_->fwd_payload[3])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fwd_payload[3])),
+            47)
       << "incorrect value for fwd_payload[3], expected 47, is "
       << last_msg_->fwd_payload[3];
-  EXPECT_EQ(last_msg_->fwd_payload[4], 81)
+  EXPECT_EQ(get_as<decltype(last_msg_->fwd_payload[4])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fwd_payload[4])),
+            81)
       << "incorrect value for fwd_payload[4], expected 81, is "
       << last_msg_->fwd_payload[4];
-  EXPECT_EQ(last_msg_->fwd_payload[5], 103)
+  EXPECT_EQ(get_as<decltype(last_msg_->fwd_payload[5])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fwd_payload[5])),
+            103)
       << "incorrect value for fwd_payload[5], expected 103, is "
       << last_msg_->fwd_payload[5];
-  EXPECT_EQ(last_msg_->fwd_payload[6], 65)
+  EXPECT_EQ(get_as<decltype(last_msg_->fwd_payload[6])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fwd_payload[6])),
+            65)
       << "incorrect value for fwd_payload[6], expected 65, is "
       << last_msg_->fwd_payload[6];
-  EXPECT_EQ(last_msg_->fwd_payload[7], 69)
+  EXPECT_EQ(get_as<decltype(last_msg_->fwd_payload[7])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fwd_payload[7])),
+            69)
       << "incorrect value for fwd_payload[7], expected 69, is "
       << last_msg_->fwd_payload[7];
-  EXPECT_EQ(last_msg_->fwd_payload[8], 65)
+  EXPECT_EQ(get_as<decltype(last_msg_->fwd_payload[8])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fwd_payload[8])),
+            65)
       << "incorrect value for fwd_payload[8], expected 65, is "
       << last_msg_->fwd_payload[8];
-  EXPECT_EQ(last_msg_->fwd_payload[9], 65)
+  EXPECT_EQ(get_as<decltype(last_msg_->fwd_payload[9])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fwd_payload[9])),
+            65)
       << "incorrect value for fwd_payload[9], expected 65, is "
       << last_msg_->fwd_payload[9];
-  EXPECT_EQ(last_msg_->fwd_payload[10], 65)
+  EXPECT_EQ(get_as<decltype(last_msg_->fwd_payload[10])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fwd_payload[10])),
+            65)
       << "incorrect value for fwd_payload[10], expected 65, is "
       << last_msg_->fwd_payload[10];
-  EXPECT_EQ(last_msg_->fwd_payload[11], 65)
+  EXPECT_EQ(get_as<decltype(last_msg_->fwd_payload[11])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fwd_payload[11])),
+            65)
       << "incorrect value for fwd_payload[11], expected 65, is "
       << last_msg_->fwd_payload[11];
-  EXPECT_EQ(last_msg_->fwd_payload[12], 65)
+  EXPECT_EQ(get_as<decltype(last_msg_->fwd_payload[12])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fwd_payload[12])),
+            65)
       << "incorrect value for fwd_payload[12], expected 65, is "
       << last_msg_->fwd_payload[12];
-  EXPECT_EQ(last_msg_->fwd_payload[13], 69)
+  EXPECT_EQ(get_as<decltype(last_msg_->fwd_payload[13])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fwd_payload[13])),
+            69)
       << "incorrect value for fwd_payload[13], expected 69, is "
       << last_msg_->fwd_payload[13];
-  EXPECT_EQ(last_msg_->fwd_payload[14], 97)
+  EXPECT_EQ(get_as<decltype(last_msg_->fwd_payload[14])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fwd_payload[14])),
+            97)
       << "incorrect value for fwd_payload[14], expected 97, is "
       << last_msg_->fwd_payload[14];
-  EXPECT_EQ(last_msg_->fwd_payload[15], 103)
+  EXPECT_EQ(get_as<decltype(last_msg_->fwd_payload[15])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fwd_payload[15])),
+            103)
       << "incorrect value for fwd_payload[15], expected 103, is "
       << last_msg_->fwd_payload[15];
-  EXPECT_EQ(last_msg_->protocol, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->protocol)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->protocol)),
+            0)
       << "incorrect value for protocol, expected 0, is " << last_msg_->protocol;
-  EXPECT_EQ(last_msg_->source, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->source)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->source)),
+            0)
       << "incorrect value for source, expected 0, is " << last_msg_->source;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_logging_MsgLog.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_logging_MsgLog.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/logging.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_logging_MsgLog0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -128,7 +135,9 @@ TEST_F(Test_legacy_auto_check_sbp_logging_MsgLog0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 2314);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->level, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->level)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->level)),
+            6)
       << "incorrect value for level, expected 6, is " << last_msg_->level;
   {
     const char check_string[] = {

--- a/c/test/legacy/cpp/auto_check_sbp_logging_MsgPrintDep.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_logging_MsgPrintDep.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/logging.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_logging_MsgPrintDep0
     : public ::testing::Test,
       public sbp::LegacyState,

--- a/c/test/legacy/cpp/auto_check_sbp_mag_MsgMagRaw.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_mag_MsgMagRaw.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/mag.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_mag_MsgMagRaw0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -115,14 +122,24 @@ TEST_F(Test_legacy_auto_check_sbp_mag_MsgMagRaw0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->mag_x, 866)
+  EXPECT_EQ(get_as<decltype(last_msg_->mag_x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->mag_x)),
+            866)
       << "incorrect value for mag_x, expected 866, is " << last_msg_->mag_x;
-  EXPECT_EQ(last_msg_->mag_y, 742)
+  EXPECT_EQ(get_as<decltype(last_msg_->mag_y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->mag_y)),
+            742)
       << "incorrect value for mag_y, expected 742, is " << last_msg_->mag_y;
-  EXPECT_EQ(last_msg_->mag_z, -6802)
+  EXPECT_EQ(get_as<decltype(last_msg_->mag_z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->mag_z)),
+            -6802)
       << "incorrect value for mag_z, expected -6802, is " << last_msg_->mag_z;
-  EXPECT_EQ(last_msg_->tow, 3332301741)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            3332301741)
       << "incorrect value for tow, expected 3332301741, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->tow_f, 206)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow_f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow_f)),
+            206)
       << "incorrect value for tow_f, expected 206, is " << last_msg_->tow_f;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgAgeCorrections.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgAgeCorrections.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgAgeCorrections0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -111,8 +118,12 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgAgeCorrections0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->age, 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->age)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->age)),
+            30)
       << "incorrect value for age, expected 30, is " << last_msg_->age;
-  EXPECT_EQ(last_msg_->tow, 100)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            100)
       << "incorrect value for tow, expected 100, is " << last_msg_->tow;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgBaselineECEF.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgBaselineECEF.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgBaselineECEF0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -117,19 +124,33 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineECEF0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            14)
       << "incorrect value for n_sats, expected 14, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 326825000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326825000)
       << "incorrect value for tow, expected 326825000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, -1154410)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            -1154410)
       << "incorrect value for x, expected -1154410, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, 1327294)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            1327294)
       << "incorrect value for y, expected 1327294, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, 631798)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            631798)
       << "incorrect value for z, expected 631798, is " << last_msg_->z;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgBaselineECEF1
@@ -220,19 +241,33 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineECEF1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            15)
       << "incorrect value for n_sats, expected 15, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 326826000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326826000)
       << "incorrect value for tow, expected 326826000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, -1154232)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            -1154232)
       << "incorrect value for x, expected -1154232, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, 1327551)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            1327551)
       << "incorrect value for y, expected 1327551, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, 631434)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            631434)
       << "incorrect value for z, expected 631434, is " << last_msg_->z;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgBaselineECEF2
@@ -323,19 +358,33 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineECEF2, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            15)
       << "incorrect value for n_sats, expected 15, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 326827000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326827000)
       << "incorrect value for tow, expected 326827000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, -1154263)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            -1154263)
       << "incorrect value for x, expected -1154263, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, 1327541)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            1327541)
       << "incorrect value for y, expected 1327541, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, 631188)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            631188)
       << "incorrect value for z, expected 631188, is " << last_msg_->z;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgBaselineECEF3
@@ -426,19 +475,33 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineECEF3, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            15)
       << "incorrect value for n_sats, expected 15, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 326828000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326828000)
       << "incorrect value for tow, expected 326828000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, -1154628)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            -1154628)
       << "incorrect value for x, expected -1154628, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, 1327185)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            1327185)
       << "incorrect value for y, expected 1327185, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, 630849)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            630849)
       << "incorrect value for z, expected 630849, is " << last_msg_->z;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgBaselineECEF4
@@ -529,18 +592,32 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineECEF4, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            15)
       << "incorrect value for n_sats, expected 15, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 326829000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326829000)
       << "incorrect value for tow, expected 326829000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, -1154883)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            -1154883)
       << "incorrect value for x, expected -1154883, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, 1326941)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            1326941)
       << "incorrect value for y, expected 1326941, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, 630626)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            630626)
       << "incorrect value for z, expected 630626, is " << last_msg_->z;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgBaselineECEFDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgBaselineECEFDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgBaselineECEFDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -119,19 +126,33 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineECEFDepA0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            1)
       << "incorrect value for flags, expected 1, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            9)
       << "incorrect value for n_sats, expected 9, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 2567700)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2567700)
       << "incorrect value for tow, expected 2567700, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, -53227)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            -53227)
       << "incorrect value for x, expected -53227, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, -35532)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            -35532)
       << "incorrect value for y, expected -35532, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, -76840)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            -76840)
       << "incorrect value for z, expected -76840, is " << last_msg_->z;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgBaselineECEFDepA1
@@ -224,19 +245,33 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineECEFDepA1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            1)
       << "incorrect value for flags, expected 1, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            9)
       << "incorrect value for n_sats, expected 9, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 2567800)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2567800)
       << "incorrect value for tow, expected 2567800, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, -52934)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            -52934)
       << "incorrect value for x, expected -52934, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, -35791)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            -35791)
       << "incorrect value for y, expected -35791, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, -76922)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            -76922)
       << "incorrect value for z, expected -76922, is " << last_msg_->z;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgBaselineECEFDepA2
@@ -329,19 +364,33 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineECEFDepA2, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            1)
       << "incorrect value for flags, expected 1, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            9)
       << "incorrect value for n_sats, expected 9, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 2567900)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2567900)
       << "incorrect value for tow, expected 2567900, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, -52639)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            -52639)
       << "incorrect value for x, expected -52639, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, -36049)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            -36049)
       << "incorrect value for y, expected -36049, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, -77004)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            -77004)
       << "incorrect value for z, expected -77004, is " << last_msg_->z;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgBaselineECEFDepA3
@@ -434,19 +483,33 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineECEFDepA3, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            1)
       << "incorrect value for flags, expected 1, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            9)
       << "incorrect value for n_sats, expected 9, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 2568000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2568000)
       << "incorrect value for tow, expected 2568000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, -52344)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            -52344)
       << "incorrect value for x, expected -52344, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, -36307)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            -36307)
       << "incorrect value for y, expected -36307, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, -77084)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            -77084)
       << "incorrect value for z, expected -77084, is " << last_msg_->z;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgBaselineECEFDepA4
@@ -539,19 +602,33 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineECEFDepA4, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            1)
       << "incorrect value for flags, expected 1, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            9)
       << "incorrect value for n_sats, expected 9, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 2568100)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2568100)
       << "incorrect value for tow, expected 2568100, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, -52048)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            -52048)
       << "incorrect value for x, expected -52048, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, -36564)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            -36564)
       << "incorrect value for y, expected -36564, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, -77163)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            -77163)
       << "incorrect value for z, expected -77163, is " << last_msg_->z;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgBaselineECEFDepA5
@@ -644,19 +721,33 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineECEFDepA5, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            6)
       << "incorrect value for n_sats, expected 6, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407180700)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407180700)
       << "incorrect value for tow, expected 407180700, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, -6231)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            -6231)
       << "incorrect value for x, expected -6231, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, -12186)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            -12186)
       << "incorrect value for y, expected -12186, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, 7419)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            7419)
       << "incorrect value for z, expected 7419, is " << last_msg_->z;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgBaselineECEFDepA6
@@ -749,19 +840,33 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineECEFDepA6, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            6)
       << "incorrect value for n_sats, expected 6, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407180800)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407180800)
       << "incorrect value for tow, expected 407180800, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, -6231)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            -6231)
       << "incorrect value for x, expected -6231, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, -12185)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            -12185)
       << "incorrect value for y, expected -12185, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, 7420)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            7420)
       << "incorrect value for z, expected 7420, is " << last_msg_->z;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgBaselineECEFDepA7
@@ -854,19 +959,33 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineECEFDepA7, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            6)
       << "incorrect value for n_sats, expected 6, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407180900)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407180900)
       << "incorrect value for tow, expected 407180900, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, -8162)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            -8162)
       << "incorrect value for x, expected -8162, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, -18496)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            -18496)
       << "incorrect value for y, expected -18496, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, 13807)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            13807)
       << "incorrect value for z, expected 13807, is " << last_msg_->z;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgBaselineECEFDepA8
@@ -959,19 +1078,33 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineECEFDepA8, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            6)
       << "incorrect value for n_sats, expected 6, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407181000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407181000)
       << "incorrect value for tow, expected 407181000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, -8164)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            -8164)
       << "incorrect value for x, expected -8164, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, -18497)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            -18497)
       << "incorrect value for y, expected -18497, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, 13810)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            13810)
       << "incorrect value for z, expected 13810, is " << last_msg_->z;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgBaselineECEFDepA9
@@ -1064,19 +1197,33 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineECEFDepA9, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            6)
       << "incorrect value for n_sats, expected 6, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407181100)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407181100)
       << "incorrect value for tow, expected 407181100, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, -7400)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            -7400)
       << "incorrect value for x, expected -7400, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, -15591)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            -15591)
       << "incorrect value for y, expected -15591, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, 15257)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            15257)
       << "incorrect value for z, expected 15257, is " << last_msg_->z;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgBaselineECEFDepA10
@@ -1169,18 +1316,32 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineECEFDepA10, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            6)
       << "incorrect value for n_sats, expected 6, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407181200)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407181200)
       << "incorrect value for tow, expected 407181200, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, -7401)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            -7401)
       << "incorrect value for x, expected -7401, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, -15591)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            -15591)
       << "incorrect value for y, expected -15591, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, 15257)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            15257)
       << "incorrect value for z, expected 15257, is " << last_msg_->z;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgBaselineHeadingDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgBaselineHeadingDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgBaselineHeadingDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -116,13 +123,21 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineHeadingDepA0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 52860);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 58)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            58)
       << "incorrect value for flags, expected 58, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->heading, 3411152452)
+  EXPECT_EQ(get_as<decltype(last_msg_->heading)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->heading)),
+            3411152452)
       << "incorrect value for heading, expected 3411152452, is "
       << last_msg_->heading;
-  EXPECT_EQ(last_msg_->n_sats, 186)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            186)
       << "incorrect value for n_sats, expected 186, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 2958585170)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2958585170)
       << "incorrect value for tow, expected 2958585170, is " << last_msg_->tow;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgBaselineNED.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgBaselineNED.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgBaselineNED0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -118,22 +125,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineNED0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, 32153)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            32153)
       << "incorrect value for d, expected 32153, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, -1681229)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            -1681229)
       << "incorrect value for e, expected -1681229, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, 816073)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            816073)
       << "incorrect value for n, expected 816073, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            14)
       << "incorrect value for n_sats, expected 14, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 326825000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326825000)
       << "incorrect value for tow, expected 326825000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -226,22 +249,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineNED1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, 32622)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            32622)
       << "incorrect value for d, expected 32622, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, -1681214)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            -1681214)
       << "incorrect value for e, expected -1681214, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, 815970)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            815970)
       << "incorrect value for n, expected 815970, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            15)
       << "incorrect value for n_sats, expected 15, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 326826000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326826000)
       << "incorrect value for tow, expected 326826000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -334,22 +373,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineNED2, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, 32750)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            32750)
       << "incorrect value for d, expected 32750, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, -1681235)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            -1681235)
       << "incorrect value for e, expected -1681235, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, 815759)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            815759)
       << "incorrect value for n, expected 815759, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            15)
       << "incorrect value for n_sats, expected 15, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 326827000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326827000)
       << "incorrect value for tow, expected 326827000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -442,22 +497,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineNED3, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, 32559)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            32559)
       << "incorrect value for d, expected 32559, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, -1681357)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            -1681357)
       << "incorrect value for e, expected -1681357, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, 815190)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            815190)
       << "incorrect value for n, expected 815190, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            15)
       << "incorrect value for n_sats, expected 15, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 326828000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326828000)
       << "incorrect value for tow, expected 326828000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -550,22 +621,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineNED4, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, 32421)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            32421)
       << "incorrect value for d, expected 32421, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, -1681444)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            -1681444)
       << "incorrect value for e, expected -1681444, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, 814806)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            814806)
       << "incorrect value for n, expected 814806, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            15)
       << "incorrect value for n_sats, expected 15, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 326829000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326829000)
       << "incorrect value for tow, expected 326829000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgBaselineNEDDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgBaselineNEDDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgBaselineNEDDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -120,22 +127,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineNEDDepA0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            0)
       << "incorrect value for d, expected 0, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, -26134)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            -26134)
       << "incorrect value for e, expected -26134, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            1)
       << "incorrect value for flags, expected 1, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, -96525)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            -96525)
       << "incorrect value for n, expected -96525, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            9)
       << "incorrect value for n_sats, expected 9, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 2567700)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2567700)
       << "incorrect value for tow, expected 2567700, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -230,22 +253,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineNEDDepA1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            0)
       << "incorrect value for d, expected 0, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, -25747)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            -25747)
       << "incorrect value for e, expected -25747, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            1)
       << "incorrect value for flags, expected 1, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, -96629)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            -96629)
       << "incorrect value for n, expected -96629, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            9)
       << "incorrect value for n_sats, expected 9, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 2567800)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2567800)
       << "incorrect value for tow, expected 2567800, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -340,22 +379,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineNEDDepA2, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            0)
       << "incorrect value for d, expected 0, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, -25360)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            -25360)
       << "incorrect value for e, expected -25360, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            1)
       << "incorrect value for flags, expected 1, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, -96731)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            -96731)
       << "incorrect value for n, expected -96731, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            9)
       << "incorrect value for n_sats, expected 9, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 2567900)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2567900)
       << "incorrect value for tow, expected 2567900, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -450,22 +505,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineNEDDepA3, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            0)
       << "incorrect value for d, expected 0, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, -24973)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            -24973)
       << "incorrect value for e, expected -24973, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            1)
       << "incorrect value for flags, expected 1, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, -96831)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            -96831)
       << "incorrect value for n, expected -96831, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            9)
       << "incorrect value for n_sats, expected 9, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 2568000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2568000)
       << "incorrect value for tow, expected 2568000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -560,22 +631,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineNEDDepA4, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            0)
       << "incorrect value for d, expected 0, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, -24586)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            -24586)
       << "incorrect value for e, expected -24586, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            1)
       << "incorrect value for flags, expected 1, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, -96931)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            -96931)
       << "incorrect value for n, expected -96931, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            9)
       << "incorrect value for n_sats, expected 9, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 2568100)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2568100)
       << "incorrect value for tow, expected 2568100, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -670,22 +757,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineNEDDepA5, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, -15325)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            -15325)
       << "incorrect value for d, expected -15325, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, 1265)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            1265)
       << "incorrect value for e, expected 1265, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, -2430)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            -2430)
       << "incorrect value for n, expected -2430, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            6)
       << "incorrect value for n_sats, expected 6, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407180700)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407180700)
       << "incorrect value for tow, expected 407180700, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -780,22 +883,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineNEDDepA6, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, -15325)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            -15325)
       << "incorrect value for d, expected -15325, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, 1265)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            1265)
       << "incorrect value for e, expected 1265, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, -2430)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            -2430)
       << "incorrect value for n, expected -2430, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            6)
       << "incorrect value for n_sats, expected 6, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407180800)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407180800)
       << "incorrect value for tow, expected 407180800, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -890,22 +1009,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineNEDDepA7, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, -24263)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            -24263)
       << "incorrect value for d, expected -24263, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, 3015)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            3015)
       << "incorrect value for e, expected 3015, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, -1248)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            -1248)
       << "incorrect value for n, expected -1248, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            6)
       << "incorrect value for n_sats, expected 6, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407180900)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407180900)
       << "incorrect value for tow, expected 407180900, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -1000,22 +1135,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineNEDDepA8, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, -24266)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            -24266)
       << "incorrect value for d, expected -24266, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, 3015)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            3015)
       << "incorrect value for e, expected 3015, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, -1247)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            -1247)
       << "incorrect value for n, expected -1247, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            6)
       << "incorrect value for n_sats, expected 6, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407181000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407181000)
       << "incorrect value for tow, expected 407181000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -1110,22 +1261,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineNEDDepA9, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, -22880)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            -22880)
       << "incorrect value for d, expected -22880, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, 2103)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            2103)
       << "incorrect value for e, expected 2103, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, 1646)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            1646)
       << "incorrect value for n, expected 1646, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            6)
       << "incorrect value for n_sats, expected 6, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407181100)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407181100)
       << "incorrect value for tow, expected 407181100, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -1220,22 +1387,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgBaselineNEDDepA10, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, -22880)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            -22880)
       << "incorrect value for d, expected -22880, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, 2102)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            2102)
       << "incorrect value for e, expected 2102, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, 1646)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            1646)
       << "incorrect value for n, expected 1646, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            6)
       << "incorrect value for n_sats, expected 6, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407181200)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407181200)
       << "incorrect value for tow, expected 407181200, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgDops.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgDops.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgDops0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -117,18 +124,32 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgDops0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->gdop, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->gdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->gdop)),
+            2)
       << "incorrect value for gdop, expected 2, is " << last_msg_->gdop;
-  EXPECT_EQ(last_msg_->hdop, 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->hdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->hdop)),
+            5)
       << "incorrect value for hdop, expected 5, is " << last_msg_->hdop;
-  EXPECT_EQ(last_msg_->pdop, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->pdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pdop)),
+            6)
       << "incorrect value for pdop, expected 6, is " << last_msg_->pdop;
-  EXPECT_EQ(last_msg_->tdop, 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->tdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tdop)),
+            5)
       << "incorrect value for tdop, expected 5, is " << last_msg_->tdop;
-  EXPECT_EQ(last_msg_->tow, 100)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            100)
       << "incorrect value for tow, expected 100, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->vdop, 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->vdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->vdop)),
+            5)
       << "incorrect value for vdop, expected 5, is " << last_msg_->vdop;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgDopsDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgDopsDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgDopsDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -116,17 +123,29 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgDopsDepA0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->gdop, 180)
+  EXPECT_EQ(get_as<decltype(last_msg_->gdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->gdop)),
+            180)
       << "incorrect value for gdop, expected 180, is " << last_msg_->gdop;
-  EXPECT_EQ(last_msg_->hdop, 160)
+  EXPECT_EQ(get_as<decltype(last_msg_->hdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->hdop)),
+            160)
       << "incorrect value for hdop, expected 160, is " << last_msg_->hdop;
-  EXPECT_EQ(last_msg_->pdop, 190)
+  EXPECT_EQ(get_as<decltype(last_msg_->pdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pdop)),
+            190)
       << "incorrect value for pdop, expected 190, is " << last_msg_->pdop;
-  EXPECT_EQ(last_msg_->tdop, 170)
+  EXPECT_EQ(get_as<decltype(last_msg_->tdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tdop)),
+            170)
       << "incorrect value for tdop, expected 170, is " << last_msg_->tdop;
-  EXPECT_EQ(last_msg_->tow, 2568200)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2568200)
       << "incorrect value for tow, expected 2568200, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->vdop, 150)
+  EXPECT_EQ(get_as<decltype(last_msg_->vdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->vdop)),
+            150)
       << "incorrect value for vdop, expected 150, is " << last_msg_->vdop;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgDopsDepA1
@@ -216,17 +235,29 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgDopsDepA1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->gdop, 180)
+  EXPECT_EQ(get_as<decltype(last_msg_->gdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->gdop)),
+            180)
       << "incorrect value for gdop, expected 180, is " << last_msg_->gdop;
-  EXPECT_EQ(last_msg_->hdop, 160)
+  EXPECT_EQ(get_as<decltype(last_msg_->hdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->hdop)),
+            160)
       << "incorrect value for hdop, expected 160, is " << last_msg_->hdop;
-  EXPECT_EQ(last_msg_->pdop, 190)
+  EXPECT_EQ(get_as<decltype(last_msg_->pdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pdop)),
+            190)
       << "incorrect value for pdop, expected 190, is " << last_msg_->pdop;
-  EXPECT_EQ(last_msg_->tdop, 170)
+  EXPECT_EQ(get_as<decltype(last_msg_->tdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tdop)),
+            170)
       << "incorrect value for tdop, expected 170, is " << last_msg_->tdop;
-  EXPECT_EQ(last_msg_->tow, 2569200)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2569200)
       << "incorrect value for tow, expected 2569200, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->vdop, 150)
+  EXPECT_EQ(get_as<decltype(last_msg_->vdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->vdop)),
+            150)
       << "incorrect value for vdop, expected 150, is " << last_msg_->vdop;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgDopsDepA2
@@ -316,17 +347,29 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgDopsDepA2, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->gdop, 180)
+  EXPECT_EQ(get_as<decltype(last_msg_->gdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->gdop)),
+            180)
       << "incorrect value for gdop, expected 180, is " << last_msg_->gdop;
-  EXPECT_EQ(last_msg_->hdop, 160)
+  EXPECT_EQ(get_as<decltype(last_msg_->hdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->hdop)),
+            160)
       << "incorrect value for hdop, expected 160, is " << last_msg_->hdop;
-  EXPECT_EQ(last_msg_->pdop, 190)
+  EXPECT_EQ(get_as<decltype(last_msg_->pdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pdop)),
+            190)
       << "incorrect value for pdop, expected 190, is " << last_msg_->pdop;
-  EXPECT_EQ(last_msg_->tdop, 170)
+  EXPECT_EQ(get_as<decltype(last_msg_->tdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tdop)),
+            170)
       << "incorrect value for tdop, expected 170, is " << last_msg_->tdop;
-  EXPECT_EQ(last_msg_->tow, 2570200)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2570200)
       << "incorrect value for tow, expected 2570200, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->vdop, 150)
+  EXPECT_EQ(get_as<decltype(last_msg_->vdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->vdop)),
+            150)
       << "incorrect value for vdop, expected 150, is " << last_msg_->vdop;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgDopsDepA3
@@ -416,17 +459,29 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgDopsDepA3, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->gdop, 247)
+  EXPECT_EQ(get_as<decltype(last_msg_->gdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->gdop)),
+            247)
       << "incorrect value for gdop, expected 247, is " << last_msg_->gdop;
-  EXPECT_EQ(last_msg_->hdop, 273)
+  EXPECT_EQ(get_as<decltype(last_msg_->hdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->hdop)),
+            273)
       << "incorrect value for hdop, expected 273, is " << last_msg_->hdop;
-  EXPECT_EQ(last_msg_->pdop, 215)
+  EXPECT_EQ(get_as<decltype(last_msg_->pdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pdop)),
+            215)
       << "incorrect value for pdop, expected 215, is " << last_msg_->pdop;
-  EXPECT_EQ(last_msg_->tdop, 123)
+  EXPECT_EQ(get_as<decltype(last_msg_->tdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tdop)),
+            123)
       << "incorrect value for tdop, expected 123, is " << last_msg_->tdop;
-  EXPECT_EQ(last_msg_->tow, 407084500)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407084500)
       << "incorrect value for tow, expected 407084500, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->vdop, 44)
+  EXPECT_EQ(get_as<decltype(last_msg_->vdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->vdop)),
+            44)
       << "incorrect value for vdop, expected 44, is " << last_msg_->vdop;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgDopsDepA4
@@ -516,17 +571,29 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgDopsDepA4, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->gdop, 65535)
+  EXPECT_EQ(get_as<decltype(last_msg_->gdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->gdop)),
+            65535)
       << "incorrect value for gdop, expected 65535, is " << last_msg_->gdop;
-  EXPECT_EQ(last_msg_->hdop, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->hdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->hdop)),
+            0)
       << "incorrect value for hdop, expected 0, is " << last_msg_->hdop;
-  EXPECT_EQ(last_msg_->pdop, 65535)
+  EXPECT_EQ(get_as<decltype(last_msg_->pdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pdop)),
+            65535)
       << "incorrect value for pdop, expected 65535, is " << last_msg_->pdop;
-  EXPECT_EQ(last_msg_->tdop, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->tdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tdop)),
+            0)
       << "incorrect value for tdop, expected 0, is " << last_msg_->tdop;
-  EXPECT_EQ(last_msg_->tow, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            0)
       << "incorrect value for tow, expected 0, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->vdop, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->vdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->vdop)),
+            0)
       << "incorrect value for vdop, expected 0, is " << last_msg_->vdop;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgDopsDepA5
@@ -616,17 +683,29 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgDopsDepA5, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->gdop, 348)
+  EXPECT_EQ(get_as<decltype(last_msg_->gdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->gdop)),
+            348)
       << "incorrect value for gdop, expected 348, is " << last_msg_->gdop;
-  EXPECT_EQ(last_msg_->hdop, 637)
+  EXPECT_EQ(get_as<decltype(last_msg_->hdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->hdop)),
+            637)
       << "incorrect value for hdop, expected 637, is " << last_msg_->hdop;
-  EXPECT_EQ(last_msg_->pdop, 312)
+  EXPECT_EQ(get_as<decltype(last_msg_->pdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pdop)),
+            312)
       << "incorrect value for pdop, expected 312, is " << last_msg_->pdop;
-  EXPECT_EQ(last_msg_->tdop, 155)
+  EXPECT_EQ(get_as<decltype(last_msg_->tdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tdop)),
+            155)
       << "incorrect value for tdop, expected 155, is " << last_msg_->tdop;
-  EXPECT_EQ(last_msg_->tow, 407152000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407152000)
       << "incorrect value for tow, expected 407152000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->vdop, 113)
+  EXPECT_EQ(get_as<decltype(last_msg_->vdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->vdop)),
+            113)
       << "incorrect value for vdop, expected 113, is " << last_msg_->vdop;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgDopsDepA6
@@ -716,17 +795,29 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgDopsDepA6, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->gdop, 348)
+  EXPECT_EQ(get_as<decltype(last_msg_->gdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->gdop)),
+            348)
       << "incorrect value for gdop, expected 348, is " << last_msg_->gdop;
-  EXPECT_EQ(last_msg_->hdop, 637)
+  EXPECT_EQ(get_as<decltype(last_msg_->hdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->hdop)),
+            637)
       << "incorrect value for hdop, expected 637, is " << last_msg_->hdop;
-  EXPECT_EQ(last_msg_->pdop, 311)
+  EXPECT_EQ(get_as<decltype(last_msg_->pdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pdop)),
+            311)
       << "incorrect value for pdop, expected 311, is " << last_msg_->pdop;
-  EXPECT_EQ(last_msg_->tdop, 155)
+  EXPECT_EQ(get_as<decltype(last_msg_->tdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tdop)),
+            155)
       << "incorrect value for tdop, expected 155, is " << last_msg_->tdop;
-  EXPECT_EQ(last_msg_->tow, 407153000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407153000)
       << "incorrect value for tow, expected 407153000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->vdop, 113)
+  EXPECT_EQ(get_as<decltype(last_msg_->vdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->vdop)),
+            113)
       << "incorrect value for vdop, expected 113, is " << last_msg_->vdop;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgDopsDepA7
@@ -816,17 +907,29 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgDopsDepA7, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->gdop, 348)
+  EXPECT_EQ(get_as<decltype(last_msg_->gdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->gdop)),
+            348)
       << "incorrect value for gdop, expected 348, is " << last_msg_->gdop;
-  EXPECT_EQ(last_msg_->hdop, 637)
+  EXPECT_EQ(get_as<decltype(last_msg_->hdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->hdop)),
+            637)
       << "incorrect value for hdop, expected 637, is " << last_msg_->hdop;
-  EXPECT_EQ(last_msg_->pdop, 311)
+  EXPECT_EQ(get_as<decltype(last_msg_->pdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pdop)),
+            311)
       << "incorrect value for pdop, expected 311, is " << last_msg_->pdop;
-  EXPECT_EQ(last_msg_->tdop, 155)
+  EXPECT_EQ(get_as<decltype(last_msg_->tdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tdop)),
+            155)
       << "incorrect value for tdop, expected 155, is " << last_msg_->tdop;
-  EXPECT_EQ(last_msg_->tow, 407154000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407154000)
       << "incorrect value for tow, expected 407154000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->vdop, 112)
+  EXPECT_EQ(get_as<decltype(last_msg_->vdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->vdop)),
+            112)
       << "incorrect value for vdop, expected 112, is " << last_msg_->vdop;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgDopsDepA8
@@ -916,16 +1019,28 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgDopsDepA8, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->gdop, 348)
+  EXPECT_EQ(get_as<decltype(last_msg_->gdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->gdop)),
+            348)
       << "incorrect value for gdop, expected 348, is " << last_msg_->gdop;
-  EXPECT_EQ(last_msg_->hdop, 637)
+  EXPECT_EQ(get_as<decltype(last_msg_->hdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->hdop)),
+            637)
       << "incorrect value for hdop, expected 637, is " << last_msg_->hdop;
-  EXPECT_EQ(last_msg_->pdop, 311)
+  EXPECT_EQ(get_as<decltype(last_msg_->pdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pdop)),
+            311)
       << "incorrect value for pdop, expected 311, is " << last_msg_->pdop;
-  EXPECT_EQ(last_msg_->tdop, 155)
+  EXPECT_EQ(get_as<decltype(last_msg_->tdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tdop)),
+            155)
       << "incorrect value for tdop, expected 155, is " << last_msg_->tdop;
-  EXPECT_EQ(last_msg_->tow, 407155000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407155000)
       << "incorrect value for tow, expected 407155000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->vdop, 112)
+  EXPECT_EQ(get_as<decltype(last_msg_->vdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->vdop)),
+            112)
       << "incorrect value for vdop, expected 112, is " << last_msg_->vdop;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgGPSTime.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgGPSTime.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgGPSTime0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -114,14 +121,22 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgGPSTime0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->ns_residual, 166900)
+  EXPECT_EQ(get_as<decltype(last_msg_->ns_residual)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ns_residual)),
+            166900)
       << "incorrect value for ns_residual, expected 166900, is "
       << last_msg_->ns_residual;
-  EXPECT_EQ(last_msg_->tow, 326825000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326825000)
       << "incorrect value for tow, expected 326825000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->wn, 1920)
+  EXPECT_EQ(get_as<decltype(last_msg_->wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->wn)),
+            1920)
       << "incorrect value for wn, expected 1920, is " << last_msg_->wn;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgGPSTime1
@@ -209,14 +224,22 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgGPSTime1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->ns_residual, 256638)
+  EXPECT_EQ(get_as<decltype(last_msg_->ns_residual)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ns_residual)),
+            256638)
       << "incorrect value for ns_residual, expected 256638, is "
       << last_msg_->ns_residual;
-  EXPECT_EQ(last_msg_->tow, 326825500)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326825500)
       << "incorrect value for tow, expected 326825500, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->wn, 1920)
+  EXPECT_EQ(get_as<decltype(last_msg_->wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->wn)),
+            1920)
       << "incorrect value for wn, expected 1920, is " << last_msg_->wn;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgGPSTime2
@@ -304,14 +327,22 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgGPSTime2, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->ns_residual, 265345)
+  EXPECT_EQ(get_as<decltype(last_msg_->ns_residual)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ns_residual)),
+            265345)
       << "incorrect value for ns_residual, expected 265345, is "
       << last_msg_->ns_residual;
-  EXPECT_EQ(last_msg_->tow, 326826000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326826000)
       << "incorrect value for tow, expected 326826000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->wn, 1920)
+  EXPECT_EQ(get_as<decltype(last_msg_->wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->wn)),
+            1920)
       << "incorrect value for wn, expected 1920, is " << last_msg_->wn;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgGPSTime3
@@ -399,14 +430,22 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgGPSTime3, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->ns_residual, 314505)
+  EXPECT_EQ(get_as<decltype(last_msg_->ns_residual)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ns_residual)),
+            314505)
       << "incorrect value for ns_residual, expected 314505, is "
       << last_msg_->ns_residual;
-  EXPECT_EQ(last_msg_->tow, 326826500)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326826500)
       << "incorrect value for tow, expected 326826500, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->wn, 1920)
+  EXPECT_EQ(get_as<decltype(last_msg_->wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->wn)),
+            1920)
       << "incorrect value for wn, expected 1920, is " << last_msg_->wn;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgGPSTime4
@@ -494,13 +533,21 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgGPSTime4, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->ns_residual, 362933)
+  EXPECT_EQ(get_as<decltype(last_msg_->ns_residual)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ns_residual)),
+            362933)
       << "incorrect value for ns_residual, expected 362933, is "
       << last_msg_->ns_residual;
-  EXPECT_EQ(last_msg_->tow, 326827000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326827000)
       << "incorrect value for tow, expected 326827000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->wn, 1920)
+  EXPECT_EQ(get_as<decltype(last_msg_->wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->wn)),
+            1920)
       << "incorrect value for wn, expected 1920, is " << last_msg_->wn;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgGPSTimeDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgGPSTimeDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgGPSTimeDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -113,14 +120,22 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgGPSTimeDepA0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->ns_residual, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->ns_residual)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ns_residual)),
+            0)
       << "incorrect value for ns_residual, expected 0, is "
       << last_msg_->ns_residual;
-  EXPECT_EQ(last_msg_->tow, 2567800)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2567800)
       << "incorrect value for tow, expected 2567800, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->wn, 1787)
+  EXPECT_EQ(get_as<decltype(last_msg_->wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->wn)),
+            1787)
       << "incorrect value for wn, expected 1787, is " << last_msg_->wn;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgGPSTimeDepA1
@@ -207,14 +222,22 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgGPSTimeDepA1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->ns_residual, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->ns_residual)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ns_residual)),
+            0)
       << "incorrect value for ns_residual, expected 0, is "
       << last_msg_->ns_residual;
-  EXPECT_EQ(last_msg_->tow, 2567900)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2567900)
       << "incorrect value for tow, expected 2567900, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->wn, 1787)
+  EXPECT_EQ(get_as<decltype(last_msg_->wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->wn)),
+            1787)
       << "incorrect value for wn, expected 1787, is " << last_msg_->wn;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgGPSTimeDepA2
@@ -301,14 +324,22 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgGPSTimeDepA2, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->ns_residual, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->ns_residual)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ns_residual)),
+            0)
       << "incorrect value for ns_residual, expected 0, is "
       << last_msg_->ns_residual;
-  EXPECT_EQ(last_msg_->tow, 2568000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2568000)
       << "incorrect value for tow, expected 2568000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->wn, 1787)
+  EXPECT_EQ(get_as<decltype(last_msg_->wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->wn)),
+            1787)
       << "incorrect value for wn, expected 1787, is " << last_msg_->wn;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgGPSTimeDepA3
@@ -395,14 +426,22 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgGPSTimeDepA3, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->ns_residual, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->ns_residual)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ns_residual)),
+            0)
       << "incorrect value for ns_residual, expected 0, is "
       << last_msg_->ns_residual;
-  EXPECT_EQ(last_msg_->tow, 2568100)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2568100)
       << "incorrect value for tow, expected 2568100, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->wn, 1787)
+  EXPECT_EQ(get_as<decltype(last_msg_->wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->wn)),
+            1787)
       << "incorrect value for wn, expected 1787, is " << last_msg_->wn;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgGPSTimeDepA4
@@ -489,14 +528,22 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgGPSTimeDepA4, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->ns_residual, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->ns_residual)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ns_residual)),
+            0)
       << "incorrect value for ns_residual, expected 0, is "
       << last_msg_->ns_residual;
-  EXPECT_EQ(last_msg_->tow, 2568200)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2568200)
       << "incorrect value for tow, expected 2568200, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->wn, 1787)
+  EXPECT_EQ(get_as<decltype(last_msg_->wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->wn)),
+            1787)
       << "incorrect value for wn, expected 1787, is " << last_msg_->wn;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgGPSTimeDepA5
@@ -584,14 +631,22 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgGPSTimeDepA5, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->ns_residual, -224401)
+  EXPECT_EQ(get_as<decltype(last_msg_->ns_residual)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ns_residual)),
+            -224401)
       << "incorrect value for ns_residual, expected -224401, is "
       << last_msg_->ns_residual;
-  EXPECT_EQ(last_msg_->tow, 407084500)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407084500)
       << "incorrect value for tow, expected 407084500, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->wn, 1838)
+  EXPECT_EQ(get_as<decltype(last_msg_->wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->wn)),
+            1838)
       << "incorrect value for wn, expected 1838, is " << last_msg_->wn;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgGPSTimeDepA6
@@ -678,14 +733,22 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgGPSTimeDepA6, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->ns_residual, 223085)
+  EXPECT_EQ(get_as<decltype(last_msg_->ns_residual)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ns_residual)),
+            223085)
       << "incorrect value for ns_residual, expected 223085, is "
       << last_msg_->ns_residual;
-  EXPECT_EQ(last_msg_->tow, 407084600)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407084600)
       << "incorrect value for tow, expected 407084600, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->wn, 1838)
+  EXPECT_EQ(get_as<decltype(last_msg_->wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->wn)),
+            1838)
       << "incorrect value for wn, expected 1838, is " << last_msg_->wn;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgGPSTimeDepA7
@@ -773,14 +836,22 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgGPSTimeDepA7, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->ns_residual, -222999)
+  EXPECT_EQ(get_as<decltype(last_msg_->ns_residual)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ns_residual)),
+            -222999)
       << "incorrect value for ns_residual, expected -222999, is "
       << last_msg_->ns_residual;
-  EXPECT_EQ(last_msg_->tow, 407084700)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407084700)
       << "incorrect value for tow, expected 407084700, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->wn, 1838)
+  EXPECT_EQ(get_as<decltype(last_msg_->wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->wn)),
+            1838)
       << "incorrect value for wn, expected 1838, is " << last_msg_->wn;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgGPSTimeDepA8
@@ -867,14 +938,22 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgGPSTimeDepA8, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->ns_residual, 236272)
+  EXPECT_EQ(get_as<decltype(last_msg_->ns_residual)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ns_residual)),
+            236272)
       << "incorrect value for ns_residual, expected 236272, is "
       << last_msg_->ns_residual;
-  EXPECT_EQ(last_msg_->tow, 407084800)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407084800)
       << "incorrect value for tow, expected 407084800, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->wn, 1838)
+  EXPECT_EQ(get_as<decltype(last_msg_->wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->wn)),
+            1838)
       << "incorrect value for wn, expected 1838, is " << last_msg_->wn;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgGPSTimeDepA9
@@ -962,14 +1041,22 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgGPSTimeDepA9, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->ns_residual, -236144)
+  EXPECT_EQ(get_as<decltype(last_msg_->ns_residual)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ns_residual)),
+            -236144)
       << "incorrect value for ns_residual, expected -236144, is "
       << last_msg_->ns_residual;
-  EXPECT_EQ(last_msg_->tow, 407084900)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407084900)
       << "incorrect value for tow, expected 407084900, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->wn, 1838)
+  EXPECT_EQ(get_as<decltype(last_msg_->wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->wn)),
+            1838)
       << "incorrect value for wn, expected 1838, is " << last_msg_->wn;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgGPSTimeDepA10
@@ -1057,13 +1144,21 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgGPSTimeDepA10, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->ns_residual, -334131)
+  EXPECT_EQ(get_as<decltype(last_msg_->ns_residual)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ns_residual)),
+            -334131)
       << "incorrect value for ns_residual, expected -334131, is "
       << last_msg_->ns_residual;
-  EXPECT_EQ(last_msg_->tow, 407151150)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407151150)
       << "incorrect value for tow, expected 407151150, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->wn, 1838)
+  EXPECT_EQ(get_as<decltype(last_msg_->wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->wn)),
+            1838)
       << "incorrect value for wn, expected 1838, is " << last_msg_->wn;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgGPSTimeGNSS.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgGPSTimeGNSS.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgGPSTimeGNSS0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -114,14 +121,22 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgGPSTimeGNSS0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->ns_residual, 166900)
+  EXPECT_EQ(get_as<decltype(last_msg_->ns_residual)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ns_residual)),
+            166900)
       << "incorrect value for ns_residual, expected 166900, is "
       << last_msg_->ns_residual;
-  EXPECT_EQ(last_msg_->tow, 326825000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326825000)
       << "incorrect value for tow, expected 326825000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->wn, 1920)
+  EXPECT_EQ(get_as<decltype(last_msg_->wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->wn)),
+            1920)
       << "incorrect value for wn, expected 1920, is " << last_msg_->wn;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgGPSTimeGNSS1
@@ -209,14 +224,22 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgGPSTimeGNSS1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->ns_residual, 256638)
+  EXPECT_EQ(get_as<decltype(last_msg_->ns_residual)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ns_residual)),
+            256638)
       << "incorrect value for ns_residual, expected 256638, is "
       << last_msg_->ns_residual;
-  EXPECT_EQ(last_msg_->tow, 326825500)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326825500)
       << "incorrect value for tow, expected 326825500, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->wn, 1920)
+  EXPECT_EQ(get_as<decltype(last_msg_->wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->wn)),
+            1920)
       << "incorrect value for wn, expected 1920, is " << last_msg_->wn;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgGPSTimeGNSS2
@@ -304,14 +327,22 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgGPSTimeGNSS2, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->ns_residual, 265345)
+  EXPECT_EQ(get_as<decltype(last_msg_->ns_residual)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ns_residual)),
+            265345)
       << "incorrect value for ns_residual, expected 265345, is "
       << last_msg_->ns_residual;
-  EXPECT_EQ(last_msg_->tow, 326826000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326826000)
       << "incorrect value for tow, expected 326826000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->wn, 1920)
+  EXPECT_EQ(get_as<decltype(last_msg_->wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->wn)),
+            1920)
       << "incorrect value for wn, expected 1920, is " << last_msg_->wn;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgGPSTimeGNSS3
@@ -399,14 +430,22 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgGPSTimeGNSS3, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->ns_residual, 314505)
+  EXPECT_EQ(get_as<decltype(last_msg_->ns_residual)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ns_residual)),
+            314505)
       << "incorrect value for ns_residual, expected 314505, is "
       << last_msg_->ns_residual;
-  EXPECT_EQ(last_msg_->tow, 326826500)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326826500)
       << "incorrect value for tow, expected 326826500, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->wn, 1920)
+  EXPECT_EQ(get_as<decltype(last_msg_->wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->wn)),
+            1920)
       << "incorrect value for wn, expected 1920, is " << last_msg_->wn;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgGPSTimeGNSS4
@@ -494,13 +533,21 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgGPSTimeGNSS4, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->ns_residual, 362933)
+  EXPECT_EQ(get_as<decltype(last_msg_->ns_residual)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ns_residual)),
+            362933)
       << "incorrect value for ns_residual, expected 362933, is "
       << last_msg_->ns_residual;
-  EXPECT_EQ(last_msg_->tow, 326827000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326827000)
       << "incorrect value for tow, expected 326827000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->wn, 1920)
+  EXPECT_EQ(get_as<decltype(last_msg_->wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->wn)),
+            1920)
       << "incorrect value for wn, expected 1920, is " << last_msg_->wn;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgPosECEF.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgPosECEF.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgPosECEF0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -118,13 +125,21 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosECEF0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            2)
       << "incorrect value for flags, expected 2, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            15)
       << "incorrect value for n_sats, expected 15, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 326826000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326826000)
       << "incorrect value for tow, expected 326826000, is " << last_msg_->tow;
   EXPECT_LT((last_msg_->x * 100 - -2684269.03266 * 100), 0.05)
       << "incorrect value for x, expected -2684269.03266, is " << last_msg_->x;
@@ -222,13 +237,21 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosECEF1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            2)
       << "incorrect value for flags, expected 2, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            15)
       << "incorrect value for n_sats, expected 15, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 326827000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326827000)
       << "incorrect value for tow, expected 326827000, is " << last_msg_->tow;
   EXPECT_LT((last_msg_->x * 100 - -2684269.06425 * 100), 0.05)
       << "incorrect value for x, expected -2684269.06425, is " << last_msg_->x;
@@ -326,13 +349,21 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosECEF2, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            2)
       << "incorrect value for flags, expected 2, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            15)
       << "incorrect value for n_sats, expected 15, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 326828000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326828000)
       << "incorrect value for tow, expected 326828000, is " << last_msg_->tow;
   EXPECT_LT((last_msg_->x * 100 - -2684269.42928 * 100), 0.05)
       << "incorrect value for x, expected -2684269.42928, is " << last_msg_->x;
@@ -430,13 +461,21 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosECEF3, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            2)
       << "incorrect value for flags, expected 2, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            15)
       << "incorrect value for n_sats, expected 15, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 326829000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326829000)
       << "incorrect value for tow, expected 326829000, is " << last_msg_->tow;
   EXPECT_LT((last_msg_->x * 100 - -2684269.68374 * 100), 0.05)
       << "incorrect value for x, expected -2684269.68374, is " << last_msg_->x;

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgPosECEFCov.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgPosECEFCov.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgPosECEFCov0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -136,11 +143,17 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosECEFCov0, Test) {
       << "incorrect value for cov_y_z, expected 8.0, is " << last_msg_->cov_y_z;
   EXPECT_LT((last_msg_->cov_z_z * 100 - 5.0 * 100), 0.05)
       << "incorrect value for cov_z_z, expected 5.0, is " << last_msg_->cov_z_z;
-  EXPECT_EQ(last_msg_->flags, 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            5)
       << "incorrect value for flags, expected 5, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            4)
       << "incorrect value for n_sats, expected 4, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            7)
       << "incorrect value for tow, expected 7, is " << last_msg_->tow;
   EXPECT_LT((last_msg_->x * 100 - 6.0 * 100), 0.05)
       << "incorrect value for x, expected 6.0, is " << last_msg_->x;

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgPosECEFCovGNSS.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgPosECEFCovGNSS.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgPosECEFCovGNSS0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -145,11 +152,17 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosECEFCovGNSS0, Test) {
   EXPECT_LT((last_msg_->cov_z_z * 100 - 0.0148738566786 * 100), 0.05)
       << "incorrect value for cov_z_z, expected 0.0148738566786, is "
       << last_msg_->cov_z_z;
-  EXPECT_EQ(last_msg_->flags, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            4)
       << "incorrect value for flags, expected 4, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            18)
       << "incorrect value for n_sats, expected 18, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 501867800)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            501867800)
       << "incorrect value for tow, expected 501867800, is " << last_msg_->tow;
   EXPECT_LT((last_msg_->x * 100 - -2694229.70798 * 100), 0.05)
       << "incorrect value for x, expected -2694229.70798, is " << last_msg_->x;

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgPosECEFDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgPosECEFDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgPosECEFDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -118,13 +125,21 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosECEFDepA0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            9)
       << "incorrect value for n_sats, expected 9, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 2567700)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2567700)
       << "incorrect value for tow, expected 2567700, is " << last_msg_->tow;
   EXPECT_LT((last_msg_->x * 100 - -2700354.59129 * 100), 0.05)
       << "incorrect value for x, expected -2700354.59129, is " << last_msg_->x;
@@ -222,13 +237,21 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosECEFDepA1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            1)
       << "incorrect value for flags, expected 1, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            9)
       << "incorrect value for n_sats, expected 9, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 2567700)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2567700)
       << "incorrect value for tow, expected 2567700, is " << last_msg_->tow;
   EXPECT_LT((last_msg_->x * 100 - -2700356.32851 * 100), 0.05)
       << "incorrect value for x, expected -2700356.32851, is " << last_msg_->x;
@@ -326,13 +349,21 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosECEFDepA2, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            9)
       << "incorrect value for n_sats, expected 9, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 2567800)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2567800)
       << "incorrect value for tow, expected 2567800, is " << last_msg_->tow;
   EXPECT_LT((last_msg_->x * 100 - -2700357.48558 * 100), 0.05)
       << "incorrect value for x, expected -2700357.48558, is " << last_msg_->x;
@@ -430,13 +461,21 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosECEFDepA3, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            1)
       << "incorrect value for flags, expected 1, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            9)
       << "incorrect value for n_sats, expected 9, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 2567800)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2567800)
       << "incorrect value for tow, expected 2567800, is " << last_msg_->tow;
   EXPECT_LT((last_msg_->x * 100 - -2700356.03495 * 100), 0.05)
       << "incorrect value for x, expected -2700356.03495, is " << last_msg_->x;
@@ -534,13 +573,21 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosECEFDepA4, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            9)
       << "incorrect value for n_sats, expected 9, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 2567900)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2567900)
       << "incorrect value for tow, expected 2567900, is " << last_msg_->tow;
   EXPECT_LT((last_msg_->x * 100 - -2700355.99131 * 100), 0.05)
       << "incorrect value for x, expected -2700355.99131, is " << last_msg_->x;
@@ -638,13 +685,21 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosECEFDepA5, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            8)
       << "incorrect value for n_sats, expected 8, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407084500)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407084500)
       << "incorrect value for tow, expected 407084500, is " << last_msg_->tow;
   EXPECT_LT((last_msg_->x * 100 - -2704376.01104 * 100), 0.05)
       << "incorrect value for x, expected -2704376.01104, is " << last_msg_->x;
@@ -742,13 +797,21 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosECEFDepA6, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            8)
       << "incorrect value for n_sats, expected 8, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407084600)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407084600)
       << "incorrect value for tow, expected 407084600, is " << last_msg_->tow;
   EXPECT_LT((last_msg_->x * 100 - -2704375.9287 * 100), 0.05)
       << "incorrect value for x, expected -2704375.9287, is " << last_msg_->x;
@@ -846,13 +909,21 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosECEFDepA7, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            8)
       << "incorrect value for n_sats, expected 8, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407084700)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407084700)
       << "incorrect value for tow, expected 407084700, is " << last_msg_->tow;
   EXPECT_LT((last_msg_->x * 100 - -2704375.16279 * 100), 0.05)
       << "incorrect value for x, expected -2704375.16279, is " << last_msg_->x;
@@ -950,13 +1021,21 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosECEFDepA8, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            8)
       << "incorrect value for n_sats, expected 8, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407084800)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407084800)
       << "incorrect value for tow, expected 407084800, is " << last_msg_->tow;
   EXPECT_LT((last_msg_->x * 100 - -2704376.35499 * 100), 0.05)
       << "incorrect value for x, expected -2704376.35499, is " << last_msg_->x;
@@ -1054,13 +1133,21 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosECEFDepA9, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            8)
       << "incorrect value for n_sats, expected 8, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407084900)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407084900)
       << "incorrect value for tow, expected 407084900, is " << last_msg_->tow;
   EXPECT_LT((last_msg_->x * 100 - -2704375.29129 * 100), 0.05)
       << "incorrect value for x, expected -2704375.29129, is " << last_msg_->x;
@@ -1158,13 +1245,21 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosECEFDepA10, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            5)
       << "incorrect value for n_sats, expected 5, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407151150)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407151150)
       << "incorrect value for tow, expected 407151150, is " << last_msg_->tow;
   EXPECT_LT((last_msg_->x * 100 - -2704375.68369 * 100), 0.05)
       << "incorrect value for x, expected -2704375.68369, is " << last_msg_->x;

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgPosECEFGNSS.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgPosECEFGNSS.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgPosECEFGNSS0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -118,14 +125,22 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosECEFGNSS0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 4096);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 182)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            182)
       << "incorrect value for accuracy, expected 182, is "
       << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            4)
       << "incorrect value for flags, expected 4, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            18)
       << "incorrect value for n_sats, expected 18, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 501867800)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            501867800)
       << "incorrect value for tow, expected 501867800, is " << last_msg_->tow;
   EXPECT_LT((last_msg_->x * 100 - -2694229.70798 * 100), 0.05)
       << "incorrect value for x, expected -2694229.70798, is " << last_msg_->x;

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgPosLLH.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgPosLLH.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgPosLLH0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -119,9 +126,13 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLH0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            2)
       << "incorrect value for flags, expected 2, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
   EXPECT_LT((last_msg_->height * 100 - 28.2116073923 * 100), 0.05)
@@ -133,11 +144,17 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLH0, Test) {
   EXPECT_LT((last_msg_->lon * 100 - -121.875053669 * 100), 0.05)
       << "incorrect value for lon, expected -121.875053669, is "
       << last_msg_->lon;
-  EXPECT_EQ(last_msg_->n_sats, 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            14)
       << "incorrect value for n_sats, expected 14, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 326825000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326825000)
       << "incorrect value for tow, expected 326825000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -231,9 +248,13 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLH1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            2)
       << "incorrect value for flags, expected 2, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
   EXPECT_LT((last_msg_->height * 100 - 27.7420555609 * 100), 0.05)
@@ -245,11 +266,17 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLH1, Test) {
   EXPECT_LT((last_msg_->lon * 100 - -121.875053496 * 100), 0.05)
       << "incorrect value for lon, expected -121.875053496, is "
       << last_msg_->lon;
-  EXPECT_EQ(last_msg_->n_sats, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            15)
       << "incorrect value for n_sats, expected 15, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 326826000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326826000)
       << "incorrect value for tow, expected 326826000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -343,9 +370,13 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLH2, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            2)
       << "incorrect value for flags, expected 2, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
   EXPECT_LT((last_msg_->height * 100 - 27.613721583 * 100), 0.05)
@@ -357,11 +388,17 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLH2, Test) {
   EXPECT_LT((last_msg_->lon * 100 - -121.875053736 * 100), 0.05)
       << "incorrect value for lon, expected -121.875053736, is "
       << last_msg_->lon;
-  EXPECT_EQ(last_msg_->n_sats, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            15)
       << "incorrect value for n_sats, expected 15, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 326827000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326827000)
       << "incorrect value for tow, expected 326827000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -455,9 +492,13 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLH3, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            2)
       << "incorrect value for flags, expected 2, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
   EXPECT_LT((last_msg_->height * 100 - 27.8025980704 * 100), 0.05)
@@ -469,11 +510,17 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLH3, Test) {
   EXPECT_LT((last_msg_->lon * 100 - -121.875055111 * 100), 0.05)
       << "incorrect value for lon, expected -121.875055111, is "
       << last_msg_->lon;
-  EXPECT_EQ(last_msg_->n_sats, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            15)
       << "incorrect value for n_sats, expected 15, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 326828000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326828000)
       << "incorrect value for tow, expected 326828000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -567,9 +614,13 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLH4, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            2)
       << "incorrect value for flags, expected 2, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
   EXPECT_LT((last_msg_->height * 100 - 27.9395123109 * 100), 0.05)
@@ -581,11 +632,17 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLH4, Test) {
   EXPECT_LT((last_msg_->lon * 100 - -121.875056094 * 100), 0.05)
       << "incorrect value for lon, expected -121.875056094, is "
       << last_msg_->lon;
-  EXPECT_EQ(last_msg_->n_sats, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            15)
       << "incorrect value for n_sats, expected 15, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 326829000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326829000)
       << "incorrect value for tow, expected 326829000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgPosLLHCov.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgPosLLHCov.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgPosLLHCov0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -136,7 +143,9 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLHCov0, Test) {
       << "incorrect value for cov_n_e, expected 5.0, is " << last_msg_->cov_n_e;
   EXPECT_LT((last_msg_->cov_n_n * 100 - 7.0 * 100), 0.05)
       << "incorrect value for cov_n_n, expected 7.0, is " << last_msg_->cov_n_n;
-  EXPECT_EQ(last_msg_->flags, 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            5)
       << "incorrect value for flags, expected 5, is " << last_msg_->flags;
   EXPECT_LT((last_msg_->height * 100 - 0.0 * 100), 0.05)
       << "incorrect value for height, expected 0.0, is " << last_msg_->height;
@@ -144,8 +153,12 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLHCov0, Test) {
       << "incorrect value for lat, expected 0.0, is " << last_msg_->lat;
   EXPECT_LT((last_msg_->lon * 100 - 7.0 * 100), 0.05)
       << "incorrect value for lon, expected 7.0, is " << last_msg_->lon;
-  EXPECT_EQ(last_msg_->n_sats, 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            5)
       << "incorrect value for n_sats, expected 5, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            7)
       << "incorrect value for tow, expected 7, is " << last_msg_->tow;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgPosLLHDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgPosLLHDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgPosLLHDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -119,9 +126,13 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLHDepA0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
   EXPECT_LT((last_msg_->height * 100 - 69.8043767518 * 100), 0.05)
@@ -133,11 +144,17 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLHDepA0, Test) {
   EXPECT_LT((last_msg_->lon * 100 - -122.173386622 * 100), 0.05)
       << "incorrect value for lon, expected -122.173386622, is "
       << last_msg_->lon;
-  EXPECT_EQ(last_msg_->n_sats, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            9)
       << "incorrect value for n_sats, expected 9, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 2567700)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2567700)
       << "incorrect value for tow, expected 2567700, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -231,9 +248,13 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLHDepA1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            1)
       << "incorrect value for flags, expected 1, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
   EXPECT_LT((last_msg_->height * 100 - 69.6881406772 * 100), 0.05)
@@ -245,11 +266,17 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLHDepA1, Test) {
   EXPECT_LT((last_msg_->lon * 100 - -122.173408261 * 100), 0.05)
       << "incorrect value for lon, expected -122.173408261, is "
       << last_msg_->lon;
-  EXPECT_EQ(last_msg_->n_sats, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            9)
       << "incorrect value for n_sats, expected 9, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 2567700)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2567700)
       << "incorrect value for tow, expected 2567700, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -343,9 +370,13 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLHDepA2, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
   EXPECT_LT((last_msg_->height * 100 - 69.4960885482 * 100), 0.05)
@@ -357,11 +388,17 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLHDepA2, Test) {
   EXPECT_LT((last_msg_->lon * 100 - -122.173420075 * 100), 0.05)
       << "incorrect value for lon, expected -122.173420075, is "
       << last_msg_->lon;
-  EXPECT_EQ(last_msg_->n_sats, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            9)
       << "incorrect value for n_sats, expected 9, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 2567800)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2567800)
       << "incorrect value for tow, expected 2567800, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -455,9 +492,13 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLHDepA3, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            1)
       << "incorrect value for flags, expected 1, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
   EXPECT_LT((last_msg_->height * 100 - 69.6878045882 * 100), 0.05)
@@ -469,11 +510,17 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLHDepA3, Test) {
   EXPECT_LT((last_msg_->lon * 100 - -122.173403896 * 100), 0.05)
       << "incorrect value for lon, expected -122.173403896, is "
       << last_msg_->lon;
-  EXPECT_EQ(last_msg_->n_sats, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            9)
       << "incorrect value for n_sats, expected 9, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 2567800)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2567800)
       << "incorrect value for tow, expected 2567800, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -567,9 +614,13 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLHDepA4, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
   EXPECT_LT((last_msg_->height * 100 - 70.5249547318 * 100), 0.05)
@@ -581,11 +632,17 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLHDepA4, Test) {
   EXPECT_LT((last_msg_->lon * 100 - -122.173404926 * 100), 0.05)
       << "incorrect value for lon, expected -122.173404926, is "
       << last_msg_->lon;
-  EXPECT_EQ(last_msg_->n_sats, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            9)
       << "incorrect value for n_sats, expected 9, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 2567900)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2567900)
       << "incorrect value for tow, expected 2567900, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -679,9 +736,13 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLHDepA5, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
   EXPECT_LT((last_msg_->height * 100 - 4.03981088521 * 100), 0.05)
@@ -693,11 +754,17 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLHDepA5, Test) {
   EXPECT_LT((last_msg_->lon * 100 - -122.389084379 * 100), 0.05)
       << "incorrect value for lon, expected -122.389084379, is "
       << last_msg_->lon;
-  EXPECT_EQ(last_msg_->n_sats, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            8)
       << "incorrect value for n_sats, expected 8, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407084500)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407084500)
       << "incorrect value for tow, expected 407084500, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -791,9 +858,13 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLHDepA6, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
   EXPECT_LT((last_msg_->height * 100 - 2.92671408701 * 100), 0.05)
@@ -805,11 +876,17 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLHDepA6, Test) {
   EXPECT_LT((last_msg_->lon * 100 - -122.389090537 * 100), 0.05)
       << "incorrect value for lon, expected -122.389090537, is "
       << last_msg_->lon;
-  EXPECT_EQ(last_msg_->n_sats, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            8)
       << "incorrect value for n_sats, expected 8, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407084600)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407084600)
       << "incorrect value for tow, expected 407084600, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -903,9 +980,13 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLHDepA7, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
   EXPECT_LT((last_msg_->height * 100 - 0.95121466474 * 100), 0.05)
@@ -917,11 +998,17 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLHDepA7, Test) {
   EXPECT_LT((last_msg_->lon * 100 - -122.389090734 * 100), 0.05)
       << "incorrect value for lon, expected -122.389090734, is "
       << last_msg_->lon;
-  EXPECT_EQ(last_msg_->n_sats, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            8)
       << "incorrect value for n_sats, expected 8, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407084700)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407084700)
       << "incorrect value for tow, expected 407084700, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -1015,9 +1102,13 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLHDepA8, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
   EXPECT_LT((last_msg_->height * 100 - 2.35413575205 * 100), 0.05)
@@ -1029,11 +1120,17 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLHDepA8, Test) {
   EXPECT_LT((last_msg_->lon * 100 - -122.389098544 * 100), 0.05)
       << "incorrect value for lon, expected -122.389098544, is "
       << last_msg_->lon;
-  EXPECT_EQ(last_msg_->n_sats, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            8)
       << "incorrect value for n_sats, expected 8, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407084800)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407084800)
       << "incorrect value for tow, expected 407084800, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -1127,9 +1224,13 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLHDepA9, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
   EXPECT_LT((last_msg_->height * 100 - 1.08767631816 * 100), 0.05)
@@ -1141,11 +1242,17 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLHDepA9, Test) {
   EXPECT_LT((last_msg_->lon * 100 - -122.389092305 * 100), 0.05)
       << "incorrect value for lon, expected -122.389092305, is "
       << last_msg_->lon;
-  EXPECT_EQ(last_msg_->n_sats, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            8)
       << "incorrect value for n_sats, expected 8, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407084900)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407084900)
       << "incorrect value for tow, expected 407084900, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -1239,9 +1346,13 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLHDepA10, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
   EXPECT_LT((last_msg_->height * 100 - 5.17153384465 * 100), 0.05)
@@ -1253,11 +1364,17 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLLHDepA10, Test) {
   EXPECT_LT((last_msg_->lon * 100 - -122.389082889 * 100), 0.05)
       << "incorrect value for lon, expected -122.389082889, is "
       << last_msg_->lon;
-  EXPECT_EQ(last_msg_->n_sats, 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            5)
       << "incorrect value for n_sats, expected 5, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407151150)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407151150)
       << "incorrect value for tow, expected 407151150, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgPosLlhAcc.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgPosLlhAcc.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgPosLlhAcc0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -131,13 +138,18 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLlhAcc0, Test) {
   EXPECT_LT((last_msg_->at_accuracy * 100 - 6297.20019531 * 100), 0.05)
       << "incorrect value for at_accuracy, expected 6297.20019531, is "
       << last_msg_->at_accuracy;
-  EXPECT_EQ(last_msg_->confidence_and_geoid, 95)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->confidence_and_geoid)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->confidence_and_geoid)),
+      95)
       << "incorrect value for confidence_and_geoid, expected 95, is "
       << last_msg_->confidence_and_geoid;
   EXPECT_LT((last_msg_->ct_accuracy * 100 - 1948.19995117 * 100), 0.05)
       << "incorrect value for ct_accuracy, expected 1948.19995117, is "
       << last_msg_->ct_accuracy;
-  EXPECT_EQ(last_msg_->flags, 72)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            72)
       << "incorrect value for flags, expected 72, is " << last_msg_->flags;
   EXPECT_LT((last_msg_->h_accuracy * 100 - 2410.19995117 * 100), 0.05)
       << "incorrect value for h_accuracy, expected 2410.19995117, is "
@@ -160,12 +172,16 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLlhAcc0, Test) {
       << "incorrect value for lat, expected 7563.2, is " << last_msg_->lat;
   EXPECT_LT((last_msg_->lon * 100 - 8494.2 * 100), 0.05)
       << "incorrect value for lon, expected 8494.2, is " << last_msg_->lon;
-  EXPECT_EQ(last_msg_->n_sats, 27)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            27)
       << "incorrect value for n_sats, expected 27, is " << last_msg_->n_sats;
   EXPECT_LT((last_msg_->orthometric_height * 100 - 4965.2 * 100), 0.05)
       << "incorrect value for orthometric_height, expected 4965.2, is "
       << last_msg_->orthometric_height;
-  EXPECT_EQ(last_msg_->tow, 309229607)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            309229607)
       << "incorrect value for tow, expected 309229607, is " << last_msg_->tow;
   EXPECT_LT((last_msg_->v_accuracy * 100 - 5539.20019531 * 100), 0.05)
       << "incorrect value for v_accuracy, expected 5539.20019531, is "

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgPosLlhCovGnss.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgPosLlhCovGnss.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgPosLlhCovGnss0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -144,7 +151,9 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLlhCovGnss0, Test) {
   EXPECT_LT((last_msg_->cov_n_n * 100 - 0.00748897157609 * 100), 0.05)
       << "incorrect value for cov_n_n, expected 0.00748897157609, is "
       << last_msg_->cov_n_n;
-  EXPECT_EQ(last_msg_->flags, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            4)
       << "incorrect value for flags, expected 4, is " << last_msg_->flags;
   EXPECT_LT((last_msg_->height * 100 - -17.3938212478 * 100), 0.05)
       << "incorrect value for height, expected -17.3938212478, is "
@@ -155,8 +164,12 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLlhCovGnss0, Test) {
   EXPECT_LT((last_msg_->lon * 100 - -122.28650381 * 100), 0.05)
       << "incorrect value for lon, expected -122.28650381, is "
       << last_msg_->lon;
-  EXPECT_EQ(last_msg_->n_sats, 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            18)
       << "incorrect value for n_sats, expected 18, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 501867800)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            501867800)
       << "incorrect value for tow, expected 501867800, is " << last_msg_->tow;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgPosLlhGnss.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgPosLlhGnss.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgPosLlhGnss0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -119,9 +126,13 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLlhGnss0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 4096);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            4)
       << "incorrect value for flags, expected 4, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 87)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            87)
       << "incorrect value for h_accuracy, expected 87, is "
       << last_msg_->h_accuracy;
   EXPECT_LT((last_msg_->height * 100 - -17.3938212478 * 100), 0.05)
@@ -133,11 +144,17 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPosLlhGnss0, Test) {
   EXPECT_LT((last_msg_->lon * 100 - -122.28650381 * 100), 0.05)
       << "incorrect value for lon, expected -122.28650381, is "
       << last_msg_->lon;
-  EXPECT_EQ(last_msg_->n_sats, 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            18)
       << "incorrect value for n_sats, expected 18, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 501867800)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            501867800)
       << "incorrect value for tow, expected 501867800, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 181)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            181)
       << "incorrect value for v_accuracy, expected 181, is "
       << last_msg_->v_accuracy;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgPoseRelative.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgPoseRelative.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgPoseRelative0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -187,34 +194,58 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgPoseRelative0, Test) {
   EXPECT_LT((last_msg_->cov_r_z_z * 100 - 1.0 * 100), 0.05)
       << "incorrect value for cov_r_z_z, expected 1.0, is "
       << last_msg_->cov_r_z_z;
-  EXPECT_EQ(last_msg_->flags, 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            5)
       << "incorrect value for flags, expected 5, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->sensor_id, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sensor_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sensor_id)),
+            0)
       << "incorrect value for sensor_id, expected 0, is "
       << last_msg_->sensor_id;
-  EXPECT_EQ(last_msg_->timestamp_1, 1110)
+  EXPECT_EQ(get_as<decltype(last_msg_->timestamp_1)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->timestamp_1)),
+            1110)
       << "incorrect value for timestamp_1, expected 1110, is "
       << last_msg_->timestamp_1;
-  EXPECT_EQ(last_msg_->timestamp_2, 2220)
+  EXPECT_EQ(get_as<decltype(last_msg_->timestamp_2)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->timestamp_2)),
+            2220)
       << "incorrect value for timestamp_2, expected 2220, is "
       << last_msg_->timestamp_2;
-  EXPECT_EQ(last_msg_->tow, 1110)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            1110)
       << "incorrect value for tow, expected 1110, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->trans[0], 1100)
+  EXPECT_EQ(get_as<decltype(last_msg_->trans[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->trans[0])),
+            1100)
       << "incorrect value for trans[0], expected 1100, is "
       << last_msg_->trans[0];
-  EXPECT_EQ(last_msg_->trans[1], 550)
+  EXPECT_EQ(get_as<decltype(last_msg_->trans[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->trans[1])),
+            550)
       << "incorrect value for trans[1], expected 550, is "
       << last_msg_->trans[1];
-  EXPECT_EQ(last_msg_->trans[2], 100)
+  EXPECT_EQ(get_as<decltype(last_msg_->trans[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->trans[2])),
+            100)
       << "incorrect value for trans[2], expected 100, is "
       << last_msg_->trans[2];
-  EXPECT_EQ(last_msg_->w, -859307164)
+  EXPECT_EQ(get_as<decltype(last_msg_->w)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->w)),
+            -859307164)
       << "incorrect value for w, expected -859307164, is " << last_msg_->w;
-  EXPECT_EQ(last_msg_->x, -6444804)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            -6444804)
       << "incorrect value for x, expected -6444804, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, -1866844813)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            -1866844813)
       << "incorrect value for y, expected -1866844813, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, 622997694)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            622997694)
       << "incorrect value for z, expected 622997694, is " << last_msg_->z;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgProtectionLevel.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgProtectionLevel.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgProtectionLevel0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -136,50 +143,86 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgProtectionLevel0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 813);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->atpl, 10663)
+  EXPECT_EQ(get_as<decltype(last_msg_->atpl)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->atpl)),
+            10663)
       << "incorrect value for atpl, expected 10663, is " << last_msg_->atpl;
-  EXPECT_EQ(last_msg_->ctpl, 5433)
+  EXPECT_EQ(get_as<decltype(last_msg_->ctpl)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ctpl)),
+            5433)
       << "incorrect value for ctpl, expected 5433, is " << last_msg_->ctpl;
-  EXPECT_EQ(last_msg_->flags, 555755625)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            555755625)
       << "incorrect value for flags, expected 555755625, is "
       << last_msg_->flags;
-  EXPECT_EQ(last_msg_->heading, -529244741)
+  EXPECT_EQ(get_as<decltype(last_msg_->heading)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->heading)),
+            -529244741)
       << "incorrect value for heading, expected -529244741, is "
       << last_msg_->heading;
   EXPECT_LT((last_msg_->height * 100 - 412.2 * 100), 0.05)
       << "incorrect value for height, expected 412.2, is " << last_msg_->height;
-  EXPECT_EQ(last_msg_->hopl, 26707)
+  EXPECT_EQ(get_as<decltype(last_msg_->hopl)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->hopl)),
+            26707)
       << "incorrect value for hopl, expected 26707, is " << last_msg_->hopl;
-  EXPECT_EQ(last_msg_->hpl, 41013)
+  EXPECT_EQ(get_as<decltype(last_msg_->hpl)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->hpl)),
+            41013)
       << "incorrect value for hpl, expected 41013, is " << last_msg_->hpl;
-  EXPECT_EQ(last_msg_->hvpl, 62681)
+  EXPECT_EQ(get_as<decltype(last_msg_->hvpl)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->hvpl)),
+            62681)
       << "incorrect value for hvpl, expected 62681, is " << last_msg_->hvpl;
   EXPECT_LT((last_msg_->lat * 100 - 5290.2 * 100), 0.05)
       << "incorrect value for lat, expected 5290.2, is " << last_msg_->lat;
   EXPECT_LT((last_msg_->lon * 100 - 9904.2 * 100), 0.05)
       << "incorrect value for lon, expected 9904.2, is " << last_msg_->lon;
-  EXPECT_EQ(last_msg_->pitch, -1598561301)
+  EXPECT_EQ(get_as<decltype(last_msg_->pitch)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pitch)),
+            -1598561301)
       << "incorrect value for pitch, expected -1598561301, is "
       << last_msg_->pitch;
-  EXPECT_EQ(last_msg_->popl, 35212)
+  EXPECT_EQ(get_as<decltype(last_msg_->popl)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->popl)),
+            35212)
       << "incorrect value for popl, expected 35212, is " << last_msg_->popl;
-  EXPECT_EQ(last_msg_->roll, 1018834477)
+  EXPECT_EQ(get_as<decltype(last_msg_->roll)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->roll)),
+            1018834477)
       << "incorrect value for roll, expected 1018834477, is "
       << last_msg_->roll;
-  EXPECT_EQ(last_msg_->ropl, 63066)
+  EXPECT_EQ(get_as<decltype(last_msg_->ropl)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ropl)),
+            63066)
       << "incorrect value for ropl, expected 63066, is " << last_msg_->ropl;
-  EXPECT_EQ(last_msg_->tow, 4060370030)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            4060370030)
       << "incorrect value for tow, expected 4060370030, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_x, -584647705)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_x)),
+            -584647705)
       << "incorrect value for v_x, expected -584647705, is " << last_msg_->v_x;
-  EXPECT_EQ(last_msg_->v_y, 1353168848)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_y)),
+            1353168848)
       << "incorrect value for v_y, expected 1353168848, is " << last_msg_->v_y;
-  EXPECT_EQ(last_msg_->v_z, -1537140001)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_z)),
+            -1537140001)
       << "incorrect value for v_z, expected -1537140001, is " << last_msg_->v_z;
-  EXPECT_EQ(last_msg_->vpl, 21593)
+  EXPECT_EQ(get_as<decltype(last_msg_->vpl)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->vpl)),
+            21593)
       << "incorrect value for vpl, expected 21593, is " << last_msg_->vpl;
-  EXPECT_EQ(last_msg_->vvpl, 41277)
+  EXPECT_EQ(get_as<decltype(last_msg_->vvpl)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->vvpl)),
+            41277)
       << "incorrect value for vvpl, expected 41277, is " << last_msg_->vvpl;
-  EXPECT_EQ(last_msg_->wn, 13102)
+  EXPECT_EQ(get_as<decltype(last_msg_->wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->wn)),
+            13102)
       << "incorrect value for wn, expected 13102, is " << last_msg_->wn;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgProtectionLevelDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgProtectionLevelDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgProtectionLevelDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -120,19 +127,27 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgProtectionLevelDepA0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 5780);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 248)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            248)
       << "incorrect value for flags, expected 248, is " << last_msg_->flags;
   EXPECT_LT((last_msg_->height * 100 - 8270.2 * 100), 0.05)
       << "incorrect value for height, expected 8270.2, is "
       << last_msg_->height;
-  EXPECT_EQ(last_msg_->hpl, 35588)
+  EXPECT_EQ(get_as<decltype(last_msg_->hpl)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->hpl)),
+            35588)
       << "incorrect value for hpl, expected 35588, is " << last_msg_->hpl;
   EXPECT_LT((last_msg_->lat * 100 - 7924.2 * 100), 0.05)
       << "incorrect value for lat, expected 7924.2, is " << last_msg_->lat;
   EXPECT_LT((last_msg_->lon * 100 - 3174.2 * 100), 0.05)
       << "incorrect value for lon, expected 3174.2, is " << last_msg_->lon;
-  EXPECT_EQ(last_msg_->tow, 3108339252)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            3108339252)
       << "incorrect value for tow, expected 3108339252, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->vpl, 21807)
+  EXPECT_EQ(get_as<decltype(last_msg_->vpl)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->vpl)),
+            21807)
       << "incorrect value for vpl, expected 21807, is " << last_msg_->vpl;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgReferenceFrameParam.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgReferenceFrameParam.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgReferenceFrameParam0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -160,38 +167,64 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgReferenceFrameParam0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->delta_X0, 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->delta_X0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->delta_X0)),
+            7)
       << "incorrect value for delta_X0, expected 7, is " << last_msg_->delta_X0;
-  EXPECT_EQ(last_msg_->delta_Y0, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->delta_Y0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->delta_Y0)),
+            8)
       << "incorrect value for delta_Y0, expected 8, is " << last_msg_->delta_Y0;
-  EXPECT_EQ(last_msg_->delta_Z0, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->delta_Z0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->delta_Z0)),
+            9)
       << "incorrect value for delta_Z0, expected 9, is " << last_msg_->delta_Z0;
-  EXPECT_EQ(last_msg_->dot_delta_X0, 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->dot_delta_X0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->dot_delta_X0)),
+            14)
       << "incorrect value for dot_delta_X0, expected 14, is "
       << last_msg_->dot_delta_X0;
-  EXPECT_EQ(last_msg_->dot_delta_Y0, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->dot_delta_Y0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->dot_delta_Y0)),
+            15)
       << "incorrect value for dot_delta_Y0, expected 15, is "
       << last_msg_->dot_delta_Y0;
-  EXPECT_EQ(last_msg_->dot_delta_Z0, 16)
+  EXPECT_EQ(get_as<decltype(last_msg_->dot_delta_Z0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->dot_delta_Z0)),
+            16)
       << "incorrect value for dot_delta_Z0, expected 16, is "
       << last_msg_->dot_delta_Z0;
-  EXPECT_EQ(last_msg_->dot_scale, 20)
+  EXPECT_EQ(get_as<decltype(last_msg_->dot_scale)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->dot_scale)),
+            20)
       << "incorrect value for dot_scale, expected 20, is "
       << last_msg_->dot_scale;
-  EXPECT_EQ(last_msg_->dot_theta_01, 17)
+  EXPECT_EQ(get_as<decltype(last_msg_->dot_theta_01)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->dot_theta_01)),
+            17)
       << "incorrect value for dot_theta_01, expected 17, is "
       << last_msg_->dot_theta_01;
-  EXPECT_EQ(last_msg_->dot_theta_02, 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->dot_theta_02)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->dot_theta_02)),
+            18)
       << "incorrect value for dot_theta_02, expected 18, is "
       << last_msg_->dot_theta_02;
-  EXPECT_EQ(last_msg_->dot_theta_03, 19)
+  EXPECT_EQ(get_as<decltype(last_msg_->dot_theta_03)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->dot_theta_03)),
+            19)
       << "incorrect value for dot_theta_03, expected 19, is "
       << last_msg_->dot_theta_03;
-  EXPECT_EQ(last_msg_->re_t0, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->re_t0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->re_t0)),
+            6)
       << "incorrect value for re_t0, expected 6, is " << last_msg_->re_t0;
-  EXPECT_EQ(last_msg_->scale, 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->scale)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->scale)),
+            13)
       << "incorrect value for scale, expected 13, is " << last_msg_->scale;
-  EXPECT_EQ(last_msg_->sin, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->sin)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sin)),
+            4)
       << "incorrect value for sin, expected 4, is " << last_msg_->sin;
   {
     const char check_string[] = {
@@ -204,15 +237,23 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgReferenceFrameParam0, Test) {
         << "incorrect value for last_msg_->sn, expected string '"
         << check_string << "', is '" << last_msg_->sn << "'";
   }
-  EXPECT_EQ(last_msg_->ssr_iod, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->ssr_iod)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ssr_iod)),
+            1)
       << "incorrect value for ssr_iod, expected 1, is " << last_msg_->ssr_iod;
-  EXPECT_EQ(last_msg_->theta_01, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->theta_01)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->theta_01)),
+            10)
       << "incorrect value for theta_01, expected 10, is "
       << last_msg_->theta_01;
-  EXPECT_EQ(last_msg_->theta_02, 11)
+  EXPECT_EQ(get_as<decltype(last_msg_->theta_02)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->theta_02)),
+            11)
       << "incorrect value for theta_02, expected 11, is "
       << last_msg_->theta_02;
-  EXPECT_EQ(last_msg_->theta_03, 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->theta_03)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->theta_03)),
+            12)
       << "incorrect value for theta_03, expected 12, is "
       << last_msg_->theta_03;
   {
@@ -226,6 +267,8 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgReferenceFrameParam0, Test) {
         << "incorrect value for last_msg_->tn, expected string '"
         << check_string << "', is '" << last_msg_->tn << "'";
   }
-  EXPECT_EQ(last_msg_->utn, 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->utn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->utn)),
+            5)
       << "incorrect value for utn, expected 5, is " << last_msg_->utn;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgUTCLeapSecond.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgUTCLeapSecond.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgUTCLeapSecond0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -118,29 +125,47 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgUTCLeapSecond0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->count_after, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->count_after)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->count_after)),
+            9)
       << "incorrect value for count_after, expected 9, is "
       << last_msg_->count_after;
-  EXPECT_EQ(last_msg_->count_before, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->count_before)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->count_before)),
+            4)
       << "incorrect value for count_before, expected 4, is "
       << last_msg_->count_before;
-  EXPECT_EQ(last_msg_->ref_dn, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->ref_dn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ref_dn)),
+            8)
       << "incorrect value for ref_dn, expected 8, is " << last_msg_->ref_dn;
-  EXPECT_EQ(last_msg_->ref_wn, 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->ref_wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ref_wn)),
+            7)
       << "incorrect value for ref_wn, expected 7, is " << last_msg_->ref_wn;
-  EXPECT_EQ(last_msg_->reserved_0, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved_0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved_0)),
+            1)
       << "incorrect value for reserved_0, expected 1, is "
       << last_msg_->reserved_0;
-  EXPECT_EQ(last_msg_->reserved_1, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved_1)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved_1)),
+            2)
       << "incorrect value for reserved_1, expected 2, is "
       << last_msg_->reserved_1;
-  EXPECT_EQ(last_msg_->reserved_2, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved_2)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved_2)),
+            3)
       << "incorrect value for reserved_2, expected 3, is "
       << last_msg_->reserved_2;
-  EXPECT_EQ(last_msg_->reserved_3, 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved_3)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved_3)),
+            5)
       << "incorrect value for reserved_3, expected 5, is "
       << last_msg_->reserved_3;
-  EXPECT_EQ(last_msg_->reserved_4, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved_4)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved_4)),
+            6)
       << "incorrect value for reserved_4, expected 6, is "
       << last_msg_->reserved_4;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgUTCTime.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgUTCTime.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgUTCTime0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -119,22 +126,40 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgUTCTime0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 789);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->day, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->day)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->day)),
+            9)
       << "incorrect value for day, expected 9, is " << last_msg_->day;
-  EXPECT_EQ(last_msg_->flags, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            1)
       << "incorrect value for flags, expected 1, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->hours, 19)
+  EXPECT_EQ(get_as<decltype(last_msg_->hours)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->hours)),
+            19)
       << "incorrect value for hours, expected 19, is " << last_msg_->hours;
-  EXPECT_EQ(last_msg_->minutes, 24)
+  EXPECT_EQ(get_as<decltype(last_msg_->minutes)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->minutes)),
+            24)
       << "incorrect value for minutes, expected 24, is " << last_msg_->minutes;
-  EXPECT_EQ(last_msg_->month, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->month)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->month)),
+            4)
       << "incorrect value for month, expected 4, is " << last_msg_->month;
-  EXPECT_EQ(last_msg_->ns, 800000000)
+  EXPECT_EQ(get_as<decltype(last_msg_->ns)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ns)),
+            800000000)
       << "incorrect value for ns, expected 800000000, is " << last_msg_->ns;
-  EXPECT_EQ(last_msg_->seconds, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->seconds)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->seconds)),
+            9)
       << "incorrect value for seconds, expected 9, is " << last_msg_->seconds;
-  EXPECT_EQ(last_msg_->tow, 501867800)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            501867800)
       << "incorrect value for tow, expected 501867800, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->year, 2021)
+  EXPECT_EQ(get_as<decltype(last_msg_->year)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->year)),
+            2021)
       << "incorrect value for year, expected 2021, is " << last_msg_->year;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgUTCTimeGNSS.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgUTCTimeGNSS.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgUTCTimeGNSS0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -119,22 +126,40 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgUTCTimeGNSS0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 789);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->day, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->day)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->day)),
+            9)
       << "incorrect value for day, expected 9, is " << last_msg_->day;
-  EXPECT_EQ(last_msg_->flags, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            1)
       << "incorrect value for flags, expected 1, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->hours, 19)
+  EXPECT_EQ(get_as<decltype(last_msg_->hours)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->hours)),
+            19)
       << "incorrect value for hours, expected 19, is " << last_msg_->hours;
-  EXPECT_EQ(last_msg_->minutes, 24)
+  EXPECT_EQ(get_as<decltype(last_msg_->minutes)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->minutes)),
+            24)
       << "incorrect value for minutes, expected 24, is " << last_msg_->minutes;
-  EXPECT_EQ(last_msg_->month, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->month)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->month)),
+            4)
       << "incorrect value for month, expected 4, is " << last_msg_->month;
-  EXPECT_EQ(last_msg_->ns, 800000000)
+  EXPECT_EQ(get_as<decltype(last_msg_->ns)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ns)),
+            800000000)
       << "incorrect value for ns, expected 800000000, is " << last_msg_->ns;
-  EXPECT_EQ(last_msg_->seconds, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->seconds)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->seconds)),
+            9)
       << "incorrect value for seconds, expected 9, is " << last_msg_->seconds;
-  EXPECT_EQ(last_msg_->tow, 501867800)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            501867800)
       << "incorrect value for tow, expected 501867800, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->year, 2021)
+  EXPECT_EQ(get_as<decltype(last_msg_->year)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->year)),
+            2021)
       << "incorrect value for year, expected 2021, is " << last_msg_->year;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgVelBody.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgVelBody.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgVelBody0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -135,16 +142,28 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelBody0, Test) {
       << "incorrect value for cov_y_z, expected 3.0, is " << last_msg_->cov_y_z;
   EXPECT_LT((last_msg_->cov_z_z * 100 - 2.0 * 100), 0.05)
       << "incorrect value for cov_z_z, expected 2.0, is " << last_msg_->cov_z_z;
-  EXPECT_EQ(last_msg_->flags, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            8)
       << "incorrect value for flags, expected 8, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            3)
       << "incorrect value for n_sats, expected 3, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            1)
       << "incorrect value for tow, expected 1, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            4)
       << "incorrect value for x, expected 4, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            2)
       << "incorrect value for y, expected 2, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            1)
       << "incorrect value for z, expected 1, is " << last_msg_->z;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgVelCog.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgVelCog.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgVelCog0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -119,23 +126,39 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelCog0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->cog, 1000)
+  EXPECT_EQ(get_as<decltype(last_msg_->cog)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cog)),
+            1000)
       << "incorrect value for cog, expected 1000, is " << last_msg_->cog;
-  EXPECT_EQ(last_msg_->cog_accuracy, 4000)
+  EXPECT_EQ(get_as<decltype(last_msg_->cog_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cog_accuracy)),
+            4000)
       << "incorrect value for cog_accuracy, expected 4000, is "
       << last_msg_->cog_accuracy;
-  EXPECT_EQ(last_msg_->flags, 62)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            62)
       << "incorrect value for flags, expected 62, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->sog, 2000)
+  EXPECT_EQ(get_as<decltype(last_msg_->sog)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sog)),
+            2000)
       << "incorrect value for sog, expected 2000, is " << last_msg_->sog;
-  EXPECT_EQ(last_msg_->sog_accuracy, 5000)
+  EXPECT_EQ(get_as<decltype(last_msg_->sog_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sog_accuracy)),
+            5000)
       << "incorrect value for sog_accuracy, expected 5000, is "
       << last_msg_->sog_accuracy;
-  EXPECT_EQ(last_msg_->tow, 326825520)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326825520)
       << "incorrect value for tow, expected 326825520, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_up, 3000)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_up)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_up)),
+            3000)
       << "incorrect value for v_up, expected 3000, is " << last_msg_->v_up;
-  EXPECT_EQ(last_msg_->v_up_accuracy, 6000)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_up_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_up_accuracy)),
+            6000)
       << "incorrect value for v_up_accuracy, expected 6000, is "
       << last_msg_->v_up_accuracy;
 }
@@ -229,23 +252,39 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelCog1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->cog, 123)
+  EXPECT_EQ(get_as<decltype(last_msg_->cog)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cog)),
+            123)
       << "incorrect value for cog, expected 123, is " << last_msg_->cog;
-  EXPECT_EQ(last_msg_->cog_accuracy, 180000000)
+  EXPECT_EQ(get_as<decltype(last_msg_->cog_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cog_accuracy)),
+            180000000)
       << "incorrect value for cog_accuracy, expected 180000000, is "
       << last_msg_->cog_accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->sog, 456)
+  EXPECT_EQ(get_as<decltype(last_msg_->sog)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sog)),
+            456)
       << "incorrect value for sog, expected 456, is " << last_msg_->sog;
-  EXPECT_EQ(last_msg_->sog_accuracy, 100)
+  EXPECT_EQ(get_as<decltype(last_msg_->sog_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sog_accuracy)),
+            100)
       << "incorrect value for sog_accuracy, expected 100, is "
       << last_msg_->sog_accuracy;
-  EXPECT_EQ(last_msg_->tow, 326825520)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326825520)
       << "incorrect value for tow, expected 326825520, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_up, -1000)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_up)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_up)),
+            -1000)
       << "incorrect value for v_up, expected -1000, is " << last_msg_->v_up;
-  EXPECT_EQ(last_msg_->v_up_accuracy, 100)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_up_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_up_accuracy)),
+            100)
       << "incorrect value for v_up_accuracy, expected 100, is "
       << last_msg_->v_up_accuracy;
 }
@@ -338,23 +377,39 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelCog2, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->cog, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->cog)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cog)),
+            0)
       << "incorrect value for cog, expected 0, is " << last_msg_->cog;
-  EXPECT_EQ(last_msg_->cog_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->cog_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cog_accuracy)),
+            0)
       << "incorrect value for cog_accuracy, expected 0, is "
       << last_msg_->cog_accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->sog, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sog)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sog)),
+            0)
       << "incorrect value for sog, expected 0, is " << last_msg_->sog;
-  EXPECT_EQ(last_msg_->sog_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sog_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sog_accuracy)),
+            0)
       << "incorrect value for sog_accuracy, expected 0, is "
       << last_msg_->sog_accuracy;
-  EXPECT_EQ(last_msg_->tow, 326825520)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326825520)
       << "incorrect value for tow, expected 326825520, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_up, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_up)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_up)),
+            0)
       << "incorrect value for v_up, expected 0, is " << last_msg_->v_up;
-  EXPECT_EQ(last_msg_->v_up_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_up_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_up_accuracy)),
+            0)
       << "incorrect value for v_up_accuracy, expected 0, is "
       << last_msg_->v_up_accuracy;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgVelECEF.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgVelECEF.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgVelECEF0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -117,19 +124,33 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelECEF0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            14)
       << "incorrect value for n_sats, expected 14, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 326825000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326825000)
       << "incorrect value for tow, expected 326825000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, -8)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            -8)
       << "incorrect value for x, expected -8, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, -5)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            -5)
       << "incorrect value for y, expected -5, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            10)
       << "incorrect value for z, expected 10, is " << last_msg_->z;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgVelECEF1
@@ -220,19 +241,33 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelECEF1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            15)
       << "incorrect value for n_sats, expected 15, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 326825500)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326825500)
       << "incorrect value for tow, expected 326825500, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, -12)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            -12)
       << "incorrect value for x, expected -12, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, -18)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            -18)
       << "incorrect value for y, expected -18, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, 11)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            11)
       << "incorrect value for z, expected 11, is " << last_msg_->z;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgVelECEF2
@@ -323,19 +358,33 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelECEF2, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            15)
       << "incorrect value for n_sats, expected 15, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 326826000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326826000)
       << "incorrect value for tow, expected 326826000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, -8)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            -8)
       << "incorrect value for x, expected -8, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, -6)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            -6)
       << "incorrect value for y, expected -6, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            7)
       << "incorrect value for z, expected 7, is " << last_msg_->z;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgVelECEF3
@@ -426,19 +475,33 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelECEF3, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            15)
       << "incorrect value for n_sats, expected 15, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 326826500)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326826500)
       << "incorrect value for tow, expected 326826500, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, -7)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            -7)
       << "incorrect value for x, expected -7, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, -17)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            -17)
       << "incorrect value for y, expected -17, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, 16)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            16)
       << "incorrect value for z, expected 16, is " << last_msg_->z;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgVelECEF4
@@ -529,18 +592,32 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelECEF4, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            15)
       << "incorrect value for n_sats, expected 15, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 326827000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326827000)
       << "incorrect value for tow, expected 326827000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, -9)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            -9)
       << "incorrect value for x, expected -9, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, -13)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            -13)
       << "incorrect value for y, expected -13, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            14)
       << "incorrect value for z, expected 14, is " << last_msg_->z;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgVelECEFCov.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgVelECEFCov.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgVelECEFCov0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -135,16 +142,28 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelECEFCov0, Test) {
       << "incorrect value for cov_y_z, expected 1.0, is " << last_msg_->cov_y_z;
   EXPECT_LT((last_msg_->cov_z_z * 100 - 3.0 * 100), 0.05)
       << "incorrect value for cov_z_z, expected 3.0, is " << last_msg_->cov_z_z;
-  EXPECT_EQ(last_msg_->flags, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            4)
       << "incorrect value for flags, expected 4, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            3)
       << "incorrect value for n_sats, expected 3, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2)
       << "incorrect value for tow, expected 2, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            0)
       << "incorrect value for x, expected 0, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            0)
       << "incorrect value for y, expected 0, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            6)
       << "incorrect value for z, expected 6, is " << last_msg_->z;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgVelECEFDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgVelECEFDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgVelECEFDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -117,19 +124,33 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelECEFDepA0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            9)
       << "incorrect value for n_sats, expected 9, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 2567700)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2567700)
       << "incorrect value for tow, expected 2567700, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, 3034)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            3034)
       << "incorrect value for x, expected 3034, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, -2682)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            -2682)
       << "incorrect value for y, expected -2682, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, -861)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            -861)
       << "incorrect value for z, expected -861, is " << last_msg_->z;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgVelECEFDepA1
@@ -220,19 +241,33 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelECEFDepA1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            9)
       << "incorrect value for n_sats, expected 9, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 2567800)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2567800)
       << "incorrect value for tow, expected 2567800, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, 2884)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            2884)
       << "incorrect value for x, expected 2884, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, -2536)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            -2536)
       << "incorrect value for y, expected -2536, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, -804)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            -804)
       << "incorrect value for z, expected -804, is " << last_msg_->z;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgVelECEFDepA2
@@ -323,19 +358,33 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelECEFDepA2, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            9)
       << "incorrect value for n_sats, expected 9, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 2567900)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2567900)
       << "incorrect value for tow, expected 2567900, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, 2837)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            2837)
       << "incorrect value for x, expected 2837, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, -2483)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            -2483)
       << "incorrect value for y, expected -2483, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, -777)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            -777)
       << "incorrect value for z, expected -777, is " << last_msg_->z;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgVelECEFDepA3
@@ -426,19 +475,33 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelECEFDepA3, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            9)
       << "incorrect value for n_sats, expected 9, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 2568000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2568000)
       << "incorrect value for tow, expected 2568000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, 2937)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            2937)
       << "incorrect value for x, expected 2937, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, -2558)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            -2558)
       << "incorrect value for y, expected -2558, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, -790)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            -790)
       << "incorrect value for z, expected -790, is " << last_msg_->z;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgVelECEFDepA4
@@ -529,19 +592,33 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelECEFDepA4, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            9)
       << "incorrect value for n_sats, expected 9, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 2568100)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2568100)
       << "incorrect value for tow, expected 2568100, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, 2847)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            2847)
       << "incorrect value for x, expected 2847, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, -2467)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            -2467)
       << "incorrect value for y, expected -2467, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, -752)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            -752)
       << "incorrect value for z, expected -752, is " << last_msg_->z;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgVelECEFDepA5
@@ -632,19 +709,33 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelECEFDepA5, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            8)
       << "incorrect value for n_sats, expected 8, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407084500)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407084500)
       << "incorrect value for tow, expected 407084500, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, 24)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            24)
       << "incorrect value for x, expected 24, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, -11)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            -11)
       << "incorrect value for y, expected -11, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, -37)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            -37)
       << "incorrect value for z, expected -37, is " << last_msg_->z;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgVelECEFDepA6
@@ -735,19 +826,33 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelECEFDepA6, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            8)
       << "incorrect value for n_sats, expected 8, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407084600)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407084600)
       << "incorrect value for tow, expected 407084600, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            4)
       << "incorrect value for x, expected 4, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, -22)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            -22)
       << "incorrect value for y, expected -22, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            18)
       << "incorrect value for z, expected 18, is " << last_msg_->z;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgVelECEFDepA7
@@ -838,19 +943,33 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelECEFDepA7, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            8)
       << "incorrect value for n_sats, expected 8, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407084700)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407084700)
       << "incorrect value for tow, expected 407084700, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, -26)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            -26)
       << "incorrect value for x, expected -26, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            4)
       << "incorrect value for y, expected 4, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            1)
       << "incorrect value for z, expected 1, is " << last_msg_->z;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgVelECEFDepA8
@@ -941,19 +1060,33 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelECEFDepA8, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            8)
       << "incorrect value for n_sats, expected 8, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407084800)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407084800)
       << "incorrect value for tow, expected 407084800, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, -9)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            -9)
       << "incorrect value for x, expected -9, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, -19)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            -19)
       << "incorrect value for y, expected -19, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, 28)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            28)
       << "incorrect value for z, expected 28, is " << last_msg_->z;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgVelECEFDepA9
@@ -1044,19 +1177,33 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelECEFDepA9, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            8)
       << "incorrect value for n_sats, expected 8, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407084900)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407084900)
       << "incorrect value for tow, expected 407084900, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, -1)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            -1)
       << "incorrect value for x, expected -1, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            2)
       << "incorrect value for y, expected 2, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, -11)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            -11)
       << "incorrect value for z, expected -11, is " << last_msg_->z;
 }
 class Test_legacy_auto_check_sbp_navigation_MsgVelECEFDepA10
@@ -1147,18 +1294,32 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelECEFDepA10, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            0)
       << "incorrect value for accuracy, expected 0, is " << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            5)
       << "incorrect value for n_sats, expected 5, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407151150)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407151150)
       << "incorrect value for tow, expected 407151150, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, -49)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            -49)
       << "incorrect value for x, expected -49, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, -71)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            -71)
       << "incorrect value for y, expected -71, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, 65)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            65)
       << "incorrect value for z, expected 65, is " << last_msg_->z;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgVelEcefCovGnss.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgVelEcefCovGnss.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgVelEcefCovGnss0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -144,16 +151,28 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelEcefCovGnss0, Test) {
   EXPECT_LT((last_msg_->cov_z_z * 100 - 0.00378042715602 * 100), 0.05)
       << "incorrect value for cov_z_z, expected 0.00378042715602, is "
       << last_msg_->cov_z_z;
-  EXPECT_EQ(last_msg_->flags, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            2)
       << "incorrect value for flags, expected 2, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 21)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            21)
       << "incorrect value for n_sats, expected 21, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 501868000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            501868000)
       << "incorrect value for tow, expected 501868000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, -3)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            -3)
       << "incorrect value for x, expected -3, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            1)
       << "incorrect value for y, expected 1, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            4)
       << "incorrect value for z, expected 4, is " << last_msg_->z;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgVelEcefGnss.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgVelEcefGnss.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgVelEcefGnss0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -117,19 +124,33 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelEcefGnss0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 4096);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->accuracy, 89)
+  EXPECT_EQ(get_as<decltype(last_msg_->accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->accuracy)),
+            89)
       << "incorrect value for accuracy, expected 89, is "
       << last_msg_->accuracy;
-  EXPECT_EQ(last_msg_->flags, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            2)
       << "incorrect value for flags, expected 2, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_sats, 21)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            21)
       << "incorrect value for n_sats, expected 21, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 501868000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            501868000)
       << "incorrect value for tow, expected 501868000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, -3)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            -3)
       << "incorrect value for x, expected -3, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            1)
       << "incorrect value for y, expected 1, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            4)
       << "incorrect value for z, expected 4, is " << last_msg_->z;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgVelNED.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgVelNED.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgVelNED0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -118,22 +125,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelNED0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, -13)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            -13)
       << "incorrect value for d, expected -13, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, -4)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            -4)
       << "incorrect value for e, expected -4, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            3)
       << "incorrect value for n, expected 3, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            14)
       << "incorrect value for n_sats, expected 14, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 326825000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326825000)
       << "incorrect value for tow, expected 326825000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -226,22 +249,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelNED1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, -24)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            -24)
       << "incorrect value for d, expected -24, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, -1)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            -1)
       << "incorrect value for e, expected -1, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, -4)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            -4)
       << "incorrect value for n, expected -4, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            15)
       << "incorrect value for n_sats, expected 15, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 326825500)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326825500)
       << "incorrect value for tow, expected 326825500, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -334,22 +373,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelNED2, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, -12)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            -12)
       << "incorrect value for d, expected -12, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, -3)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            -3)
       << "incorrect value for e, expected -3, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            0)
       << "incorrect value for n, expected 0, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            15)
       << "incorrect value for n_sats, expected 15, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 326826000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326826000)
       << "incorrect value for tow, expected 326826000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -442,22 +497,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelNED3, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, -24)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            -24)
       << "incorrect value for d, expected -24, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            3)
       << "incorrect value for e, expected 3, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            2)
       << "incorrect value for n, expected 2, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            15)
       << "incorrect value for n_sats, expected 15, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 326826500)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326826500)
       << "incorrect value for tow, expected 326826500, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -550,22 +621,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelNED4, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, -21)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            -21)
       << "incorrect value for d, expected -21, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            0)
       << "incorrect value for e, expected 0, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            1)
       << "incorrect value for n, expected 1, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            15)
       << "incorrect value for n_sats, expected 15, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 326827000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            326827000)
       << "incorrect value for tow, expected 326827000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgVelNEDCOV.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgVelNEDCOV.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgVelNEDCOV0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -135,16 +142,28 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelNEDCOV0, Test) {
       << "incorrect value for cov_n_e, expected 1.0, is " << last_msg_->cov_n_e;
   EXPECT_LT((last_msg_->cov_n_n * 100 - 1.0 * 100), 0.05)
       << "incorrect value for cov_n_n, expected 1.0, is " << last_msg_->cov_n_n;
-  EXPECT_EQ(last_msg_->d, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            1)
       << "incorrect value for d, expected 1, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            1)
       << "incorrect value for e, expected 1, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            1)
       << "incorrect value for n, expected 1, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            10)
       << "incorrect value for n_sats, expected 10, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 100)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            100)
       << "incorrect value for tow, expected 100, is " << last_msg_->tow;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgVelNEDDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgVelNEDDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgVelNEDDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -118,22 +125,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelNEDDepA0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            0)
       << "incorrect value for d, expected 0, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, 3996)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            3996)
       << "incorrect value for e, expected 3996, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, -1082)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            -1082)
       << "incorrect value for n, expected -1082, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            9)
       << "incorrect value for n_sats, expected 9, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 2567700)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2567700)
       << "incorrect value for tow, expected 2567700, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -226,22 +249,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelNEDDepA1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            0)
       << "incorrect value for d, expected 0, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, 3791)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            3791)
       << "incorrect value for e, expected 3791, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, -1010)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            -1010)
       << "incorrect value for n, expected -1010, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            9)
       << "incorrect value for n_sats, expected 9, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 2567800)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2567800)
       << "incorrect value for tow, expected 2567800, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -334,22 +373,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelNEDDepA2, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            0)
       << "incorrect value for d, expected 0, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, 3724)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            3724)
       << "incorrect value for e, expected 3724, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, -976)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            -976)
       << "incorrect value for n, expected -976, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            9)
       << "incorrect value for n_sats, expected 9, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 2567900)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2567900)
       << "incorrect value for tow, expected 2567900, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -442,22 +497,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelNEDDepA3, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            0)
       << "incorrect value for d, expected 0, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, 3848)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            3848)
       << "incorrect value for e, expected 3848, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, -992)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            -992)
       << "incorrect value for n, expected -992, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            9)
       << "incorrect value for n_sats, expected 9, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 2568000)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2568000)
       << "incorrect value for tow, expected 2568000, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -550,22 +621,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelNEDDepA4, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            0)
       << "incorrect value for d, expected 0, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, 3724)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            3724)
       << "incorrect value for e, expected 3724, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, -944)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            -944)
       << "incorrect value for n, expected -944, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            9)
       << "incorrect value for n_sats, expected 9, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 2568100)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2568100)
       << "incorrect value for tow, expected 2568100, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -658,22 +745,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelNEDDepA5, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, 25)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            25)
       << "incorrect value for d, expected 25, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, 26)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            26)
       << "incorrect value for e, expected 26, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, -27)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            -27)
       << "incorrect value for n, expected -27, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            8)
       << "incorrect value for n_sats, expected 8, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407084500)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407084500)
       << "incorrect value for tow, expected 407084500, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -766,22 +869,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelNEDDepA6, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, -24)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            -24)
       << "incorrect value for d, expected -24, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            15)
       << "incorrect value for e, expected 15, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            4)
       << "incorrect value for n, expected 4, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            8)
       << "incorrect value for n_sats, expected 8, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407084600)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407084600)
       << "incorrect value for tow, expected 407084600, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -874,22 +993,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelNEDDepA7, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, -9)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            -9)
       << "incorrect value for d, expected -9, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, -24)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            -24)
       << "incorrect value for e, expected -24, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, -5)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            -5)
       << "incorrect value for n, expected -5, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            8)
       << "incorrect value for n_sats, expected 8, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407084700)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407084700)
       << "incorrect value for tow, expected 407084700, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -982,22 +1117,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelNEDDepA8, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, -34)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            -34)
       << "incorrect value for d, expected -34, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            2)
       << "incorrect value for e, expected 2, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            10)
       << "incorrect value for n, expected 10, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            8)
       << "incorrect value for n_sats, expected 8, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407084800)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407084800)
       << "incorrect value for tow, expected 407084800, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -1090,22 +1241,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelNEDDepA9, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            7)
       << "incorrect value for d, expected 7, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, -2)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            -2)
       << "incorrect value for e, expected -2, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, -8)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            -8)
       << "incorrect value for n, expected -8, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            8)
       << "incorrect value for n_sats, expected 8, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407084900)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407084900)
       << "incorrect value for tow, expected 407084900, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }
@@ -1198,22 +1365,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelNEDDepA10, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, -108)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            -108)
       << "incorrect value for d, expected -108, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, -3)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            -3)
       << "incorrect value for e, expected -3, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            0)
       << "incorrect value for h_accuracy, expected 0, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, -1)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            -1)
       << "incorrect value for n, expected -1, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            5)
       << "incorrect value for n_sats, expected 5, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 407151150)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            407151150)
       << "incorrect value for tow, expected 407151150, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            0)
       << "incorrect value for v_accuracy, expected 0, is "
       << last_msg_->v_accuracy;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgVelNedCovGnss.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgVelNedCovGnss.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgVelNedCovGnss0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -143,16 +150,28 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelNedCovGnss0, Test) {
   EXPECT_LT((last_msg_->cov_n_n * 100 - 0.0015810149489 * 100), 0.05)
       << "incorrect value for cov_n_n, expected 0.0015810149489, is "
       << last_msg_->cov_n_n;
-  EXPECT_EQ(last_msg_->d, -10)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            -10)
       << "incorrect value for d, expected -10, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            0)
       << "incorrect value for e, expected 0, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            2)
       << "incorrect value for flags, expected 2, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n, -5)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            -5)
       << "incorrect value for n, expected -5, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 21)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            21)
       << "incorrect value for n_sats, expected 21, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 501868200)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            501868200)
       << "incorrect value for tow, expected 501868200, is " << last_msg_->tow;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_navigation_MsgVelNedGnss.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_navigation_MsgVelNedGnss.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/navigation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_navigation_MsgVelNedGnss0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -118,22 +125,38 @@ TEST_F(Test_legacy_auto_check_sbp_navigation_MsgVelNedGnss0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 4096);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->d, -10)
+  EXPECT_EQ(get_as<decltype(last_msg_->d)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->d)),
+            -10)
       << "incorrect value for d, expected -10, is " << last_msg_->d;
-  EXPECT_EQ(last_msg_->e, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->e)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->e)),
+            0)
       << "incorrect value for e, expected 0, is " << last_msg_->e;
-  EXPECT_EQ(last_msg_->flags, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            2)
       << "incorrect value for flags, expected 2, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->h_accuracy, 40)
+  EXPECT_EQ(get_as<decltype(last_msg_->h_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->h_accuracy)),
+            40)
       << "incorrect value for h_accuracy, expected 40, is "
       << last_msg_->h_accuracy;
-  EXPECT_EQ(last_msg_->n, -5)
+  EXPECT_EQ(get_as<decltype(last_msg_->n)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n)),
+            -5)
       << "incorrect value for n, expected -5, is " << last_msg_->n;
-  EXPECT_EQ(last_msg_->n_sats, 21)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            21)
       << "incorrect value for n_sats, expected 21, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 501868200)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            501868200)
       << "incorrect value for tow, expected 501868200, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->v_accuracy, 89)
+  EXPECT_EQ(get_as<decltype(last_msg_->v_accuracy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->v_accuracy)),
+            89)
       << "incorrect value for v_accuracy, expected 89, is "
       << last_msg_->v_accuracy;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_ndb_MsgNdbEvent.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_ndb_MsgNdbEvent.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/ndb.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_ndb_MsgNdbEvent0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -120,32 +127,52 @@ TEST_F(Test_legacy_auto_check_sbp_ndb_MsgNdbEvent0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 44708);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->data_source, 115)
+  EXPECT_EQ(get_as<decltype(last_msg_->data_source)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data_source)),
+            115)
       << "incorrect value for data_source, expected 115, is "
       << last_msg_->data_source;
-  EXPECT_EQ(last_msg_->event, 249)
+  EXPECT_EQ(get_as<decltype(last_msg_->event)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->event)),
+            249)
       << "incorrect value for event, expected 249, is " << last_msg_->event;
-  EXPECT_EQ(last_msg_->object_sid.code, 74)
+  EXPECT_EQ(get_as<decltype(last_msg_->object_sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->object_sid.code)),
+            74)
       << "incorrect value for object_sid.code, expected 74, is "
       << last_msg_->object_sid.code;
-  EXPECT_EQ(last_msg_->object_sid.sat, 238)
+  EXPECT_EQ(get_as<decltype(last_msg_->object_sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->object_sid.sat)),
+            238)
       << "incorrect value for object_sid.sat, expected 238, is "
       << last_msg_->object_sid.sat;
-  EXPECT_EQ(last_msg_->object_type, 73)
+  EXPECT_EQ(get_as<decltype(last_msg_->object_type)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->object_type)),
+            73)
       << "incorrect value for object_type, expected 73, is "
       << last_msg_->object_type;
-  EXPECT_EQ(last_msg_->original_sender, 38070)
+  EXPECT_EQ(get_as<decltype(last_msg_->original_sender)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->original_sender)),
+            38070)
       << "incorrect value for original_sender, expected 38070, is "
       << last_msg_->original_sender;
-  EXPECT_EQ(last_msg_->recv_time, 299461164286)
+  EXPECT_EQ(get_as<decltype(last_msg_->recv_time)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->recv_time)),
+            299461164286)
       << "incorrect value for recv_time, expected 299461164286, is "
       << last_msg_->recv_time;
-  EXPECT_EQ(last_msg_->result, 205)
+  EXPECT_EQ(get_as<decltype(last_msg_->result)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->result)),
+            205)
       << "incorrect value for result, expected 205, is " << last_msg_->result;
-  EXPECT_EQ(last_msg_->src_sid.code, 66)
+  EXPECT_EQ(get_as<decltype(last_msg_->src_sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->src_sid.code)),
+            66)
       << "incorrect value for src_sid.code, expected 66, is "
       << last_msg_->src_sid.code;
-  EXPECT_EQ(last_msg_->src_sid.sat, 98)
+  EXPECT_EQ(get_as<decltype(last_msg_->src_sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->src_sid.sat)),
+            98)
       << "incorrect value for src_sid.sat, expected 98, is "
       << last_msg_->src_sid.sat;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgAlmanacGLO.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgAlmanacGLO.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgAlmanacGLO0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -129,28 +136,44 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgAlmanacGLO0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->common.fit_interval, 14400)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.fit_interval)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.fit_interval)),
+      14400)
       << "incorrect value for common.fit_interval, expected 14400, is "
       << last_msg_->common.fit_interval;
-  EXPECT_EQ(last_msg_->common.health_bits, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.health_bits)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.health_bits)),
+      0)
       << "incorrect value for common.health_bits, expected 0, is "
       << last_msg_->common.health_bits;
-  EXPECT_EQ(last_msg_->common.sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.code)),
+            0)
       << "incorrect value for common.sid.code, expected 0, is "
       << last_msg_->common.sid.code;
-  EXPECT_EQ(last_msg_->common.sid.sat, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.sat)),
+            22)
       << "incorrect value for common.sid.sat, expected 22, is "
       << last_msg_->common.sid.sat;
-  EXPECT_EQ(last_msg_->common.toa.tow, 446384)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toa.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toa.tow)),
+            446384)
       << "incorrect value for common.toa.tow, expected 446384, is "
       << last_msg_->common.toa.tow;
-  EXPECT_EQ(last_msg_->common.toa.wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toa.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toa.wn)),
+            2154)
       << "incorrect value for common.toa.wn, expected 2154, is "
       << last_msg_->common.toa.wn;
   EXPECT_LT((last_msg_->common.ura * 100 - 2.2 * 100), 0.05)
       << "incorrect value for common.ura, expected 2.2, is "
       << last_msg_->common.ura;
-  EXPECT_EQ(last_msg_->common.valid, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.valid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.valid)),
+            1)
       << "incorrect value for common.valid, expected 1, is "
       << last_msg_->common.valid;
   EXPECT_LT((last_msg_->epsilon * 100 - -0.98930366296 * 100), 0.05)

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgAlmanacGLODep.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgAlmanacGLODep.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgAlmanacGLODep0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -130,31 +137,50 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgAlmanacGLODep0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->common.fit_interval, 14400)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.fit_interval)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.fit_interval)),
+      14400)
       << "incorrect value for common.fit_interval, expected 14400, is "
       << last_msg_->common.fit_interval;
-  EXPECT_EQ(last_msg_->common.health_bits, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.health_bits)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.health_bits)),
+      0)
       << "incorrect value for common.health_bits, expected 0, is "
       << last_msg_->common.health_bits;
-  EXPECT_EQ(last_msg_->common.sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.code)),
+            0)
       << "incorrect value for common.sid.code, expected 0, is "
       << last_msg_->common.sid.code;
-  EXPECT_EQ(last_msg_->common.sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.reserved)),
+      0)
       << "incorrect value for common.sid.reserved, expected 0, is "
       << last_msg_->common.sid.reserved;
-  EXPECT_EQ(last_msg_->common.sid.sat, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.sat)),
+            22)
       << "incorrect value for common.sid.sat, expected 22, is "
       << last_msg_->common.sid.sat;
-  EXPECT_EQ(last_msg_->common.toa.tow, 446384)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toa.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toa.tow)),
+            446384)
       << "incorrect value for common.toa.tow, expected 446384, is "
       << last_msg_->common.toa.tow;
-  EXPECT_EQ(last_msg_->common.toa.wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toa.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toa.wn)),
+            2154)
       << "incorrect value for common.toa.wn, expected 2154, is "
       << last_msg_->common.toa.wn;
   EXPECT_LT((last_msg_->common.ura * 100 - 2.2 * 100), 0.05)
       << "incorrect value for common.ura, expected 2.2, is "
       << last_msg_->common.ura;
-  EXPECT_EQ(last_msg_->common.valid, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.valid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.valid)),
+            1)
       << "incorrect value for common.valid, expected 1, is "
       << last_msg_->common.valid;
   EXPECT_LT((last_msg_->epsilon * 100 - -0.98930366296 * 100), 0.05)

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgAlmanacGPS.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgAlmanacGPS.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgAlmanacGPS0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -138,28 +145,44 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgAlmanacGPS0, Test) {
   EXPECT_LT((last_msg_->af1 * 100 - 8.98126018001e-12 * 100), 0.05)
       << "incorrect value for af1, expected 8.98126018001e-12, is "
       << last_msg_->af1;
-  EXPECT_EQ(last_msg_->common.fit_interval, 14400)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.fit_interval)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.fit_interval)),
+      14400)
       << "incorrect value for common.fit_interval, expected 14400, is "
       << last_msg_->common.fit_interval;
-  EXPECT_EQ(last_msg_->common.health_bits, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.health_bits)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.health_bits)),
+      0)
       << "incorrect value for common.health_bits, expected 0, is "
       << last_msg_->common.health_bits;
-  EXPECT_EQ(last_msg_->common.sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.code)),
+            0)
       << "incorrect value for common.sid.code, expected 0, is "
       << last_msg_->common.sid.code;
-  EXPECT_EQ(last_msg_->common.sid.sat, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.sat)),
+            22)
       << "incorrect value for common.sid.sat, expected 22, is "
       << last_msg_->common.sid.sat;
-  EXPECT_EQ(last_msg_->common.toa.tow, 446384)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toa.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toa.tow)),
+            446384)
       << "incorrect value for common.toa.tow, expected 446384, is "
       << last_msg_->common.toa.tow;
-  EXPECT_EQ(last_msg_->common.toa.wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toa.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toa.wn)),
+            2154)
       << "incorrect value for common.toa.wn, expected 2154, is "
       << last_msg_->common.toa.wn;
   EXPECT_LT((last_msg_->common.ura * 100 - 2.2 * 100), 0.05)
       << "incorrect value for common.ura, expected 2.2, is "
       << last_msg_->common.ura;
-  EXPECT_EQ(last_msg_->common.valid, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.valid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.valid)),
+            1)
       << "incorrect value for common.valid, expected 1, is "
       << last_msg_->common.valid;
   EXPECT_LT((last_msg_->ecc * 100 - 0.00707220705226 * 100), 0.05)

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgAlmanacGPSDep.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgAlmanacGPSDep.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgAlmanacGPSDep0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -139,31 +146,50 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgAlmanacGPSDep0, Test) {
   EXPECT_LT((last_msg_->af1 * 100 - 8.98126018001e-12 * 100), 0.05)
       << "incorrect value for af1, expected 8.98126018001e-12, is "
       << last_msg_->af1;
-  EXPECT_EQ(last_msg_->common.fit_interval, 14400)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.fit_interval)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.fit_interval)),
+      14400)
       << "incorrect value for common.fit_interval, expected 14400, is "
       << last_msg_->common.fit_interval;
-  EXPECT_EQ(last_msg_->common.health_bits, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.health_bits)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.health_bits)),
+      0)
       << "incorrect value for common.health_bits, expected 0, is "
       << last_msg_->common.health_bits;
-  EXPECT_EQ(last_msg_->common.sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.code)),
+            0)
       << "incorrect value for common.sid.code, expected 0, is "
       << last_msg_->common.sid.code;
-  EXPECT_EQ(last_msg_->common.sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.reserved)),
+      0)
       << "incorrect value for common.sid.reserved, expected 0, is "
       << last_msg_->common.sid.reserved;
-  EXPECT_EQ(last_msg_->common.sid.sat, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.sat)),
+            22)
       << "incorrect value for common.sid.sat, expected 22, is "
       << last_msg_->common.sid.sat;
-  EXPECT_EQ(last_msg_->common.toa.tow, 446384)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toa.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toa.tow)),
+            446384)
       << "incorrect value for common.toa.tow, expected 446384, is "
       << last_msg_->common.toa.tow;
-  EXPECT_EQ(last_msg_->common.toa.wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toa.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toa.wn)),
+            2154)
       << "incorrect value for common.toa.wn, expected 2154, is "
       << last_msg_->common.toa.wn;
   EXPECT_LT((last_msg_->common.ura * 100 - 2.2 * 100), 0.05)
       << "incorrect value for common.ura, expected 2.2, is "
       << last_msg_->common.ura;
-  EXPECT_EQ(last_msg_->common.valid, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.valid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.valid)),
+            1)
       << "incorrect value for common.valid, expected 1, is "
       << last_msg_->common.valid;
   EXPECT_LT((last_msg_->ecc * 100 - 0.00707220705226 * 100), 0.05)

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgBasePosEcef.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgBasePosEcef.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgBasePosEcef0
     : public ::testing::Test,
       public sbp::LegacyState,

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgBasePosLLH.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgBasePosLLH.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgBasePosLLH0
     : public ::testing::Test,
       public sbp::LegacyState,

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisBds.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisBds.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgEphemerisBds0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -177,28 +184,44 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisBds0, Test) {
   EXPECT_LT((last_msg_->c_us * 100 - 6.55185431242e-07 * 100), 0.05)
       << "incorrect value for c_us, expected 6.55185431242e-07, is "
       << last_msg_->c_us;
-  EXPECT_EQ(last_msg_->common.fit_interval, 10800)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.fit_interval)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.fit_interval)),
+      10800)
       << "incorrect value for common.fit_interval, expected 10800, is "
       << last_msg_->common.fit_interval;
-  EXPECT_EQ(last_msg_->common.health_bits, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.health_bits)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.health_bits)),
+      0)
       << "incorrect value for common.health_bits, expected 0, is "
       << last_msg_->common.health_bits;
-  EXPECT_EQ(last_msg_->common.sid.code, 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.code)),
+            12)
       << "incorrect value for common.sid.code, expected 12, is "
       << last_msg_->common.sid.code;
-  EXPECT_EQ(last_msg_->common.sid.sat, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.sat)),
+            8)
       << "incorrect value for common.sid.sat, expected 8, is "
       << last_msg_->common.sid.sat;
-  EXPECT_EQ(last_msg_->common.toe.tow, 439214)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toe.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toe.tow)),
+            439214)
       << "incorrect value for common.toe.tow, expected 439214, is "
       << last_msg_->common.toe.tow;
-  EXPECT_EQ(last_msg_->common.toe.wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toe.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toe.wn)),
+            2154)
       << "incorrect value for common.toe.wn, expected 2154, is "
       << last_msg_->common.toe.wn;
   EXPECT_LT((last_msg_->common.ura * 100 - 2.0 * 100), 0.05)
       << "incorrect value for common.ura, expected 2.0, is "
       << last_msg_->common.ura;
-  EXPECT_EQ(last_msg_->common.valid, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.valid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.valid)),
+            1)
       << "incorrect value for common.valid, expected 1, is "
       << last_msg_->common.valid;
   EXPECT_LT((last_msg_->dn * 100 - 1.12968991326e-09 * 100), 0.05)
@@ -213,9 +236,13 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisBds0, Test) {
   EXPECT_LT((last_msg_->inc_dot * 100 - 7.5074555728e-10 * 100), 0.05)
       << "incorrect value for inc_dot, expected 7.5074555728e-10, is "
       << last_msg_->inc_dot;
-  EXPECT_EQ(last_msg_->iodc, 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->iodc)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iodc)),
+            5)
       << "incorrect value for iodc, expected 5, is " << last_msg_->iodc;
-  EXPECT_EQ(last_msg_->iode, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->iode)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iode)),
+            6)
       << "incorrect value for iode, expected 6, is " << last_msg_->iode;
   EXPECT_LT((last_msg_->m0 * 100 - 1.69439581907 * 100), 0.05)
       << "incorrect value for m0, expected 1.69439581907, is " << last_msg_->m0;
@@ -234,10 +261,14 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisBds0, Test) {
   EXPECT_LT((last_msg_->tgd2 * 100 - -1.09999997999e-09 * 100), 0.05)
       << "incorrect value for tgd2, expected -1.09999997999e-09, is "
       << last_msg_->tgd2;
-  EXPECT_EQ(last_msg_->toc.tow, 439214)
+  EXPECT_EQ(get_as<decltype(last_msg_->toc.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->toc.tow)),
+            439214)
       << "incorrect value for toc.tow, expected 439214, is "
       << last_msg_->toc.tow;
-  EXPECT_EQ(last_msg_->toc.wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->toc.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->toc.wn)),
+            2154)
       << "incorrect value for toc.wn, expected 2154, is " << last_msg_->toc.wn;
   EXPECT_LT((last_msg_->w * 100 - -2.69860320574 * 100), 0.05)
       << "incorrect value for w, expected -2.69860320574, is " << last_msg_->w;

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgEphemerisDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -177,7 +184,9 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisDepA0, Test) {
   EXPECT_LT((last_msg_->ecc * 100 - 0.00707220705226 * 100), 0.05)
       << "incorrect value for ecc, expected 0.00707220705226, is "
       << last_msg_->ecc;
-  EXPECT_EQ(last_msg_->healthy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->healthy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->healthy)),
+            0)
       << "incorrect value for healthy, expected 0, is " << last_msg_->healthy;
   EXPECT_LT((last_msg_->inc * 100 - 0.934151448026 * 100), 0.05)
       << "incorrect value for inc, expected 0.934151448026, is "
@@ -194,7 +203,9 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisDepA0, Test) {
   EXPECT_LT((last_msg_->omegadot * 100 - -8.90358515577e-09 * 100), 0.05)
       << "incorrect value for omegadot, expected -8.90358515577e-09, is "
       << last_msg_->omegadot;
-  EXPECT_EQ(last_msg_->prn, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->prn)),
+            22)
       << "incorrect value for prn, expected 22, is " << last_msg_->prn;
   EXPECT_LT((last_msg_->sqrta * 100 - 5153.55002975 * 100), 0.05)
       << "incorrect value for sqrta, expected 5153.55002975, is "
@@ -205,14 +216,20 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisDepA0, Test) {
   EXPECT_LT((last_msg_->toc_tow * 100 - 446384.2 * 100), 0.05)
       << "incorrect value for toc_tow, expected 446384.2, is "
       << last_msg_->toc_tow;
-  EXPECT_EQ(last_msg_->toc_wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->toc_wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->toc_wn)),
+            2154)
       << "incorrect value for toc_wn, expected 2154, is " << last_msg_->toc_wn;
   EXPECT_LT((last_msg_->toe_tow * 100 - 446384.2 * 100), 0.05)
       << "incorrect value for toe_tow, expected 446384.2, is "
       << last_msg_->toe_tow;
-  EXPECT_EQ(last_msg_->toe_wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->toe_wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->toe_wn)),
+            2154)
       << "incorrect value for toe_wn, expected 2154, is " << last_msg_->toe_wn;
-  EXPECT_EQ(last_msg_->valid, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->valid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->valid)),
+            1)
       << "incorrect value for valid, expected 1, is " << last_msg_->valid;
   EXPECT_LT((last_msg_->w * 100 - -0.98930366296 * 100), 0.05)
       << "incorrect value for w, expected -0.98930366296, is " << last_msg_->w;

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisDepC.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisDepC.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgEphemerisDepC0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -182,7 +189,9 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisDepC0, Test) {
   EXPECT_LT((last_msg_->ecc * 100 - 0.00707220705226 * 100), 0.05)
       << "incorrect value for ecc, expected 0.00707220705226, is "
       << last_msg_->ecc;
-  EXPECT_EQ(last_msg_->healthy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->healthy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->healthy)),
+            0)
       << "incorrect value for healthy, expected 0, is " << last_msg_->healthy;
   EXPECT_LT((last_msg_->inc * 100 - 0.934151448026 * 100), 0.05)
       << "incorrect value for inc, expected 0.934151448026, is "
@@ -190,9 +199,13 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisDepC0, Test) {
   EXPECT_LT((last_msg_->inc_dot * 100 - -4.03588239642e-11 * 100), 0.05)
       << "incorrect value for inc_dot, expected -4.03588239642e-11, is "
       << last_msg_->inc_dot;
-  EXPECT_EQ(last_msg_->iodc, 45)
+  EXPECT_EQ(get_as<decltype(last_msg_->iodc)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iodc)),
+            45)
       << "incorrect value for iodc, expected 45, is " << last_msg_->iodc;
-  EXPECT_EQ(last_msg_->iode, 45)
+  EXPECT_EQ(get_as<decltype(last_msg_->iode)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iode)),
+            45)
       << "incorrect value for iode, expected 45, is " << last_msg_->iode;
   EXPECT_LT((last_msg_->m0 * 100 - -0.0220007884211 * 100), 0.05)
       << "incorrect value for m0, expected -0.0220007884211, is "
@@ -203,14 +216,22 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisDepC0, Test) {
   EXPECT_LT((last_msg_->omegadot * 100 - -8.90358515577e-09 * 100), 0.05)
       << "incorrect value for omegadot, expected -8.90358515577e-09, is "
       << last_msg_->omegadot;
-  EXPECT_EQ(last_msg_->reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved)),
+            0)
       << "incorrect value for reserved, expected 0, is " << last_msg_->reserved;
-  EXPECT_EQ(last_msg_->sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.code)),
+            0)
       << "incorrect value for sid.code, expected 0, is " << last_msg_->sid.code;
-  EXPECT_EQ(last_msg_->sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.reserved)),
+            0)
       << "incorrect value for sid.reserved, expected 0, is "
       << last_msg_->sid.reserved;
-  EXPECT_EQ(last_msg_->sid.sat, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.sat)),
+            22)
       << "incorrect value for sid.sat, expected 22, is " << last_msg_->sid.sat;
   EXPECT_LT((last_msg_->sqrta * 100 - 5153.55002975 * 100), 0.05)
       << "incorrect value for sqrta, expected 5153.55002975, is "
@@ -221,14 +242,20 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisDepC0, Test) {
   EXPECT_LT((last_msg_->toc_tow * 100 - 446384.2 * 100), 0.05)
       << "incorrect value for toc_tow, expected 446384.2, is "
       << last_msg_->toc_tow;
-  EXPECT_EQ(last_msg_->toc_wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->toc_wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->toc_wn)),
+            2154)
       << "incorrect value for toc_wn, expected 2154, is " << last_msg_->toc_wn;
   EXPECT_LT((last_msg_->toe_tow * 100 - 446384.2 * 100), 0.05)
       << "incorrect value for toe_tow, expected 446384.2, is "
       << last_msg_->toe_tow;
-  EXPECT_EQ(last_msg_->toe_wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->toe_wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->toe_wn)),
+            2154)
       << "incorrect value for toe_wn, expected 2154, is " << last_msg_->toe_wn;
-  EXPECT_EQ(last_msg_->valid, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->valid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->valid)),
+            1)
       << "incorrect value for valid, expected 1, is " << last_msg_->valid;
   EXPECT_LT((last_msg_->w * 100 - -0.98930366296 * 100), 0.05)
       << "incorrect value for w, expected -0.98930366296, is " << last_msg_->w;

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisDepD.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisDepD.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgEphemerisDepD0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -182,7 +189,9 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisDepD0, Test) {
   EXPECT_LT((last_msg_->ecc * 100 - 0.00707220705226 * 100), 0.05)
       << "incorrect value for ecc, expected 0.00707220705226, is "
       << last_msg_->ecc;
-  EXPECT_EQ(last_msg_->healthy, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->healthy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->healthy)),
+            0)
       << "incorrect value for healthy, expected 0, is " << last_msg_->healthy;
   EXPECT_LT((last_msg_->inc * 100 - 0.934151448026 * 100), 0.05)
       << "incorrect value for inc, expected 0.934151448026, is "
@@ -190,9 +199,13 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisDepD0, Test) {
   EXPECT_LT((last_msg_->inc_dot * 100 - -4.03588239642e-11 * 100), 0.05)
       << "incorrect value for inc_dot, expected -4.03588239642e-11, is "
       << last_msg_->inc_dot;
-  EXPECT_EQ(last_msg_->iodc, 45)
+  EXPECT_EQ(get_as<decltype(last_msg_->iodc)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iodc)),
+            45)
       << "incorrect value for iodc, expected 45, is " << last_msg_->iodc;
-  EXPECT_EQ(last_msg_->iode, 45)
+  EXPECT_EQ(get_as<decltype(last_msg_->iode)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iode)),
+            45)
       << "incorrect value for iode, expected 45, is " << last_msg_->iode;
   EXPECT_LT((last_msg_->m0 * 100 - -0.0220007884211 * 100), 0.05)
       << "incorrect value for m0, expected -0.0220007884211, is "
@@ -203,14 +216,22 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisDepD0, Test) {
   EXPECT_LT((last_msg_->omegadot * 100 - -8.90358515577e-09 * 100), 0.05)
       << "incorrect value for omegadot, expected -8.90358515577e-09, is "
       << last_msg_->omegadot;
-  EXPECT_EQ(last_msg_->reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved)),
+            0)
       << "incorrect value for reserved, expected 0, is " << last_msg_->reserved;
-  EXPECT_EQ(last_msg_->sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.code)),
+            0)
       << "incorrect value for sid.code, expected 0, is " << last_msg_->sid.code;
-  EXPECT_EQ(last_msg_->sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.reserved)),
+            0)
       << "incorrect value for sid.reserved, expected 0, is "
       << last_msg_->sid.reserved;
-  EXPECT_EQ(last_msg_->sid.sat, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.sat)),
+            22)
       << "incorrect value for sid.sat, expected 22, is " << last_msg_->sid.sat;
   EXPECT_LT((last_msg_->sqrta * 100 - 5153.55002975 * 100), 0.05)
       << "incorrect value for sqrta, expected 5153.55002975, is "
@@ -221,14 +242,20 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisDepD0, Test) {
   EXPECT_LT((last_msg_->toc_tow * 100 - 446384.2 * 100), 0.05)
       << "incorrect value for toc_tow, expected 446384.2, is "
       << last_msg_->toc_tow;
-  EXPECT_EQ(last_msg_->toc_wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->toc_wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->toc_wn)),
+            2154)
       << "incorrect value for toc_wn, expected 2154, is " << last_msg_->toc_wn;
   EXPECT_LT((last_msg_->toe_tow * 100 - 446384.2 * 100), 0.05)
       << "incorrect value for toe_tow, expected 446384.2, is "
       << last_msg_->toe_tow;
-  EXPECT_EQ(last_msg_->toe_wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->toe_wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->toe_wn)),
+            2154)
       << "incorrect value for toe_wn, expected 2154, is " << last_msg_->toe_wn;
-  EXPECT_EQ(last_msg_->valid, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->valid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->valid)),
+            1)
       << "incorrect value for valid, expected 1, is " << last_msg_->valid;
   EXPECT_LT((last_msg_->w * 100 - -0.98930366296 * 100), 0.05)
       << "incorrect value for w, expected -0.98930366296, is " << last_msg_->w;

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisGLO.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisGLO.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgEphemerisGLO0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -182,39 +189,59 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisGLO0, Test) {
   EXPECT_LT((last_msg_->acc[2] * 100 - 2.79396772385e-06 * 100), 0.05)
       << "incorrect value for acc[2], expected 2.79396772385e-06, is "
       << last_msg_->acc[2];
-  EXPECT_EQ(last_msg_->common.fit_interval, 2400)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.fit_interval)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.fit_interval)),
+      2400)
       << "incorrect value for common.fit_interval, expected 2400, is "
       << last_msg_->common.fit_interval;
-  EXPECT_EQ(last_msg_->common.health_bits, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.health_bits)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.health_bits)),
+      0)
       << "incorrect value for common.health_bits, expected 0, is "
       << last_msg_->common.health_bits;
-  EXPECT_EQ(last_msg_->common.sid.code, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.code)),
+            3)
       << "incorrect value for common.sid.code, expected 3, is "
       << last_msg_->common.sid.code;
-  EXPECT_EQ(last_msg_->common.sid.sat, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.sat)),
+            4)
       << "incorrect value for common.sid.sat, expected 4, is "
       << last_msg_->common.sid.sat;
-  EXPECT_EQ(last_msg_->common.toe.tow, 443718)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toe.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toe.tow)),
+            443718)
       << "incorrect value for common.toe.tow, expected 443718, is "
       << last_msg_->common.toe.tow;
-  EXPECT_EQ(last_msg_->common.toe.wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toe.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toe.wn)),
+            2154)
       << "incorrect value for common.toe.wn, expected 2154, is "
       << last_msg_->common.toe.wn;
   EXPECT_LT((last_msg_->common.ura * 100 - 5.0 * 100), 0.05)
       << "incorrect value for common.ura, expected 5.0, is "
       << last_msg_->common.ura;
-  EXPECT_EQ(last_msg_->common.valid, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.valid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.valid)),
+            1)
       << "incorrect value for common.valid, expected 1, is "
       << last_msg_->common.valid;
   EXPECT_LT((last_msg_->d_tau * 100 - -2.79396772385e-09 * 100), 0.05)
       << "incorrect value for d_tau, expected -2.79396772385e-09, is "
       << last_msg_->d_tau;
-  EXPECT_EQ(last_msg_->fcn, 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fcn)),
+            14)
       << "incorrect value for fcn, expected 14, is " << last_msg_->fcn;
   EXPECT_LT((last_msg_->gamma * 100 - 9.09494701773e-13 * 100), 0.05)
       << "incorrect value for gamma, expected 9.09494701773e-13, is "
       << last_msg_->gamma;
-  EXPECT_EQ(last_msg_->iod, 100)
+  EXPECT_EQ(get_as<decltype(last_msg_->iod)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iod)),
+            100)
       << "incorrect value for iod, expected 100, is " << last_msg_->iod;
   EXPECT_LT((last_msg_->pos[0] * 100 - -12177330.0781 * 100), 0.05)
       << "incorrect value for pos[0], expected -12177330.0781, is "

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisGLODepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisGLODepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgEphemerisGLODepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -183,31 +190,50 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisGLODepA0, Test) {
   EXPECT_LT((last_msg_->acc[2] * 100 - 2.79396772385e-06 * 100), 0.05)
       << "incorrect value for acc[2], expected 2.79396772385e-06, is "
       << last_msg_->acc[2];
-  EXPECT_EQ(last_msg_->common.fit_interval, 2400)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.fit_interval)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.fit_interval)),
+      2400)
       << "incorrect value for common.fit_interval, expected 2400, is "
       << last_msg_->common.fit_interval;
-  EXPECT_EQ(last_msg_->common.health_bits, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.health_bits)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.health_bits)),
+      0)
       << "incorrect value for common.health_bits, expected 0, is "
       << last_msg_->common.health_bits;
-  EXPECT_EQ(last_msg_->common.sid.code, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.code)),
+            3)
       << "incorrect value for common.sid.code, expected 3, is "
       << last_msg_->common.sid.code;
-  EXPECT_EQ(last_msg_->common.sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.reserved)),
+      0)
       << "incorrect value for common.sid.reserved, expected 0, is "
       << last_msg_->common.sid.reserved;
-  EXPECT_EQ(last_msg_->common.sid.sat, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.sat)),
+            4)
       << "incorrect value for common.sid.sat, expected 4, is "
       << last_msg_->common.sid.sat;
-  EXPECT_EQ(last_msg_->common.toe.tow, 443718)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toe.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toe.tow)),
+            443718)
       << "incorrect value for common.toe.tow, expected 443718, is "
       << last_msg_->common.toe.tow;
-  EXPECT_EQ(last_msg_->common.toe.wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toe.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toe.wn)),
+            2154)
       << "incorrect value for common.toe.wn, expected 2154, is "
       << last_msg_->common.toe.wn;
   EXPECT_LT((last_msg_->common.ura * 100 - 5.2 * 100), 0.05)
       << "incorrect value for common.ura, expected 5.2, is "
       << last_msg_->common.ura;
-  EXPECT_EQ(last_msg_->common.valid, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.valid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.valid)),
+            1)
       << "incorrect value for common.valid, expected 1, is "
       << last_msg_->common.valid;
   EXPECT_LT((last_msg_->gamma * 100 - 9.09494701773e-13 * 100), 0.05)

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisGLODepB.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisGLODepB.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgEphemerisGLODepB0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -182,28 +189,44 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisGLODepB0, Test) {
   EXPECT_LT((last_msg_->acc[2] * 100 - 2.79396772385e-06 * 100), 0.05)
       << "incorrect value for acc[2], expected 2.79396772385e-06, is "
       << last_msg_->acc[2];
-  EXPECT_EQ(last_msg_->common.fit_interval, 2400)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.fit_interval)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.fit_interval)),
+      2400)
       << "incorrect value for common.fit_interval, expected 2400, is "
       << last_msg_->common.fit_interval;
-  EXPECT_EQ(last_msg_->common.health_bits, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.health_bits)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.health_bits)),
+      0)
       << "incorrect value for common.health_bits, expected 0, is "
       << last_msg_->common.health_bits;
-  EXPECT_EQ(last_msg_->common.sid.code, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.code)),
+            3)
       << "incorrect value for common.sid.code, expected 3, is "
       << last_msg_->common.sid.code;
-  EXPECT_EQ(last_msg_->common.sid.sat, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.sat)),
+            4)
       << "incorrect value for common.sid.sat, expected 4, is "
       << last_msg_->common.sid.sat;
-  EXPECT_EQ(last_msg_->common.toe.tow, 443718)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toe.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toe.tow)),
+            443718)
       << "incorrect value for common.toe.tow, expected 443718, is "
       << last_msg_->common.toe.tow;
-  EXPECT_EQ(last_msg_->common.toe.wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toe.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toe.wn)),
+            2154)
       << "incorrect value for common.toe.wn, expected 2154, is "
       << last_msg_->common.toe.wn;
   EXPECT_LT((last_msg_->common.ura * 100 - 5.2 * 100), 0.05)
       << "incorrect value for common.ura, expected 5.2, is "
       << last_msg_->common.ura;
-  EXPECT_EQ(last_msg_->common.valid, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.valid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.valid)),
+            1)
       << "incorrect value for common.valid, expected 1, is "
       << last_msg_->common.valid;
   EXPECT_LT((last_msg_->gamma * 100 - 9.09494701773e-13 * 100), 0.05)

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisGLODepC.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisGLODepC.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgEphemerisGLODepC0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -185,34 +192,52 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisGLODepC0, Test) {
   EXPECT_LT((last_msg_->acc[2] * 100 - 2.79396772385e-06 * 100), 0.05)
       << "incorrect value for acc[2], expected 2.79396772385e-06, is "
       << last_msg_->acc[2];
-  EXPECT_EQ(last_msg_->common.fit_interval, 2400)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.fit_interval)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.fit_interval)),
+      2400)
       << "incorrect value for common.fit_interval, expected 2400, is "
       << last_msg_->common.fit_interval;
-  EXPECT_EQ(last_msg_->common.health_bits, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.health_bits)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.health_bits)),
+      0)
       << "incorrect value for common.health_bits, expected 0, is "
       << last_msg_->common.health_bits;
-  EXPECT_EQ(last_msg_->common.sid.code, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.code)),
+            3)
       << "incorrect value for common.sid.code, expected 3, is "
       << last_msg_->common.sid.code;
-  EXPECT_EQ(last_msg_->common.sid.sat, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.sat)),
+            4)
       << "incorrect value for common.sid.sat, expected 4, is "
       << last_msg_->common.sid.sat;
-  EXPECT_EQ(last_msg_->common.toe.tow, 443718)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toe.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toe.tow)),
+            443718)
       << "incorrect value for common.toe.tow, expected 443718, is "
       << last_msg_->common.toe.tow;
-  EXPECT_EQ(last_msg_->common.toe.wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toe.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toe.wn)),
+            2154)
       << "incorrect value for common.toe.wn, expected 2154, is "
       << last_msg_->common.toe.wn;
   EXPECT_LT((last_msg_->common.ura * 100 - 5.2 * 100), 0.05)
       << "incorrect value for common.ura, expected 5.2, is "
       << last_msg_->common.ura;
-  EXPECT_EQ(last_msg_->common.valid, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.valid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.valid)),
+            1)
       << "incorrect value for common.valid, expected 1, is "
       << last_msg_->common.valid;
   EXPECT_LT((last_msg_->d_tau * 100 - -2.79396772385e-09 * 100), 0.05)
       << "incorrect value for d_tau, expected -2.79396772385e-09, is "
       << last_msg_->d_tau;
-  EXPECT_EQ(last_msg_->fcn, 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fcn)),
+            14)
       << "incorrect value for fcn, expected 14, is " << last_msg_->fcn;
   EXPECT_LT((last_msg_->gamma * 100 - 9.09494701773e-13 * 100), 0.05)
       << "incorrect value for gamma, expected 9.09494701773e-13, is "

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisGLODepD.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisGLODepD.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgEphemerisGLODepD0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -186,39 +193,59 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisGLODepD0, Test) {
   EXPECT_LT((last_msg_->acc[2] * 100 - 2.79396772385e-06 * 100), 0.05)
       << "incorrect value for acc[2], expected 2.79396772385e-06, is "
       << last_msg_->acc[2];
-  EXPECT_EQ(last_msg_->common.fit_interval, 2400)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.fit_interval)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.fit_interval)),
+      2400)
       << "incorrect value for common.fit_interval, expected 2400, is "
       << last_msg_->common.fit_interval;
-  EXPECT_EQ(last_msg_->common.health_bits, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.health_bits)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.health_bits)),
+      0)
       << "incorrect value for common.health_bits, expected 0, is "
       << last_msg_->common.health_bits;
-  EXPECT_EQ(last_msg_->common.sid.code, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.code)),
+            3)
       << "incorrect value for common.sid.code, expected 3, is "
       << last_msg_->common.sid.code;
-  EXPECT_EQ(last_msg_->common.sid.sat, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.sat)),
+            4)
       << "incorrect value for common.sid.sat, expected 4, is "
       << last_msg_->common.sid.sat;
-  EXPECT_EQ(last_msg_->common.toe.tow, 443718)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toe.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toe.tow)),
+            443718)
       << "incorrect value for common.toe.tow, expected 443718, is "
       << last_msg_->common.toe.tow;
-  EXPECT_EQ(last_msg_->common.toe.wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toe.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toe.wn)),
+            2154)
       << "incorrect value for common.toe.wn, expected 2154, is "
       << last_msg_->common.toe.wn;
   EXPECT_LT((last_msg_->common.ura * 100 - 5.2 * 100), 0.05)
       << "incorrect value for common.ura, expected 5.2, is "
       << last_msg_->common.ura;
-  EXPECT_EQ(last_msg_->common.valid, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.valid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.valid)),
+            1)
       << "incorrect value for common.valid, expected 1, is "
       << last_msg_->common.valid;
   EXPECT_LT((last_msg_->d_tau * 100 - -2.79396772385e-09 * 100), 0.05)
       << "incorrect value for d_tau, expected -2.79396772385e-09, is "
       << last_msg_->d_tau;
-  EXPECT_EQ(last_msg_->fcn, 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fcn)),
+            14)
       << "incorrect value for fcn, expected 14, is " << last_msg_->fcn;
   EXPECT_LT((last_msg_->gamma * 100 - 9.09494701773e-13 * 100), 0.05)
       << "incorrect value for gamma, expected 9.09494701773e-13, is "
       << last_msg_->gamma;
-  EXPECT_EQ(last_msg_->iod, 100)
+  EXPECT_EQ(get_as<decltype(last_msg_->iod)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iod)),
+            100)
       << "incorrect value for iod, expected 100, is " << last_msg_->iod;
   EXPECT_LT((last_msg_->pos[0] * 100 - -12177330.0781 * 100), 0.05)
       << "incorrect value for pos[0], expected -12177330.0781, is "

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisGPS.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisGPS.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgEphemerisGPS0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -173,28 +180,44 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisGPS0, Test) {
   EXPECT_LT((last_msg_->c_us * 100 - 3.1366944313e-06 * 100), 0.05)
       << "incorrect value for c_us, expected 3.1366944313e-06, is "
       << last_msg_->c_us;
-  EXPECT_EQ(last_msg_->common.fit_interval, 14400)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.fit_interval)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.fit_interval)),
+      14400)
       << "incorrect value for common.fit_interval, expected 14400, is "
       << last_msg_->common.fit_interval;
-  EXPECT_EQ(last_msg_->common.health_bits, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.health_bits)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.health_bits)),
+      0)
       << "incorrect value for common.health_bits, expected 0, is "
       << last_msg_->common.health_bits;
-  EXPECT_EQ(last_msg_->common.sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.code)),
+            0)
       << "incorrect value for common.sid.code, expected 0, is "
       << last_msg_->common.sid.code;
-  EXPECT_EQ(last_msg_->common.sid.sat, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.sat)),
+            22)
       << "incorrect value for common.sid.sat, expected 22, is "
       << last_msg_->common.sid.sat;
-  EXPECT_EQ(last_msg_->common.toe.tow, 446384)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toe.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toe.tow)),
+            446384)
       << "incorrect value for common.toe.tow, expected 446384, is "
       << last_msg_->common.toe.tow;
-  EXPECT_EQ(last_msg_->common.toe.wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toe.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toe.wn)),
+            2154)
       << "incorrect value for common.toe.wn, expected 2154, is "
       << last_msg_->common.toe.wn;
   EXPECT_LT((last_msg_->common.ura * 100 - 2.0 * 100), 0.05)
       << "incorrect value for common.ura, expected 2.0, is "
       << last_msg_->common.ura;
-  EXPECT_EQ(last_msg_->common.valid, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.valid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.valid)),
+            1)
       << "incorrect value for common.valid, expected 1, is "
       << last_msg_->common.valid;
   EXPECT_LT((last_msg_->dn * 100 - 5.69452291402e-09 * 100), 0.05)
@@ -209,9 +232,13 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisGPS0, Test) {
   EXPECT_LT((last_msg_->inc_dot * 100 - -4.03588239642e-11 * 100), 0.05)
       << "incorrect value for inc_dot, expected -4.03588239642e-11, is "
       << last_msg_->inc_dot;
-  EXPECT_EQ(last_msg_->iodc, 45)
+  EXPECT_EQ(get_as<decltype(last_msg_->iodc)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iodc)),
+            45)
       << "incorrect value for iodc, expected 45, is " << last_msg_->iodc;
-  EXPECT_EQ(last_msg_->iode, 45)
+  EXPECT_EQ(get_as<decltype(last_msg_->iode)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iode)),
+            45)
       << "incorrect value for iode, expected 45, is " << last_msg_->iode;
   EXPECT_LT((last_msg_->m0 * 100 - -0.0220007884211 * 100), 0.05)
       << "incorrect value for m0, expected -0.0220007884211, is "
@@ -228,10 +255,14 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisGPS0, Test) {
   EXPECT_LT((last_msg_->tgd * 100 - -1.76951289177e-08 * 100), 0.05)
       << "incorrect value for tgd, expected -1.76951289177e-08, is "
       << last_msg_->tgd;
-  EXPECT_EQ(last_msg_->toc.tow, 446384)
+  EXPECT_EQ(get_as<decltype(last_msg_->toc.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->toc.tow)),
+            446384)
       << "incorrect value for toc.tow, expected 446384, is "
       << last_msg_->toc.tow;
-  EXPECT_EQ(last_msg_->toc.wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->toc.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->toc.wn)),
+            2154)
       << "incorrect value for toc.wn, expected 2154, is " << last_msg_->toc.wn;
   EXPECT_LT((last_msg_->w * 100 - -0.98930366296 * 100), 0.05)
       << "incorrect value for w, expected -0.98930366296, is " << last_msg_->w;

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisGPSDepE.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisGPSDepE.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgEphemerisGPSDepE0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -179,31 +186,50 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisGPSDepE0, Test) {
   EXPECT_LT((last_msg_->c_us * 100 - 3.1366944313e-06 * 100), 0.05)
       << "incorrect value for c_us, expected 3.1366944313e-06, is "
       << last_msg_->c_us;
-  EXPECT_EQ(last_msg_->common.fit_interval, 14400)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.fit_interval)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.fit_interval)),
+      14400)
       << "incorrect value for common.fit_interval, expected 14400, is "
       << last_msg_->common.fit_interval;
-  EXPECT_EQ(last_msg_->common.health_bits, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.health_bits)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.health_bits)),
+      0)
       << "incorrect value for common.health_bits, expected 0, is "
       << last_msg_->common.health_bits;
-  EXPECT_EQ(last_msg_->common.sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.code)),
+            0)
       << "incorrect value for common.sid.code, expected 0, is "
       << last_msg_->common.sid.code;
-  EXPECT_EQ(last_msg_->common.sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.reserved)),
+      0)
       << "incorrect value for common.sid.reserved, expected 0, is "
       << last_msg_->common.sid.reserved;
-  EXPECT_EQ(last_msg_->common.sid.sat, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.sat)),
+            22)
       << "incorrect value for common.sid.sat, expected 22, is "
       << last_msg_->common.sid.sat;
-  EXPECT_EQ(last_msg_->common.toe.tow, 446384)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toe.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toe.tow)),
+            446384)
       << "incorrect value for common.toe.tow, expected 446384, is "
       << last_msg_->common.toe.tow;
-  EXPECT_EQ(last_msg_->common.toe.wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toe.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toe.wn)),
+            2154)
       << "incorrect value for common.toe.wn, expected 2154, is "
       << last_msg_->common.toe.wn;
   EXPECT_LT((last_msg_->common.ura * 100 - 2.0 * 100), 0.05)
       << "incorrect value for common.ura, expected 2.0, is "
       << last_msg_->common.ura;
-  EXPECT_EQ(last_msg_->common.valid, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.valid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.valid)),
+            1)
       << "incorrect value for common.valid, expected 1, is "
       << last_msg_->common.valid;
   EXPECT_LT((last_msg_->dn * 100 - 5.69452291402e-09 * 100), 0.05)
@@ -218,9 +244,13 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisGPSDepE0, Test) {
   EXPECT_LT((last_msg_->inc_dot * 100 - -4.03588239642e-11 * 100), 0.05)
       << "incorrect value for inc_dot, expected -4.03588239642e-11, is "
       << last_msg_->inc_dot;
-  EXPECT_EQ(last_msg_->iodc, 45)
+  EXPECT_EQ(get_as<decltype(last_msg_->iodc)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iodc)),
+            45)
       << "incorrect value for iodc, expected 45, is " << last_msg_->iodc;
-  EXPECT_EQ(last_msg_->iode, 45)
+  EXPECT_EQ(get_as<decltype(last_msg_->iode)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iode)),
+            45)
       << "incorrect value for iode, expected 45, is " << last_msg_->iode;
   EXPECT_LT((last_msg_->m0 * 100 - -0.0220007884211 * 100), 0.05)
       << "incorrect value for m0, expected -0.0220007884211, is "
@@ -237,10 +267,14 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisGPSDepE0, Test) {
   EXPECT_LT((last_msg_->tgd * 100 - -1.76951289177e-08 * 100), 0.05)
       << "incorrect value for tgd, expected -1.76951289177e-08, is "
       << last_msg_->tgd;
-  EXPECT_EQ(last_msg_->toc.tow, 446384)
+  EXPECT_EQ(get_as<decltype(last_msg_->toc.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->toc.tow)),
+            446384)
       << "incorrect value for toc.tow, expected 446384, is "
       << last_msg_->toc.tow;
-  EXPECT_EQ(last_msg_->toc.wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->toc.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->toc.wn)),
+            2154)
       << "incorrect value for toc.wn, expected 2154, is " << last_msg_->toc.wn;
   EXPECT_LT((last_msg_->w * 100 - -0.98930366296 * 100), 0.05)
       << "incorrect value for w, expected -0.98930366296, is " << last_msg_->w;

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisGPSDepF.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisGPSDepF.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgEphemerisGPSDepF0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -178,28 +185,44 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisGPSDepF0, Test) {
   EXPECT_LT((last_msg_->c_us * 100 - 3.1366944313e-06 * 100), 0.05)
       << "incorrect value for c_us, expected 3.1366944313e-06, is "
       << last_msg_->c_us;
-  EXPECT_EQ(last_msg_->common.fit_interval, 14400)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.fit_interval)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.fit_interval)),
+      14400)
       << "incorrect value for common.fit_interval, expected 14400, is "
       << last_msg_->common.fit_interval;
-  EXPECT_EQ(last_msg_->common.health_bits, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.health_bits)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.health_bits)),
+      0)
       << "incorrect value for common.health_bits, expected 0, is "
       << last_msg_->common.health_bits;
-  EXPECT_EQ(last_msg_->common.sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.code)),
+            0)
       << "incorrect value for common.sid.code, expected 0, is "
       << last_msg_->common.sid.code;
-  EXPECT_EQ(last_msg_->common.sid.sat, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.sat)),
+            22)
       << "incorrect value for common.sid.sat, expected 22, is "
       << last_msg_->common.sid.sat;
-  EXPECT_EQ(last_msg_->common.toe.tow, 446384)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toe.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toe.tow)),
+            446384)
       << "incorrect value for common.toe.tow, expected 446384, is "
       << last_msg_->common.toe.tow;
-  EXPECT_EQ(last_msg_->common.toe.wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toe.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toe.wn)),
+            2154)
       << "incorrect value for common.toe.wn, expected 2154, is "
       << last_msg_->common.toe.wn;
   EXPECT_LT((last_msg_->common.ura * 100 - 2.0 * 100), 0.05)
       << "incorrect value for common.ura, expected 2.0, is "
       << last_msg_->common.ura;
-  EXPECT_EQ(last_msg_->common.valid, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.valid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.valid)),
+            1)
       << "incorrect value for common.valid, expected 1, is "
       << last_msg_->common.valid;
   EXPECT_LT((last_msg_->dn * 100 - 5.69452291402e-09 * 100), 0.05)
@@ -214,9 +237,13 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisGPSDepF0, Test) {
   EXPECT_LT((last_msg_->inc_dot * 100 - -4.03588239642e-11 * 100), 0.05)
       << "incorrect value for inc_dot, expected -4.03588239642e-11, is "
       << last_msg_->inc_dot;
-  EXPECT_EQ(last_msg_->iodc, 45)
+  EXPECT_EQ(get_as<decltype(last_msg_->iodc)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iodc)),
+            45)
       << "incorrect value for iodc, expected 45, is " << last_msg_->iodc;
-  EXPECT_EQ(last_msg_->iode, 45)
+  EXPECT_EQ(get_as<decltype(last_msg_->iode)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iode)),
+            45)
       << "incorrect value for iode, expected 45, is " << last_msg_->iode;
   EXPECT_LT((last_msg_->m0 * 100 - -0.0220007884211 * 100), 0.05)
       << "incorrect value for m0, expected -0.0220007884211, is "
@@ -233,10 +260,14 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisGPSDepF0, Test) {
   EXPECT_LT((last_msg_->tgd * 100 - -1.76951289177e-08 * 100), 0.05)
       << "incorrect value for tgd, expected -1.76951289177e-08, is "
       << last_msg_->tgd;
-  EXPECT_EQ(last_msg_->toc.tow, 446384)
+  EXPECT_EQ(get_as<decltype(last_msg_->toc.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->toc.tow)),
+            446384)
       << "incorrect value for toc.tow, expected 446384, is "
       << last_msg_->toc.tow;
-  EXPECT_EQ(last_msg_->toc.wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->toc.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->toc.wn)),
+            2154)
       << "incorrect value for toc.wn, expected 2154, is " << last_msg_->toc.wn;
   EXPECT_LT((last_msg_->w * 100 - -0.98930366296 * 100), 0.05)
       << "incorrect value for w, expected -0.98930366296, is " << last_msg_->w;

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisGal.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisGal.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgEphemerisGal0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -182,28 +189,44 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisGal0, Test) {
   EXPECT_LT((last_msg_->c_us * 100 - 3.99351119995e-06 * 100), 0.05)
       << "incorrect value for c_us, expected 3.99351119995e-06, is "
       << last_msg_->c_us;
-  EXPECT_EQ(last_msg_->common.fit_interval, 14400)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.fit_interval)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.fit_interval)),
+      14400)
       << "incorrect value for common.fit_interval, expected 14400, is "
       << last_msg_->common.fit_interval;
-  EXPECT_EQ(last_msg_->common.health_bits, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.health_bits)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.health_bits)),
+      0)
       << "incorrect value for common.health_bits, expected 0, is "
       << last_msg_->common.health_bits;
-  EXPECT_EQ(last_msg_->common.sid.code, 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.code)),
+            14)
       << "incorrect value for common.sid.code, expected 14, is "
       << last_msg_->common.sid.code;
-  EXPECT_EQ(last_msg_->common.sid.sat, 27)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.sat)),
+            27)
       << "incorrect value for common.sid.sat, expected 27, is "
       << last_msg_->common.sid.sat;
-  EXPECT_EQ(last_msg_->common.toe.tow, 448800)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toe.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toe.tow)),
+            448800)
       << "incorrect value for common.toe.tow, expected 448800, is "
       << last_msg_->common.toe.tow;
-  EXPECT_EQ(last_msg_->common.toe.wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toe.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toe.wn)),
+            2154)
       << "incorrect value for common.toe.wn, expected 2154, is "
       << last_msg_->common.toe.wn;
   EXPECT_LT((last_msg_->common.ura * 100 - 3.11999988556 * 100), 0.05)
       << "incorrect value for common.ura, expected 3.11999988556, is "
       << last_msg_->common.ura;
-  EXPECT_EQ(last_msg_->common.valid, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.valid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.valid)),
+            1)
       << "incorrect value for common.valid, expected 1, is "
       << last_msg_->common.valid;
   EXPECT_LT((last_msg_->dn * 100 - 3.22620581299e-09 * 100), 0.05)
@@ -218,9 +241,13 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisGal0, Test) {
   EXPECT_LT((last_msg_->inc_dot * 100 - -3.17870383435e-10 * 100), 0.05)
       << "incorrect value for inc_dot, expected -3.17870383435e-10, is "
       << last_msg_->inc_dot;
-  EXPECT_EQ(last_msg_->iodc, 108)
+  EXPECT_EQ(get_as<decltype(last_msg_->iodc)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iodc)),
+            108)
       << "incorrect value for iodc, expected 108, is " << last_msg_->iodc;
-  EXPECT_EQ(last_msg_->iode, 108)
+  EXPECT_EQ(get_as<decltype(last_msg_->iode)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iode)),
+            108)
       << "incorrect value for iode, expected 108, is " << last_msg_->iode;
   EXPECT_LT((last_msg_->m0 * 100 - -1.84571157442 * 100), 0.05)
       << "incorrect value for m0, expected -1.84571157442, is "
@@ -231,15 +258,21 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisGal0, Test) {
   EXPECT_LT((last_msg_->omegadot * 100 - -5.75738267524e-09 * 100), 0.05)
       << "incorrect value for omegadot, expected -5.75738267524e-09, is "
       << last_msg_->omegadot;
-  EXPECT_EQ(last_msg_->source, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->source)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->source)),
+            0)
       << "incorrect value for source, expected 0, is " << last_msg_->source;
   EXPECT_LT((last_msg_->sqrta * 100 - 5440.60240173 * 100), 0.05)
       << "incorrect value for sqrta, expected 5440.60240173, is "
       << last_msg_->sqrta;
-  EXPECT_EQ(last_msg_->toc.tow, 448800)
+  EXPECT_EQ(get_as<decltype(last_msg_->toc.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->toc.tow)),
+            448800)
       << "incorrect value for toc.tow, expected 448800, is "
       << last_msg_->toc.tow;
-  EXPECT_EQ(last_msg_->toc.wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->toc.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->toc.wn)),
+            2154)
       << "incorrect value for toc.wn, expected 2154, is " << last_msg_->toc.wn;
   EXPECT_LT((last_msg_->w * 100 - 0.122509120917 * 100), 0.05)
       << "incorrect value for w, expected 0.122509120917, is " << last_msg_->w;

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisGalDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisGalDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgEphemerisGalDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -184,28 +191,44 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisGalDepA0, Test) {
   EXPECT_LT((last_msg_->c_us * 100 - 6.19999980927 * 100), 0.05)
       << "incorrect value for c_us, expected 6.19999980927, is "
       << last_msg_->c_us;
-  EXPECT_EQ(last_msg_->common.fit_interval, 14400)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.fit_interval)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.fit_interval)),
+      14400)
       << "incorrect value for common.fit_interval, expected 14400, is "
       << last_msg_->common.fit_interval;
-  EXPECT_EQ(last_msg_->common.health_bits, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.health_bits)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.health_bits)),
+      0)
       << "incorrect value for common.health_bits, expected 0, is "
       << last_msg_->common.health_bits;
-  EXPECT_EQ(last_msg_->common.sid.code, 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.code)),
+            14)
       << "incorrect value for common.sid.code, expected 14, is "
       << last_msg_->common.sid.code;
-  EXPECT_EQ(last_msg_->common.sid.sat, 27)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.sat)),
+            27)
       << "incorrect value for common.sid.sat, expected 27, is "
       << last_msg_->common.sid.sat;
-  EXPECT_EQ(last_msg_->common.toe.tow, 448800)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toe.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toe.tow)),
+            448800)
       << "incorrect value for common.toe.tow, expected 448800, is "
       << last_msg_->common.toe.tow;
-  EXPECT_EQ(last_msg_->common.toe.wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toe.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toe.wn)),
+            2154)
       << "incorrect value for common.toe.wn, expected 2154, is "
       << last_msg_->common.toe.wn;
   EXPECT_LT((last_msg_->common.ura * 100 - 7.19999980927 * 100), 0.05)
       << "incorrect value for common.ura, expected 7.19999980927, is "
       << last_msg_->common.ura;
-  EXPECT_EQ(last_msg_->common.valid, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.valid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.valid)),
+            1)
       << "incorrect value for common.valid, expected 1, is "
       << last_msg_->common.valid;
   EXPECT_LT((last_msg_->dn * 100 - 3.22620581299e-09 * 100), 0.05)
@@ -220,9 +243,13 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisGalDepA0, Test) {
   EXPECT_LT((last_msg_->inc_dot * 100 - -3.17870383435e-10 * 100), 0.05)
       << "incorrect value for inc_dot, expected -3.17870383435e-10, is "
       << last_msg_->inc_dot;
-  EXPECT_EQ(last_msg_->iodc, 108)
+  EXPECT_EQ(get_as<decltype(last_msg_->iodc)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iodc)),
+            108)
       << "incorrect value for iodc, expected 108, is " << last_msg_->iodc;
-  EXPECT_EQ(last_msg_->iode, 108)
+  EXPECT_EQ(get_as<decltype(last_msg_->iode)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iode)),
+            108)
       << "incorrect value for iode, expected 108, is " << last_msg_->iode;
   EXPECT_LT((last_msg_->m0 * 100 - -1.84571157442 * 100), 0.05)
       << "incorrect value for m0, expected -1.84571157442, is "
@@ -236,10 +263,14 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisGalDepA0, Test) {
   EXPECT_LT((last_msg_->sqrta * 100 - 5440.60240173 * 100), 0.05)
       << "incorrect value for sqrta, expected 5440.60240173, is "
       << last_msg_->sqrta;
-  EXPECT_EQ(last_msg_->toc.tow, 448800)
+  EXPECT_EQ(get_as<decltype(last_msg_->toc.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->toc.tow)),
+            448800)
       << "incorrect value for toc.tow, expected 448800, is "
       << last_msg_->toc.tow;
-  EXPECT_EQ(last_msg_->toc.wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->toc.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->toc.wn)),
+            2154)
       << "incorrect value for toc.wn, expected 2154, is " << last_msg_->toc.wn;
   EXPECT_LT((last_msg_->w * 100 - 0.122509120917 * 100), 0.05)
       << "incorrect value for w, expected 0.122509120917, is " << last_msg_->w;

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisSbas.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisSbas.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgEphemerisSbas0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -184,28 +191,44 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisSbas0, Test) {
   EXPECT_LT((last_msg_->acc[2] * 100 - 2.79396772385e-06 * 100), 0.05)
       << "incorrect value for acc[2], expected 2.79396772385e-06, is "
       << last_msg_->acc[2];
-  EXPECT_EQ(last_msg_->common.fit_interval, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.fit_interval)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.fit_interval)),
+      0)
       << "incorrect value for common.fit_interval, expected 0, is "
       << last_msg_->common.fit_interval;
-  EXPECT_EQ(last_msg_->common.health_bits, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.health_bits)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.health_bits)),
+      0)
       << "incorrect value for common.health_bits, expected 0, is "
       << last_msg_->common.health_bits;
-  EXPECT_EQ(last_msg_->common.sid.code, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.code)),
+            6)
       << "incorrect value for common.sid.code, expected 6, is "
       << last_msg_->common.sid.code;
-  EXPECT_EQ(last_msg_->common.sid.sat, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.sat)),
+            22)
       << "incorrect value for common.sid.sat, expected 22, is "
       << last_msg_->common.sid.sat;
-  EXPECT_EQ(last_msg_->common.toe.tow, 446384)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toe.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toe.tow)),
+            446384)
       << "incorrect value for common.toe.tow, expected 446384, is "
       << last_msg_->common.toe.tow;
-  EXPECT_EQ(last_msg_->common.toe.wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toe.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toe.wn)),
+            2154)
       << "incorrect value for common.toe.wn, expected 2154, is "
       << last_msg_->common.toe.wn;
   EXPECT_LT((last_msg_->common.ura * 100 - -2.79396772385e-09 * 100), 0.05)
       << "incorrect value for common.ura, expected -2.79396772385e-09, is "
       << last_msg_->common.ura;
-  EXPECT_EQ(last_msg_->common.valid, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.valid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.valid)),
+            1)
       << "incorrect value for common.valid, expected 1, is "
       << last_msg_->common.valid;
   EXPECT_LT((last_msg_->pos[0] * 100 - -12177330.0781 * 100), 0.05)

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisSbasDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisSbasDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgEphemerisSbasDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -189,31 +196,50 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisSbasDepA0, Test) {
   EXPECT_LT((last_msg_->acc[2] * 100 - 2.79396772385e-06 * 100), 0.05)
       << "incorrect value for acc[2], expected 2.79396772385e-06, is "
       << last_msg_->acc[2];
-  EXPECT_EQ(last_msg_->common.fit_interval, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.fit_interval)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.fit_interval)),
+      0)
       << "incorrect value for common.fit_interval, expected 0, is "
       << last_msg_->common.fit_interval;
-  EXPECT_EQ(last_msg_->common.health_bits, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.health_bits)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.health_bits)),
+      0)
       << "incorrect value for common.health_bits, expected 0, is "
       << last_msg_->common.health_bits;
-  EXPECT_EQ(last_msg_->common.sid.code, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.code)),
+            6)
       << "incorrect value for common.sid.code, expected 6, is "
       << last_msg_->common.sid.code;
-  EXPECT_EQ(last_msg_->common.sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.reserved)),
+      0)
       << "incorrect value for common.sid.reserved, expected 0, is "
       << last_msg_->common.sid.reserved;
-  EXPECT_EQ(last_msg_->common.sid.sat, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.sat)),
+            22)
       << "incorrect value for common.sid.sat, expected 22, is "
       << last_msg_->common.sid.sat;
-  EXPECT_EQ(last_msg_->common.toe.tow, 446384)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toe.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toe.tow)),
+            446384)
       << "incorrect value for common.toe.tow, expected 446384, is "
       << last_msg_->common.toe.tow;
-  EXPECT_EQ(last_msg_->common.toe.wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toe.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toe.wn)),
+            2154)
       << "incorrect value for common.toe.wn, expected 2154, is "
       << last_msg_->common.toe.wn;
   EXPECT_LT((last_msg_->common.ura * 100 - 2.0 * 100), 0.05)
       << "incorrect value for common.ura, expected 2.0, is "
       << last_msg_->common.ura;
-  EXPECT_EQ(last_msg_->common.valid, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.valid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.valid)),
+            1)
       << "incorrect value for common.valid, expected 1, is "
       << last_msg_->common.valid;
   EXPECT_LT((last_msg_->pos[0] * 100 - -12177330.0781 * 100), 0.05)

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisSbasDepB.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgEphemerisSbasDepB.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgEphemerisSbasDepB0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -188,28 +195,44 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgEphemerisSbasDepB0, Test) {
   EXPECT_LT((last_msg_->acc[2] * 100 - 2.79396772385e-06 * 100), 0.05)
       << "incorrect value for acc[2], expected 2.79396772385e-06, is "
       << last_msg_->acc[2];
-  EXPECT_EQ(last_msg_->common.fit_interval, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.fit_interval)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.fit_interval)),
+      0)
       << "incorrect value for common.fit_interval, expected 0, is "
       << last_msg_->common.fit_interval;
-  EXPECT_EQ(last_msg_->common.health_bits, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.health_bits)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.health_bits)),
+      0)
       << "incorrect value for common.health_bits, expected 0, is "
       << last_msg_->common.health_bits;
-  EXPECT_EQ(last_msg_->common.sid.code, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.code)),
+            6)
       << "incorrect value for common.sid.code, expected 6, is "
       << last_msg_->common.sid.code;
-  EXPECT_EQ(last_msg_->common.sid.sat, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.sat)),
+            22)
       << "incorrect value for common.sid.sat, expected 22, is "
       << last_msg_->common.sid.sat;
-  EXPECT_EQ(last_msg_->common.toe.tow, 446384)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toe.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toe.tow)),
+            446384)
       << "incorrect value for common.toe.tow, expected 446384, is "
       << last_msg_->common.toe.tow;
-  EXPECT_EQ(last_msg_->common.toe.wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toe.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toe.wn)),
+            2154)
       << "incorrect value for common.toe.wn, expected 2154, is "
       << last_msg_->common.toe.wn;
   EXPECT_LT((last_msg_->common.ura * 100 - 2.0 * 100), 0.05)
       << "incorrect value for common.ura, expected 2.0, is "
       << last_msg_->common.ura;
-  EXPECT_EQ(last_msg_->common.valid, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.valid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.valid)),
+            1)
       << "incorrect value for common.valid, expected 1, is "
       << last_msg_->common.valid;
   EXPECT_LT((last_msg_->pos[0] * 100 - -12177330.0781 * 100), 0.05)

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgGloBiases.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgGloBiases.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgGloBiases0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -114,16 +121,26 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgGloBiases0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 0);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->l1ca_bias, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->l1ca_bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->l1ca_bias)),
+            0)
       << "incorrect value for l1ca_bias, expected 0, is "
       << last_msg_->l1ca_bias;
-  EXPECT_EQ(last_msg_->l1p_bias, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->l1p_bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->l1p_bias)),
+            0)
       << "incorrect value for l1p_bias, expected 0, is " << last_msg_->l1p_bias;
-  EXPECT_EQ(last_msg_->l2ca_bias, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->l2ca_bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->l2ca_bias)),
+            0)
       << "incorrect value for l2ca_bias, expected 0, is "
       << last_msg_->l2ca_bias;
-  EXPECT_EQ(last_msg_->l2p_bias, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->l2p_bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->l2p_bias)),
+            0)
       << "incorrect value for l2p_bias, expected 0, is " << last_msg_->l2p_bias;
-  EXPECT_EQ(last_msg_->mask, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->mask)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->mask)),
+            0)
       << "incorrect value for mask, expected 0, is " << last_msg_->mask;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgGnssCapb.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgGnssCapb.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgGnssCapb0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -133,55 +140,89 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgGnssCapb0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 123);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->gc.bds_active, 1929005864)
+  EXPECT_EQ(get_as<decltype(last_msg_->gc.bds_active)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->gc.bds_active)),
+            1929005864)
       << "incorrect value for gc.bds_active, expected 1929005864, is "
       << last_msg_->gc.bds_active;
-  EXPECT_EQ(last_msg_->gc.bds_b2, 33839445)
+  EXPECT_EQ(get_as<decltype(last_msg_->gc.bds_b2)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->gc.bds_b2)),
+            33839445)
       << "incorrect value for gc.bds_b2, expected 33839445, is "
       << last_msg_->gc.bds_b2;
-  EXPECT_EQ(last_msg_->gc.bds_b2a, 378107113)
+  EXPECT_EQ(get_as<decltype(last_msg_->gc.bds_b2a)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->gc.bds_b2a)),
+            378107113)
       << "incorrect value for gc.bds_b2a, expected 378107113, is "
       << last_msg_->gc.bds_b2a;
-  EXPECT_EQ(last_msg_->gc.bds_d2nav, 1367053175)
+  EXPECT_EQ(get_as<decltype(last_msg_->gc.bds_d2nav)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->gc.bds_d2nav)),
+            1367053175)
       << "incorrect value for gc.bds_d2nav, expected 1367053175, is "
       << last_msg_->gc.bds_d2nav;
-  EXPECT_EQ(last_msg_->gc.gal_active, 1392028637)
+  EXPECT_EQ(get_as<decltype(last_msg_->gc.gal_active)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->gc.gal_active)),
+            1392028637)
       << "incorrect value for gc.gal_active, expected 1392028637, is "
       << last_msg_->gc.gal_active;
-  EXPECT_EQ(last_msg_->gc.gal_e5, 484261628)
+  EXPECT_EQ(get_as<decltype(last_msg_->gc.gal_e5)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->gc.gal_e5)),
+            484261628)
       << "incorrect value for gc.gal_e5, expected 484261628, is "
       << last_msg_->gc.gal_e5;
-  EXPECT_EQ(last_msg_->gc.glo_active, 13159676)
+  EXPECT_EQ(get_as<decltype(last_msg_->gc.glo_active)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->gc.glo_active)),
+            13159676)
       << "incorrect value for gc.glo_active, expected 13159676, is "
       << last_msg_->gc.glo_active;
-  EXPECT_EQ(last_msg_->gc.glo_l2of, 824073421)
+  EXPECT_EQ(get_as<decltype(last_msg_->gc.glo_l2of)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->gc.glo_l2of)),
+            824073421)
       << "incorrect value for gc.glo_l2of, expected 824073421, is "
       << last_msg_->gc.glo_l2of;
-  EXPECT_EQ(last_msg_->gc.glo_l3, 404081648)
+  EXPECT_EQ(get_as<decltype(last_msg_->gc.glo_l3)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->gc.glo_l3)),
+            404081648)
       << "incorrect value for gc.glo_l3, expected 404081648, is "
       << last_msg_->gc.glo_l3;
-  EXPECT_EQ(last_msg_->gc.gps_active, 1079028506)
+  EXPECT_EQ(get_as<decltype(last_msg_->gc.gps_active)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->gc.gps_active)),
+            1079028506)
       << "incorrect value for gc.gps_active, expected 1079028506, is "
       << last_msg_->gc.gps_active;
-  EXPECT_EQ(last_msg_->gc.gps_l2c, 781233489)
+  EXPECT_EQ(get_as<decltype(last_msg_->gc.gps_l2c)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->gc.gps_l2c)),
+            781233489)
       << "incorrect value for gc.gps_l2c, expected 781233489, is "
       << last_msg_->gc.gps_l2c;
-  EXPECT_EQ(last_msg_->gc.gps_l5, 1818069969)
+  EXPECT_EQ(get_as<decltype(last_msg_->gc.gps_l5)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->gc.gps_l5)),
+            1818069969)
       << "incorrect value for gc.gps_l5, expected 1818069969, is "
       << last_msg_->gc.gps_l5;
-  EXPECT_EQ(last_msg_->gc.qzss_active, 198929863)
+  EXPECT_EQ(get_as<decltype(last_msg_->gc.qzss_active)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->gc.qzss_active)),
+            198929863)
       << "incorrect value for gc.qzss_active, expected 198929863, is "
       << last_msg_->gc.qzss_active;
-  EXPECT_EQ(last_msg_->gc.sbas_active, 548822484)
+  EXPECT_EQ(get_as<decltype(last_msg_->gc.sbas_active)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->gc.sbas_active)),
+            548822484)
       << "incorrect value for gc.sbas_active, expected 548822484, is "
       << last_msg_->gc.sbas_active;
-  EXPECT_EQ(last_msg_->gc.sbas_l5, 465576041)
+  EXPECT_EQ(get_as<decltype(last_msg_->gc.sbas_l5)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->gc.sbas_l5)),
+            465576041)
       << "incorrect value for gc.sbas_l5, expected 465576041, is "
       << last_msg_->gc.sbas_l5;
-  EXPECT_EQ(last_msg_->t_nmct.tow, 446384)
+  EXPECT_EQ(get_as<decltype(last_msg_->t_nmct.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->t_nmct.tow)),
+            446384)
       << "incorrect value for t_nmct.tow, expected 446384, is "
       << last_msg_->t_nmct.tow;
-  EXPECT_EQ(last_msg_->t_nmct.wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->t_nmct.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->t_nmct.wn)),
+            2154)
       << "incorrect value for t_nmct.wn, expected 2154, is "
       << last_msg_->t_nmct.wn;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgGroupDelay.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgGroupDelay.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgGroupDelay0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -118,24 +125,40 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgGroupDelay0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 123);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->isc_l1ca, -91)
+  EXPECT_EQ(get_as<decltype(last_msg_->isc_l1ca)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->isc_l1ca)),
+            -91)
       << "incorrect value for isc_l1ca, expected -91, is "
       << last_msg_->isc_l1ca;
-  EXPECT_EQ(last_msg_->isc_l2c, 6125)
+  EXPECT_EQ(get_as<decltype(last_msg_->isc_l2c)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->isc_l2c)),
+            6125)
       << "incorrect value for isc_l2c, expected 6125, is "
       << last_msg_->isc_l2c;
-  EXPECT_EQ(last_msg_->sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.code)),
+            0)
       << "incorrect value for sid.code, expected 0, is " << last_msg_->sid.code;
-  EXPECT_EQ(last_msg_->sid.sat, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.sat)),
+            22)
       << "incorrect value for sid.sat, expected 22, is " << last_msg_->sid.sat;
-  EXPECT_EQ(last_msg_->t_op.tow, 446384)
+  EXPECT_EQ(get_as<decltype(last_msg_->t_op.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->t_op.tow)),
+            446384)
       << "incorrect value for t_op.tow, expected 446384, is "
       << last_msg_->t_op.tow;
-  EXPECT_EQ(last_msg_->t_op.wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->t_op.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->t_op.wn)),
+            2154)
       << "incorrect value for t_op.wn, expected 2154, is "
       << last_msg_->t_op.wn;
-  EXPECT_EQ(last_msg_->tgd, -514)
+  EXPECT_EQ(get_as<decltype(last_msg_->tgd)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tgd)),
+            -514)
       << "incorrect value for tgd, expected -514, is " << last_msg_->tgd;
-  EXPECT_EQ(last_msg_->valid, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->valid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->valid)),
+            1)
       << "incorrect value for valid, expected 1, is " << last_msg_->valid;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgGroupDelayDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgGroupDelayDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgGroupDelayDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -119,22 +126,36 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgGroupDelayDepA0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 123);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->isc_l1ca, -91)
+  EXPECT_EQ(get_as<decltype(last_msg_->isc_l1ca)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->isc_l1ca)),
+            -91)
       << "incorrect value for isc_l1ca, expected -91, is "
       << last_msg_->isc_l1ca;
-  EXPECT_EQ(last_msg_->isc_l2c, 6125)
+  EXPECT_EQ(get_as<decltype(last_msg_->isc_l2c)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->isc_l2c)),
+            6125)
       << "incorrect value for isc_l2c, expected 6125, is "
       << last_msg_->isc_l2c;
-  EXPECT_EQ(last_msg_->prn, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->prn)),
+            22)
       << "incorrect value for prn, expected 22, is " << last_msg_->prn;
-  EXPECT_EQ(last_msg_->t_op.tow, 446384)
+  EXPECT_EQ(get_as<decltype(last_msg_->t_op.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->t_op.tow)),
+            446384)
       << "incorrect value for t_op.tow, expected 446384, is "
       << last_msg_->t_op.tow;
-  EXPECT_EQ(last_msg_->t_op.wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->t_op.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->t_op.wn)),
+            2154)
       << "incorrect value for t_op.wn, expected 2154, is "
       << last_msg_->t_op.wn;
-  EXPECT_EQ(last_msg_->tgd, -514)
+  EXPECT_EQ(get_as<decltype(last_msg_->tgd)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tgd)),
+            -514)
       << "incorrect value for tgd, expected -514, is " << last_msg_->tgd;
-  EXPECT_EQ(last_msg_->valid, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->valid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->valid)),
+            1)
       << "incorrect value for valid, expected 1, is " << last_msg_->valid;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgGroupDelayDepB.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgGroupDelayDepB.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgGroupDelayDepB0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -121,27 +128,45 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgGroupDelayDepB0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 123);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->isc_l1ca, -91)
+  EXPECT_EQ(get_as<decltype(last_msg_->isc_l1ca)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->isc_l1ca)),
+            -91)
       << "incorrect value for isc_l1ca, expected -91, is "
       << last_msg_->isc_l1ca;
-  EXPECT_EQ(last_msg_->isc_l2c, 6125)
+  EXPECT_EQ(get_as<decltype(last_msg_->isc_l2c)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->isc_l2c)),
+            6125)
       << "incorrect value for isc_l2c, expected 6125, is "
       << last_msg_->isc_l2c;
-  EXPECT_EQ(last_msg_->sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.code)),
+            0)
       << "incorrect value for sid.code, expected 0, is " << last_msg_->sid.code;
-  EXPECT_EQ(last_msg_->sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.reserved)),
+            0)
       << "incorrect value for sid.reserved, expected 0, is "
       << last_msg_->sid.reserved;
-  EXPECT_EQ(last_msg_->sid.sat, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.sat)),
+            22)
       << "incorrect value for sid.sat, expected 22, is " << last_msg_->sid.sat;
-  EXPECT_EQ(last_msg_->t_op.tow, 446384)
+  EXPECT_EQ(get_as<decltype(last_msg_->t_op.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->t_op.tow)),
+            446384)
       << "incorrect value for t_op.tow, expected 446384, is "
       << last_msg_->t_op.tow;
-  EXPECT_EQ(last_msg_->t_op.wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->t_op.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->t_op.wn)),
+            2154)
       << "incorrect value for t_op.wn, expected 2154, is "
       << last_msg_->t_op.wn;
-  EXPECT_EQ(last_msg_->tgd, -514)
+  EXPECT_EQ(get_as<decltype(last_msg_->tgd)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tgd)),
+            -514)
       << "incorrect value for tgd, expected -514, is " << last_msg_->tgd;
-  EXPECT_EQ(last_msg_->valid, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->valid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->valid)),
+            1)
       << "incorrect value for valid, expected 1, is " << last_msg_->valid;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgIono.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgIono.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgIono0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -143,10 +150,14 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgIono0, Test) {
       << "incorrect value for b2, expected -65536.0, is " << last_msg_->b2;
   EXPECT_LT((last_msg_->b3 * 100 - -327680.0 * 100), 0.05)
       << "incorrect value for b3, expected -327680.0, is " << last_msg_->b3;
-  EXPECT_EQ(last_msg_->t_nmct.tow, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->t_nmct.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->t_nmct.tow)),
+            0)
       << "incorrect value for t_nmct.tow, expected 0, is "
       << last_msg_->t_nmct.tow;
-  EXPECT_EQ(last_msg_->t_nmct.wn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->t_nmct.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->t_nmct.wn)),
+            0)
       << "incorrect value for t_nmct.wn, expected 0, is "
       << last_msg_->t_nmct.wn;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgObs.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgObs.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgObs0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -326,436 +333,729 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgObs0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 61569);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->header.n_obs, 32)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.n_obs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.n_obs)),
+            32)
       << "incorrect value for header.n_obs, expected 32, is "
       << last_msg_->header.n_obs;
-  EXPECT_EQ(last_msg_->header.t.ns_residual, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->header.t.ns_residual)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->header.t.ns_residual)),
+      0)
       << "incorrect value for header.t.ns_residual, expected 0, is "
       << last_msg_->header.t.ns_residual;
-  EXPECT_EQ(last_msg_->header.t.tow, 434293400)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.tow)),
+            434293400)
       << "incorrect value for header.t.tow, expected 434293400, is "
       << last_msg_->header.t.tow;
-  EXPECT_EQ(last_msg_->header.t.wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.wn)),
+            2154)
       << "incorrect value for header.t.wn, expected 2154, is "
       << last_msg_->header.t.wn;
-  EXPECT_EQ(last_msg_->obs[0].D.f, 172)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].D.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].D.f)),
+            172)
       << "incorrect value for obs[0].D.f, expected 172, is "
       << last_msg_->obs[0].D.f;
-  EXPECT_EQ(last_msg_->obs[0].D.i, -1536)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].D.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].D.i)),
+            -1536)
       << "incorrect value for obs[0].D.i, expected -1536, is "
       << last_msg_->obs[0].D.i;
-  EXPECT_EQ(last_msg_->obs[0].L.f, 146)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.f)),
+            146)
       << "incorrect value for obs[0].L.f, expected 146, is "
       << last_msg_->obs[0].L.f;
-  EXPECT_EQ(last_msg_->obs[0].L.i, 111080057)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.i)),
+            111080057)
       << "incorrect value for obs[0].L.i, expected 111080057, is "
       << last_msg_->obs[0].L.i;
-  EXPECT_EQ(last_msg_->obs[0].P, 1056891697)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].P)),
+            1056891697)
       << "incorrect value for obs[0].P, expected 1056891697, is "
       << last_msg_->obs[0].P;
-  EXPECT_EQ(last_msg_->obs[0].cn0, 182)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].cn0)),
+            182)
       << "incorrect value for obs[0].cn0, expected 182, is "
       << last_msg_->obs[0].cn0;
-  EXPECT_EQ(last_msg_->obs[0].flags, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].flags)),
+            15)
       << "incorrect value for obs[0].flags, expected 15, is "
       << last_msg_->obs[0].flags;
-  EXPECT_EQ(last_msg_->obs[0].lock, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].lock)),
+            10)
       << "incorrect value for obs[0].lock, expected 10, is "
       << last_msg_->obs[0].lock;
-  EXPECT_EQ(last_msg_->obs[0].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.code)),
+            0)
       << "incorrect value for obs[0].sid.code, expected 0, is "
       << last_msg_->obs[0].sid.code;
-  EXPECT_EQ(last_msg_->obs[0].sid.sat, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.sat)),
+            10)
       << "incorrect value for obs[0].sid.sat, expected 10, is "
       << last_msg_->obs[0].sid.sat;
-  EXPECT_EQ(last_msg_->obs[1].D.f, 172)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].D.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].D.f)),
+            172)
       << "incorrect value for obs[1].D.f, expected 172, is "
       << last_msg_->obs[1].D.f;
-  EXPECT_EQ(last_msg_->obs[1].D.i, -1197)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].D.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].D.i)),
+            -1197)
       << "incorrect value for obs[1].D.i, expected -1197, is "
       << last_msg_->obs[1].D.i;
-  EXPECT_EQ(last_msg_->obs[1].L.f, 59)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].L.f)),
+            59)
       << "incorrect value for obs[1].L.f, expected 59, is "
       << last_msg_->obs[1].L.f;
-  EXPECT_EQ(last_msg_->obs[1].L.i, 86555916)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].L.i)),
+            86555916)
       << "incorrect value for obs[1].L.i, expected 86555916, is "
       << last_msg_->obs[1].L.i;
-  EXPECT_EQ(last_msg_->obs[1].P, 1056891934)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].P)),
+            1056891934)
       << "incorrect value for obs[1].P, expected 1056891934, is "
       << last_msg_->obs[1].P;
-  EXPECT_EQ(last_msg_->obs[1].cn0, 178)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].cn0)),
+            178)
       << "incorrect value for obs[1].cn0, expected 178, is "
       << last_msg_->obs[1].cn0;
-  EXPECT_EQ(last_msg_->obs[1].flags, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].flags)),
+            15)
       << "incorrect value for obs[1].flags, expected 15, is "
       << last_msg_->obs[1].flags;
-  EXPECT_EQ(last_msg_->obs[1].lock, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].lock)),
+            10)
       << "incorrect value for obs[1].lock, expected 10, is "
       << last_msg_->obs[1].lock;
-  EXPECT_EQ(last_msg_->obs[1].sid.code, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.code)),
+            1)
       << "incorrect value for obs[1].sid.code, expected 1, is "
       << last_msg_->obs[1].sid.code;
-  EXPECT_EQ(last_msg_->obs[1].sid.sat, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.sat)),
+            10)
       << "incorrect value for obs[1].sid.sat, expected 10, is "
       << last_msg_->obs[1].sid.sat;
-  EXPECT_EQ(last_msg_->obs[2].D.f, 119)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].D.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].D.f)),
+            119)
       << "incorrect value for obs[2].D.f, expected 119, is "
       << last_msg_->obs[2].D.f;
-  EXPECT_EQ(last_msg_->obs[2].D.i, -3219)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].D.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].D.i)),
+            -3219)
       << "incorrect value for obs[2].D.i, expected -3219, is "
       << last_msg_->obs[2].D.i;
-  EXPECT_EQ(last_msg_->obs[2].L.f, 243)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].L.f)),
+            243)
       << "incorrect value for obs[2].L.f, expected 243, is "
       << last_msg_->obs[2].L.f;
-  EXPECT_EQ(last_msg_->obs[2].L.i, 127954794)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].L.i)),
+            127954794)
       << "incorrect value for obs[2].L.i, expected 127954794, is "
       << last_msg_->obs[2].L.i;
-  EXPECT_EQ(last_msg_->obs[2].P, 1217449431)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].P)),
+            1217449431)
       << "incorrect value for obs[2].P, expected 1217449431, is "
       << last_msg_->obs[2].P;
-  EXPECT_EQ(last_msg_->obs[2].cn0, 158)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].cn0)),
+            158)
       << "incorrect value for obs[2].cn0, expected 158, is "
       << last_msg_->obs[2].cn0;
-  EXPECT_EQ(last_msg_->obs[2].flags, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].flags)),
+            15)
       << "incorrect value for obs[2].flags, expected 15, is "
       << last_msg_->obs[2].flags;
-  EXPECT_EQ(last_msg_->obs[2].lock, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].lock)),
+            10)
       << "incorrect value for obs[2].lock, expected 10, is "
       << last_msg_->obs[2].lock;
-  EXPECT_EQ(last_msg_->obs[2].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.code)),
+            0)
       << "incorrect value for obs[2].sid.code, expected 0, is "
       << last_msg_->obs[2].sid.code;
-  EXPECT_EQ(last_msg_->obs[2].sid.sat, 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.sat)),
+            18)
       << "incorrect value for obs[2].sid.sat, expected 18, is "
       << last_msg_->obs[2].sid.sat;
-  EXPECT_EQ(last_msg_->obs[3].D.f, 27)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].D.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].D.f)),
+            27)
       << "incorrect value for obs[3].D.f, expected 27, is "
       << last_msg_->obs[3].D.f;
-  EXPECT_EQ(last_msg_->obs[3].D.i, -2508)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].D.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].D.i)),
+            -2508)
       << "incorrect value for obs[3].D.i, expected -2508, is "
       << last_msg_->obs[3].D.i;
-  EXPECT_EQ(last_msg_->obs[3].L.f, 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].L.f)),
+            12)
       << "incorrect value for obs[3].L.f, expected 12, is "
       << last_msg_->obs[3].L.f;
-  EXPECT_EQ(last_msg_->obs[3].L.i, 99705055)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].L.i)),
+            99705055)
       << "incorrect value for obs[3].L.i, expected 99705055, is "
       << last_msg_->obs[3].L.i;
-  EXPECT_EQ(last_msg_->obs[3].P, 1217449753)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].P)),
+            1217449753)
       << "incorrect value for obs[3].P, expected 1217449753, is "
       << last_msg_->obs[3].P;
-  EXPECT_EQ(last_msg_->obs[3].cn0, 125)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].cn0)),
+            125)
       << "incorrect value for obs[3].cn0, expected 125, is "
       << last_msg_->obs[3].cn0;
-  EXPECT_EQ(last_msg_->obs[3].flags, 11)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].flags)),
+            11)
       << "incorrect value for obs[3].flags, expected 11, is "
       << last_msg_->obs[3].flags;
-  EXPECT_EQ(last_msg_->obs[3].lock, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].lock)),
+            9)
       << "incorrect value for obs[3].lock, expected 9, is "
       << last_msg_->obs[3].lock;
-  EXPECT_EQ(last_msg_->obs[3].sid.code, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].sid.code)),
+            1)
       << "incorrect value for obs[3].sid.code, expected 1, is "
       << last_msg_->obs[3].sid.code;
-  EXPECT_EQ(last_msg_->obs[3].sid.sat, 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].sid.sat)),
+            18)
       << "incorrect value for obs[3].sid.sat, expected 18, is "
       << last_msg_->obs[3].sid.sat;
-  EXPECT_EQ(last_msg_->obs[4].D.f, 245)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].D.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].D.f)),
+            245)
       << "incorrect value for obs[4].D.f, expected 245, is "
       << last_msg_->obs[4].D.f;
-  EXPECT_EQ(last_msg_->obs[4].D.i, 2829)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].D.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].D.i)),
+            2829)
       << "incorrect value for obs[4].D.i, expected 2829, is "
       << last_msg_->obs[4].D.i;
-  EXPECT_EQ(last_msg_->obs[4].L.f, 53)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].L.f)),
+            53)
       << "incorrect value for obs[4].L.f, expected 53, is "
       << last_msg_->obs[4].L.f;
-  EXPECT_EQ(last_msg_->obs[4].L.i, 132024982)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].L.i)),
+            132024982)
       << "incorrect value for obs[4].L.i, expected 132024982, is "
       << last_msg_->obs[4].L.i;
-  EXPECT_EQ(last_msg_->obs[4].P, 1256175650)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].P)),
+            1256175650)
       << "incorrect value for obs[4].P, expected 1256175650, is "
       << last_msg_->obs[4].P;
-  EXPECT_EQ(last_msg_->obs[4].cn0, 114)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].cn0)),
+            114)
       << "incorrect value for obs[4].cn0, expected 114, is "
       << last_msg_->obs[4].cn0;
-  EXPECT_EQ(last_msg_->obs[4].flags, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].flags)),
+            15)
       << "incorrect value for obs[4].flags, expected 15, is "
       << last_msg_->obs[4].flags;
-  EXPECT_EQ(last_msg_->obs[4].lock, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].lock)),
+            9)
       << "incorrect value for obs[4].lock, expected 9, is "
       << last_msg_->obs[4].lock;
-  EXPECT_EQ(last_msg_->obs[4].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].sid.code)),
+            0)
       << "incorrect value for obs[4].sid.code, expected 0, is "
       << last_msg_->obs[4].sid.code;
-  EXPECT_EQ(last_msg_->obs[4].sid.sat, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].sid.sat)),
+            22)
       << "incorrect value for obs[4].sid.sat, expected 22, is "
       << last_msg_->obs[4].sid.sat;
-  EXPECT_EQ(last_msg_->obs[5].D.f, 246)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].D.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].D.f)),
+            246)
       << "incorrect value for obs[5].D.f, expected 246, is "
       << last_msg_->obs[5].D.f;
-  EXPECT_EQ(last_msg_->obs[5].D.i, -2433)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].D.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].D.i)),
+            -2433)
       << "incorrect value for obs[5].D.i, expected -2433, is "
       << last_msg_->obs[5].D.i;
-  EXPECT_EQ(last_msg_->obs[5].L.f, 70)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].L.f)),
+            70)
       << "incorrect value for obs[5].L.f, expected 70, is "
       << last_msg_->obs[5].L.f;
-  EXPECT_EQ(last_msg_->obs[5].L.i, 121711010)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].L.i)),
+            121711010)
       << "incorrect value for obs[5].L.i, expected 121711010, is "
       << last_msg_->obs[5].L.i;
-  EXPECT_EQ(last_msg_->obs[5].P, 1158041713)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].P)),
+            1158041713)
       << "incorrect value for obs[5].P, expected 1158041713, is "
       << last_msg_->obs[5].P;
-  EXPECT_EQ(last_msg_->obs[5].cn0, 189)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].cn0)),
+            189)
       << "incorrect value for obs[5].cn0, expected 189, is "
       << last_msg_->obs[5].cn0;
-  EXPECT_EQ(last_msg_->obs[5].flags, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].flags)),
+            15)
       << "incorrect value for obs[5].flags, expected 15, is "
       << last_msg_->obs[5].flags;
-  EXPECT_EQ(last_msg_->obs[5].lock, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].lock)),
+            9)
       << "incorrect value for obs[5].lock, expected 9, is "
       << last_msg_->obs[5].lock;
-  EXPECT_EQ(last_msg_->obs[5].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].sid.code)),
+            0)
       << "incorrect value for obs[5].sid.code, expected 0, is "
       << last_msg_->obs[5].sid.code;
-  EXPECT_EQ(last_msg_->obs[5].sid.sat, 23)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].sid.sat)),
+            23)
       << "incorrect value for obs[5].sid.sat, expected 23, is "
       << last_msg_->obs[5].sid.sat;
-  EXPECT_EQ(last_msg_->obs[6].D.f, 231)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[6].D.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[6].D.f)),
+            231)
       << "incorrect value for obs[6].D.f, expected 231, is "
       << last_msg_->obs[6].D.f;
-  EXPECT_EQ(last_msg_->obs[6].D.i, -1896)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[6].D.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[6].D.i)),
+            -1896)
       << "incorrect value for obs[6].D.i, expected -1896, is "
       << last_msg_->obs[6].D.i;
-  EXPECT_EQ(last_msg_->obs[6].L.f, 221)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[6].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[6].L.f)),
+            221)
       << "incorrect value for obs[6].L.f, expected 221, is "
       << last_msg_->obs[6].L.f;
-  EXPECT_EQ(last_msg_->obs[6].L.i, 94839765)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[6].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[6].L.i)),
+            94839765)
       << "incorrect value for obs[6].L.i, expected 94839765, is "
       << last_msg_->obs[6].L.i;
-  EXPECT_EQ(last_msg_->obs[6].P, 1158041847)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[6].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[6].P)),
+            1158041847)
       << "incorrect value for obs[6].P, expected 1158041847, is "
       << last_msg_->obs[6].P;
-  EXPECT_EQ(last_msg_->obs[6].cn0, 158)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[6].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[6].cn0)),
+            158)
       << "incorrect value for obs[6].cn0, expected 158, is "
       << last_msg_->obs[6].cn0;
-  EXPECT_EQ(last_msg_->obs[6].flags, 11)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[6].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[6].flags)),
+            11)
       << "incorrect value for obs[6].flags, expected 11, is "
       << last_msg_->obs[6].flags;
-  EXPECT_EQ(last_msg_->obs[6].lock, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[6].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[6].lock)),
+            9)
       << "incorrect value for obs[6].lock, expected 9, is "
       << last_msg_->obs[6].lock;
-  EXPECT_EQ(last_msg_->obs[6].sid.code, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[6].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[6].sid.code)),
+            1)
       << "incorrect value for obs[6].sid.code, expected 1, is "
       << last_msg_->obs[6].sid.code;
-  EXPECT_EQ(last_msg_->obs[6].sid.sat, 23)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[6].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[6].sid.sat)),
+            23)
       << "incorrect value for obs[6].sid.sat, expected 23, is "
       << last_msg_->obs[6].sid.sat;
-  EXPECT_EQ(last_msg_->obs[7].D.f, 67)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[7].D.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[7].D.f)),
+            67)
       << "incorrect value for obs[7].D.f, expected 67, is "
       << last_msg_->obs[7].D.f;
-  EXPECT_EQ(last_msg_->obs[7].D.i, -1997)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[7].D.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[7].D.i)),
+            -1997)
       << "incorrect value for obs[7].D.i, expected -1997, is "
       << last_msg_->obs[7].D.i;
-  EXPECT_EQ(last_msg_->obs[7].L.f, 114)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[7].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[7].L.f)),
+            114)
       << "incorrect value for obs[7].L.f, expected 114, is "
       << last_msg_->obs[7].L.f;
-  EXPECT_EQ(last_msg_->obs[7].L.i, 113998348)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[7].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[7].L.i)),
+            113998348)
       << "incorrect value for obs[7].L.i, expected 113998348, is "
       << last_msg_->obs[7].L.i;
-  EXPECT_EQ(last_msg_->obs[7].P, 1084658184)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[7].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[7].P)),
+            1084658184)
       << "incorrect value for obs[7].P, expected 1084658184, is "
       << last_msg_->obs[7].P;
-  EXPECT_EQ(last_msg_->obs[7].cn0, 93)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[7].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[7].cn0)),
+            93)
       << "incorrect value for obs[7].cn0, expected 93, is "
       << last_msg_->obs[7].cn0;
-  EXPECT_EQ(last_msg_->obs[7].flags, 11)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[7].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[7].flags)),
+            11)
       << "incorrect value for obs[7].flags, expected 11, is "
       << last_msg_->obs[7].flags;
-  EXPECT_EQ(last_msg_->obs[7].lock, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[7].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[7].lock)),
+            3)
       << "incorrect value for obs[7].lock, expected 3, is "
       << last_msg_->obs[7].lock;
-  EXPECT_EQ(last_msg_->obs[7].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[7].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[7].sid.code)),
+            0)
       << "incorrect value for obs[7].sid.code, expected 0, is "
       << last_msg_->obs[7].sid.code;
-  EXPECT_EQ(last_msg_->obs[7].sid.sat, 27)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[7].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[7].sid.sat)),
+            27)
       << "incorrect value for obs[7].sid.sat, expected 27, is "
       << last_msg_->obs[7].sid.sat;
-  EXPECT_EQ(last_msg_->obs[8].D.f, 237)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[8].D.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[8].D.f)),
+            237)
       << "incorrect value for obs[8].D.f, expected 237, is "
       << last_msg_->obs[8].D.f;
-  EXPECT_EQ(last_msg_->obs[8].D.i, 3041)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[8].D.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[8].D.i)),
+            3041)
       << "incorrect value for obs[8].D.i, expected 3041, is "
       << last_msg_->obs[8].D.i;
-  EXPECT_EQ(last_msg_->obs[8].L.f, 232)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[8].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[8].L.f)),
+            232)
       << "incorrect value for obs[8].L.f, expected 232, is "
       << last_msg_->obs[8].L.f;
-  EXPECT_EQ(last_msg_->obs[8].L.i, 133443545)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[8].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[8].L.i)),
+            133443545)
       << "incorrect value for obs[8].L.i, expected 133443545, is "
       << last_msg_->obs[8].L.i;
-  EXPECT_EQ(last_msg_->obs[8].P, 1269673181)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[8].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[8].P)),
+            1269673181)
       << "incorrect value for obs[8].P, expected 1269673181, is "
       << last_msg_->obs[8].P;
-  EXPECT_EQ(last_msg_->obs[8].cn0, 123)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[8].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[8].cn0)),
+            123)
       << "incorrect value for obs[8].cn0, expected 123, is "
       << last_msg_->obs[8].cn0;
-  EXPECT_EQ(last_msg_->obs[8].flags, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[8].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[8].flags)),
+            15)
       << "incorrect value for obs[8].flags, expected 15, is "
       << last_msg_->obs[8].flags;
-  EXPECT_EQ(last_msg_->obs[8].lock, 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[8].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[8].lock)),
+            5)
       << "incorrect value for obs[8].lock, expected 5, is "
       << last_msg_->obs[8].lock;
-  EXPECT_EQ(last_msg_->obs[8].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[8].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[8].sid.code)),
+            0)
       << "incorrect value for obs[8].sid.code, expected 0, is "
       << last_msg_->obs[8].sid.code;
-  EXPECT_EQ(last_msg_->obs[8].sid.sat, 31)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[8].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[8].sid.sat)),
+            31)
       << "incorrect value for obs[8].sid.sat, expected 31, is "
       << last_msg_->obs[8].sid.sat;
-  EXPECT_EQ(last_msg_->obs[9].D.f, 62)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[9].D.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[9].D.f)),
+            62)
       << "incorrect value for obs[9].D.f, expected 62, is "
       << last_msg_->obs[9].D.f;
-  EXPECT_EQ(last_msg_->obs[9].D.i, 2374)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[9].D.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[9].D.i)),
+            2374)
       << "incorrect value for obs[9].D.i, expected 2374, is "
       << last_msg_->obs[9].D.i;
-  EXPECT_EQ(last_msg_->obs[9].L.f, 40)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[9].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[9].L.f)),
+            40)
       << "incorrect value for obs[9].L.f, expected 40, is "
       << last_msg_->obs[9].L.f;
-  EXPECT_EQ(last_msg_->obs[9].L.i, 103982040)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[9].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[9].L.i)),
+            103982040)
       << "incorrect value for obs[9].L.i, expected 103982040, is "
       << last_msg_->obs[9].L.i;
-  EXPECT_EQ(last_msg_->obs[9].P, 1269673722)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[9].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[9].P)),
+            1269673722)
       << "incorrect value for obs[9].P, expected 1269673722, is "
       << last_msg_->obs[9].P;
-  EXPECT_EQ(last_msg_->obs[9].cn0, 120)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[9].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[9].cn0)),
+            120)
       << "incorrect value for obs[9].cn0, expected 120, is "
       << last_msg_->obs[9].cn0;
-  EXPECT_EQ(last_msg_->obs[9].flags, 11)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[9].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[9].flags)),
+            11)
       << "incorrect value for obs[9].flags, expected 11, is "
       << last_msg_->obs[9].flags;
-  EXPECT_EQ(last_msg_->obs[9].lock, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[9].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[9].lock)),
+            3)
       << "incorrect value for obs[9].lock, expected 3, is "
       << last_msg_->obs[9].lock;
-  EXPECT_EQ(last_msg_->obs[9].sid.code, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[9].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[9].sid.code)),
+            1)
       << "incorrect value for obs[9].sid.code, expected 1, is "
       << last_msg_->obs[9].sid.code;
-  EXPECT_EQ(last_msg_->obs[9].sid.sat, 31)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[9].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[9].sid.sat)),
+            31)
       << "incorrect value for obs[9].sid.sat, expected 31, is "
       << last_msg_->obs[9].sid.sat;
-  EXPECT_EQ(last_msg_->obs[10].D.f, 96)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[10].D.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[10].D.f)),
+            96)
       << "incorrect value for obs[10].D.f, expected 96, is "
       << last_msg_->obs[10].D.f;
-  EXPECT_EQ(last_msg_->obs[10].D.i, -3446)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[10].D.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[10].D.i)),
+            -3446)
       << "incorrect value for obs[10].D.i, expected -3446, is "
       << last_msg_->obs[10].D.i;
-  EXPECT_EQ(last_msg_->obs[10].L.f, 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[10].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[10].L.f)),
+            7)
       << "incorrect value for obs[10].L.f, expected 7, is "
       << last_msg_->obs[10].L.f;
-  EXPECT_EQ(last_msg_->obs[10].L.i, 118217315)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[10].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[10].L.i)),
+            118217315)
       << "incorrect value for obs[10].L.i, expected 118217315, is "
       << last_msg_->obs[10].L.i;
-  EXPECT_EQ(last_msg_->obs[10].P, 1107693703)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[10].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[10].P)),
+            1107693703)
       << "incorrect value for obs[10].P, expected 1107693703, is "
       << last_msg_->obs[10].P;
-  EXPECT_EQ(last_msg_->obs[10].cn0, 176)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[10].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[10].cn0)),
+            176)
       << "incorrect value for obs[10].cn0, expected 176, is "
       << last_msg_->obs[10].cn0;
-  EXPECT_EQ(last_msg_->obs[10].flags, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[10].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[10].flags)),
+            15)
       << "incorrect value for obs[10].flags, expected 15, is "
       << last_msg_->obs[10].flags;
-  EXPECT_EQ(last_msg_->obs[10].lock, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[10].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[10].lock)),
+            10)
       << "incorrect value for obs[10].lock, expected 10, is "
       << last_msg_->obs[10].lock;
-  EXPECT_EQ(last_msg_->obs[10].sid.code, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[10].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[10].sid.code)),
+      3)
       << "incorrect value for obs[10].sid.code, expected 3, is "
       << last_msg_->obs[10].sid.code;
-  EXPECT_EQ(last_msg_->obs[10].sid.sat, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[10].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[10].sid.sat)),
+            2)
       << "incorrect value for obs[10].sid.sat, expected 2, is "
       << last_msg_->obs[10].sid.sat;
-  EXPECT_EQ(last_msg_->obs[11].D.f, 96)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[11].D.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[11].D.f)),
+            96)
       << "incorrect value for obs[11].D.f, expected 96, is "
       << last_msg_->obs[11].D.f;
-  EXPECT_EQ(last_msg_->obs[11].D.i, -1003)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[11].D.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[11].D.i)),
+            -1003)
       << "incorrect value for obs[11].D.i, expected -1003, is "
       << last_msg_->obs[11].D.i;
-  EXPECT_EQ(last_msg_->obs[11].L.f, 203)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[11].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[11].L.f)),
+            203)
       << "incorrect value for obs[11].L.f, expected 203, is "
       << last_msg_->obs[11].L.f;
-  EXPECT_EQ(last_msg_->obs[11].L.i, 104224985)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[11].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[11].L.i)),
+            104224985)
       << "incorrect value for obs[11].L.i, expected 104224985, is "
       << last_msg_->obs[11].L.i;
-  EXPECT_EQ(last_msg_->obs[11].P, 973505172)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[11].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[11].P)),
+            973505172)
       << "incorrect value for obs[11].P, expected 973505172, is "
       << last_msg_->obs[11].P;
-  EXPECT_EQ(last_msg_->obs[11].cn0, 170)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[11].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[11].cn0)),
+            170)
       << "incorrect value for obs[11].cn0, expected 170, is "
       << last_msg_->obs[11].cn0;
-  EXPECT_EQ(last_msg_->obs[11].flags, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[11].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[11].flags)),
+            15)
       << "incorrect value for obs[11].flags, expected 15, is "
       << last_msg_->obs[11].flags;
-  EXPECT_EQ(last_msg_->obs[11].lock, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[11].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[11].lock)),
+            10)
       << "incorrect value for obs[11].lock, expected 10, is "
       << last_msg_->obs[11].lock;
-  EXPECT_EQ(last_msg_->obs[11].sid.code, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[11].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[11].sid.code)),
+      3)
       << "incorrect value for obs[11].sid.code, expected 3, is "
       << last_msg_->obs[11].sid.code;
-  EXPECT_EQ(last_msg_->obs[11].sid.sat, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[11].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[11].sid.sat)),
+            3)
       << "incorrect value for obs[11].sid.sat, expected 3, is "
       << last_msg_->obs[11].sid.sat;
-  EXPECT_EQ(last_msg_->obs[12].D.f, 219)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[12].D.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[12].D.f)),
+            219)
       << "incorrect value for obs[12].D.f, expected 219, is "
       << last_msg_->obs[12].D.f;
-  EXPECT_EQ(last_msg_->obs[12].D.i, -3836)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[12].D.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[12].D.i)),
+            -3836)
       << "incorrect value for obs[12].D.i, expected -3836, is "
       << last_msg_->obs[12].D.i;
-  EXPECT_EQ(last_msg_->obs[12].L.f, 80)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[12].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[12].L.f)),
+            80)
       << "incorrect value for obs[12].L.f, expected 80, is "
       << last_msg_->obs[12].L.f;
-  EXPECT_EQ(last_msg_->obs[12].L.i, 114505343)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[12].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[12].L.i)),
+            114505343)
       << "incorrect value for obs[12].L.i, expected 114505343, is "
       << last_msg_->obs[12].L.i;
-  EXPECT_EQ(last_msg_->obs[12].P, 1069903034)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[12].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[12].P)),
+            1069903034)
       << "incorrect value for obs[12].P, expected 1069903034, is "
       << last_msg_->obs[12].P;
-  EXPECT_EQ(last_msg_->obs[12].cn0, 200)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[12].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[12].cn0)),
+            200)
       << "incorrect value for obs[12].cn0, expected 200, is "
       << last_msg_->obs[12].cn0;
-  EXPECT_EQ(last_msg_->obs[12].flags, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[12].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[12].flags)),
+            15)
       << "incorrect value for obs[12].flags, expected 15, is "
       << last_msg_->obs[12].flags;
-  EXPECT_EQ(last_msg_->obs[12].lock, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[12].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[12].lock)),
+            10)
       << "incorrect value for obs[12].lock, expected 10, is "
       << last_msg_->obs[12].lock;
-  EXPECT_EQ(last_msg_->obs[12].sid.code, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[12].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[12].sid.code)),
+      3)
       << "incorrect value for obs[12].sid.code, expected 3, is "
       << last_msg_->obs[12].sid.code;
-  EXPECT_EQ(last_msg_->obs[12].sid.sat, 17)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[12].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[12].sid.sat)),
+            17)
       << "incorrect value for obs[12].sid.sat, expected 17, is "
       << last_msg_->obs[12].sid.sat;
-  EXPECT_EQ(last_msg_->obs[13].D.f, 182)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[13].D.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[13].D.f)),
+            182)
       << "incorrect value for obs[13].D.f, expected 182, is "
       << last_msg_->obs[13].D.f;
-  EXPECT_EQ(last_msg_->obs[13].D.i, -461)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[13].D.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[13].D.i)),
+            -461)
       << "incorrect value for obs[13].D.i, expected -461, is "
       << last_msg_->obs[13].D.i;
-  EXPECT_EQ(last_msg_->obs[13].L.f, 105)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[13].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[13].L.f)),
+            105)
       << "incorrect value for obs[13].L.f, expected 105, is "
       << last_msg_->obs[13].L.f;
-  EXPECT_EQ(last_msg_->obs[13].L.i, 102157331)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[13].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[13].L.i)),
+            102157331)
       << "incorrect value for obs[13].L.i, expected 102157331, is "
       << last_msg_->obs[13].L.i;
-  EXPECT_EQ(last_msg_->obs[13].P, 956875687)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[13].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[13].P)),
+            956875687)
       << "incorrect value for obs[13].P, expected 956875687, is "
       << last_msg_->obs[13].P;
-  EXPECT_EQ(last_msg_->obs[13].cn0, 152)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[13].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[13].cn0)),
+            152)
       << "incorrect value for obs[13].cn0, expected 152, is "
       << last_msg_->obs[13].cn0;
-  EXPECT_EQ(last_msg_->obs[13].flags, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[13].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[13].flags)),
+            15)
       << "incorrect value for obs[13].flags, expected 15, is "
       << last_msg_->obs[13].flags;
-  EXPECT_EQ(last_msg_->obs[13].lock, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[13].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[13].lock)),
+            10)
       << "incorrect value for obs[13].lock, expected 10, is "
       << last_msg_->obs[13].lock;
-  EXPECT_EQ(last_msg_->obs[13].sid.code, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[13].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[13].sid.code)),
+      3)
       << "incorrect value for obs[13].sid.code, expected 3, is "
       << last_msg_->obs[13].sid.code;
-  EXPECT_EQ(last_msg_->obs[13].sid.sat, 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[13].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[13].sid.sat)),
+            18)
       << "incorrect value for obs[13].sid.sat, expected 18, is "
       << last_msg_->obs[13].sid.sat;
 }
@@ -844,16 +1144,25 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgObs1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 61569);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->header.n_obs, 16)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.n_obs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.n_obs)),
+            16)
       << "incorrect value for header.n_obs, expected 16, is "
       << last_msg_->header.n_obs;
-  EXPECT_EQ(last_msg_->header.t.ns_residual, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->header.t.ns_residual)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->header.t.ns_residual)),
+      0)
       << "incorrect value for header.t.ns_residual, expected 0, is "
       << last_msg_->header.t.ns_residual;
-  EXPECT_EQ(last_msg_->header.t.tow, 434293400)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.tow)),
+            434293400)
       << "incorrect value for header.t.tow, expected 434293400, is "
       << last_msg_->header.t.tow;
-  EXPECT_EQ(last_msg_->header.t.wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.wn)),
+            2154)
       << "incorrect value for header.t.wn, expected 2154, is "
       << last_msg_->header.t.wn;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgObsDepB.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgObsDepB.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgObsDepB0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -190,157 +197,265 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgObsDepB0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->header.n_obs, 32)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.n_obs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.n_obs)),
+            32)
       << "incorrect value for header.n_obs, expected 32, is "
       << last_msg_->header.n_obs;
-  EXPECT_EQ(last_msg_->header.t.tow, 2567800)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.tow)),
+            2567800)
       << "incorrect value for header.t.tow, expected 2567800, is "
       << last_msg_->header.t.tow;
-  EXPECT_EQ(last_msg_->header.t.wn, 1787)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.wn)),
+            1787)
       << "incorrect value for header.t.wn, expected 1787, is "
       << last_msg_->header.t.wn;
-  EXPECT_EQ(last_msg_->obs[0].L.f, 27)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.f)),
+            27)
       << "incorrect value for obs[0].L.f, expected 27, is "
       << last_msg_->obs[0].L.f;
-  EXPECT_EQ(last_msg_->obs[0].L.i, 117913055)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.i)),
+            117913055)
       << "incorrect value for obs[0].L.i, expected 117913055, is "
       << last_msg_->obs[0].L.i;
-  EXPECT_EQ(last_msg_->obs[0].P, 2243669940)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].P)),
+            2243669940)
       << "incorrect value for obs[0].P, expected 2243669940, is "
       << last_msg_->obs[0].P;
-  EXPECT_EQ(last_msg_->obs[0].cn0, 157)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].cn0)),
+            157)
       << "incorrect value for obs[0].cn0, expected 157, is "
       << last_msg_->obs[0].cn0;
-  EXPECT_EQ(last_msg_->obs[0].lock, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].lock)),
+            0)
       << "incorrect value for obs[0].lock, expected 0, is "
       << last_msg_->obs[0].lock;
-  EXPECT_EQ(last_msg_->obs[0].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.code)),
+            0)
       << "incorrect value for obs[0].sid.code, expected 0, is "
       << last_msg_->obs[0].sid.code;
-  EXPECT_EQ(last_msg_->obs[0].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[0].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.reserved)),
+      0)
       << "incorrect value for obs[0].sid.reserved, expected 0, is "
       << last_msg_->obs[0].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[0].sid.sat, 202)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.sat)),
+            202)
       << "incorrect value for obs[0].sid.sat, expected 202, is "
       << last_msg_->obs[0].sid.sat;
-  EXPECT_EQ(last_msg_->obs[1].L.f, 175)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].L.f)),
+            175)
       << "incorrect value for obs[1].L.f, expected 175, is "
       << last_msg_->obs[1].L.f;
-  EXPECT_EQ(last_msg_->obs[1].L.i, 129899608)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].L.i)),
+            129899608)
       << "incorrect value for obs[1].L.i, expected 129899608, is "
       << last_msg_->obs[1].L.i;
-  EXPECT_EQ(last_msg_->obs[1].P, 2471857210)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].P)),
+            2471857210)
       << "incorrect value for obs[1].P, expected 2471857210, is "
       << last_msg_->obs[1].P;
-  EXPECT_EQ(last_msg_->obs[1].cn0, 144)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].cn0)),
+            144)
       << "incorrect value for obs[1].cn0, expected 144, is "
       << last_msg_->obs[1].cn0;
-  EXPECT_EQ(last_msg_->obs[1].lock, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].lock)),
+            0)
       << "incorrect value for obs[1].lock, expected 0, is "
       << last_msg_->obs[1].lock;
-  EXPECT_EQ(last_msg_->obs[1].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.code)),
+            0)
       << "incorrect value for obs[1].sid.code, expected 0, is "
       << last_msg_->obs[1].sid.code;
-  EXPECT_EQ(last_msg_->obs[1].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[1].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.reserved)),
+      0)
       << "incorrect value for obs[1].sid.reserved, expected 0, is "
       << last_msg_->obs[1].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[1].sid.sat, 203)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.sat)),
+            203)
       << "incorrect value for obs[1].sid.sat, expected 203, is "
       << last_msg_->obs[1].sid.sat;
-  EXPECT_EQ(last_msg_->obs[2].L.f, 135)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].L.f)),
+            135)
       << "incorrect value for obs[2].L.f, expected 135, is "
       << last_msg_->obs[2].L.f;
-  EXPECT_EQ(last_msg_->obs[2].L.i, 122531024)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].L.i)),
+            122531024)
       << "incorrect value for obs[2].L.i, expected 122531024, is "
       << last_msg_->obs[2].L.i;
-  EXPECT_EQ(last_msg_->obs[2].P, 2331544796)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].P)),
+            2331544796)
       << "incorrect value for obs[2].P, expected 2331544796, is "
       << last_msg_->obs[2].P;
-  EXPECT_EQ(last_msg_->obs[2].cn0, 151)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].cn0)),
+            151)
       << "incorrect value for obs[2].cn0, expected 151, is "
       << last_msg_->obs[2].cn0;
-  EXPECT_EQ(last_msg_->obs[2].lock, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].lock)),
+            0)
       << "incorrect value for obs[2].lock, expected 0, is "
       << last_msg_->obs[2].lock;
-  EXPECT_EQ(last_msg_->obs[2].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.code)),
+            0)
       << "incorrect value for obs[2].sid.code, expected 0, is "
       << last_msg_->obs[2].sid.code;
-  EXPECT_EQ(last_msg_->obs[2].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[2].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.reserved)),
+      0)
       << "incorrect value for obs[2].sid.reserved, expected 0, is "
       << last_msg_->obs[2].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[2].sid.sat, 208)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.sat)),
+            208)
       << "incorrect value for obs[2].sid.sat, expected 208, is "
       << last_msg_->obs[2].sid.sat;
-  EXPECT_EQ(last_msg_->obs[3].L.f, 242)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].L.f)),
+            242)
       << "incorrect value for obs[3].L.f, expected 242, is "
       << last_msg_->obs[3].L.f;
-  EXPECT_EQ(last_msg_->obs[3].L.i, 119280243)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].L.i)),
+            119280243)
       << "incorrect value for obs[3].L.i, expected 119280243, is "
       << last_msg_->obs[3].L.i;
-  EXPECT_EQ(last_msg_->obs[3].P, 2269692589)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].P)),
+            2269692589)
       << "incorrect value for obs[3].P, expected 2269692589, is "
       << last_msg_->obs[3].P;
-  EXPECT_EQ(last_msg_->obs[3].cn0, 156)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].cn0)),
+            156)
       << "incorrect value for obs[3].cn0, expected 156, is "
       << last_msg_->obs[3].cn0;
-  EXPECT_EQ(last_msg_->obs[3].lock, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].lock)),
+            0)
       << "incorrect value for obs[3].lock, expected 0, is "
       << last_msg_->obs[3].lock;
-  EXPECT_EQ(last_msg_->obs[3].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].sid.code)),
+            0)
       << "incorrect value for obs[3].sid.code, expected 0, is "
       << last_msg_->obs[3].sid.code;
-  EXPECT_EQ(last_msg_->obs[3].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[3].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].sid.reserved)),
+      0)
       << "incorrect value for obs[3].sid.reserved, expected 0, is "
       << last_msg_->obs[3].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[3].sid.sat, 212)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].sid.sat)),
+            212)
       << "incorrect value for obs[3].sid.sat, expected 212, is "
       << last_msg_->obs[3].sid.sat;
-  EXPECT_EQ(last_msg_->obs[4].L.f, 120)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].L.f)),
+            120)
       << "incorrect value for obs[4].L.f, expected 120, is "
       << last_msg_->obs[4].L.f;
-  EXPECT_EQ(last_msg_->obs[4].L.i, 109691922)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].L.i)),
+            109691922)
       << "incorrect value for obs[4].L.i, expected 109691922, is "
       << last_msg_->obs[4].L.i;
-  EXPECT_EQ(last_msg_->obs[4].P, 2087293092)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].P)),
+            2087293092)
       << "incorrect value for obs[4].P, expected 2087293092, is "
       << last_msg_->obs[4].P;
-  EXPECT_EQ(last_msg_->obs[4].cn0, 168)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].cn0)),
+            168)
       << "incorrect value for obs[4].cn0, expected 168, is "
       << last_msg_->obs[4].cn0;
-  EXPECT_EQ(last_msg_->obs[4].lock, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].lock)),
+            0)
       << "incorrect value for obs[4].lock, expected 0, is "
       << last_msg_->obs[4].lock;
-  EXPECT_EQ(last_msg_->obs[4].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].sid.code)),
+            0)
       << "incorrect value for obs[4].sid.code, expected 0, is "
       << last_msg_->obs[4].sid.code;
-  EXPECT_EQ(last_msg_->obs[4].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[4].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].sid.reserved)),
+      0)
       << "incorrect value for obs[4].sid.reserved, expected 0, is "
       << last_msg_->obs[4].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[4].sid.sat, 217)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].sid.sat)),
+            217)
       << "incorrect value for obs[4].sid.sat, expected 217, is "
       << last_msg_->obs[4].sid.sat;
-  EXPECT_EQ(last_msg_->obs[5].L.f, 87)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].L.f)),
+            87)
       << "incorrect value for obs[5].L.f, expected 87, is "
       << last_msg_->obs[5].L.f;
-  EXPECT_EQ(last_msg_->obs[5].L.i, 123340754)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].L.i)),
+            123340754)
       << "incorrect value for obs[5].L.i, expected 123340754, is "
       << last_msg_->obs[5].L.i;
-  EXPECT_EQ(last_msg_->obs[5].P, 2347034654)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].P)),
+            2347034654)
       << "incorrect value for obs[5].P, expected 2347034654, is "
       << last_msg_->obs[5].P;
-  EXPECT_EQ(last_msg_->obs[5].cn0, 150)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].cn0)),
+            150)
       << "incorrect value for obs[5].cn0, expected 150, is "
       << last_msg_->obs[5].cn0;
-  EXPECT_EQ(last_msg_->obs[5].lock, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].lock)),
+            0)
       << "incorrect value for obs[5].lock, expected 0, is "
       << last_msg_->obs[5].lock;
-  EXPECT_EQ(last_msg_->obs[5].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].sid.code)),
+            0)
       << "incorrect value for obs[5].sid.code, expected 0, is "
       << last_msg_->obs[5].sid.code;
-  EXPECT_EQ(last_msg_->obs[5].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[5].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].sid.reserved)),
+      0)
       << "incorrect value for obs[5].sid.reserved, expected 0, is "
       << last_msg_->obs[5].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[5].sid.sat, 218)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].sid.sat)),
+            218)
       << "incorrect value for obs[5].sid.sat, expected 218, is "
       << last_msg_->obs[5].sid.sat;
 }
@@ -466,85 +581,142 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgObsDepB1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->header.n_obs, 33)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.n_obs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.n_obs)),
+            33)
       << "incorrect value for header.n_obs, expected 33, is "
       << last_msg_->header.n_obs;
-  EXPECT_EQ(last_msg_->header.t.tow, 2567800)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.tow)),
+            2567800)
       << "incorrect value for header.t.tow, expected 2567800, is "
       << last_msg_->header.t.tow;
-  EXPECT_EQ(last_msg_->header.t.wn, 1787)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.wn)),
+            1787)
       << "incorrect value for header.t.wn, expected 1787, is "
       << last_msg_->header.t.wn;
-  EXPECT_EQ(last_msg_->obs[0].L.f, 219)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.f)),
+            219)
       << "incorrect value for obs[0].L.f, expected 219, is "
       << last_msg_->obs[0].L.f;
-  EXPECT_EQ(last_msg_->obs[0].L.i, 120256389)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.i)),
+            120256389)
       << "incorrect value for obs[0].L.i, expected 120256389, is "
       << last_msg_->obs[0].L.i;
-  EXPECT_EQ(last_msg_->obs[0].P, 2288371524)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].P)),
+            2288371524)
       << "incorrect value for obs[0].P, expected 2288371524, is "
       << last_msg_->obs[0].P;
-  EXPECT_EQ(last_msg_->obs[0].cn0, 154)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].cn0)),
+            154)
       << "incorrect value for obs[0].cn0, expected 154, is "
       << last_msg_->obs[0].cn0;
-  EXPECT_EQ(last_msg_->obs[0].lock, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].lock)),
+            0)
       << "incorrect value for obs[0].lock, expected 0, is "
       << last_msg_->obs[0].lock;
-  EXPECT_EQ(last_msg_->obs[0].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.code)),
+            0)
       << "incorrect value for obs[0].sid.code, expected 0, is "
       << last_msg_->obs[0].sid.code;
-  EXPECT_EQ(last_msg_->obs[0].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[0].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.reserved)),
+      0)
       << "incorrect value for obs[0].sid.reserved, expected 0, is "
       << last_msg_->obs[0].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[0].sid.sat, 220)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.sat)),
+            220)
       << "incorrect value for obs[0].sid.sat, expected 220, is "
       << last_msg_->obs[0].sid.sat;
-  EXPECT_EQ(last_msg_->obs[1].L.f, 235)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].L.f)),
+            235)
       << "incorrect value for obs[1].L.f, expected 235, is "
       << last_msg_->obs[1].L.f;
-  EXPECT_EQ(last_msg_->obs[1].L.i, 117692256)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].L.i)),
+            117692256)
       << "incorrect value for obs[1].L.i, expected 117692256, is "
       << last_msg_->obs[1].L.i;
-  EXPECT_EQ(last_msg_->obs[1].P, 2239434459)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].P)),
+            2239434459)
       << "incorrect value for obs[1].P, expected 2239434459, is "
       << last_msg_->obs[1].P;
-  EXPECT_EQ(last_msg_->obs[1].cn0, 156)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].cn0)),
+            156)
       << "incorrect value for obs[1].cn0, expected 156, is "
       << last_msg_->obs[1].cn0;
-  EXPECT_EQ(last_msg_->obs[1].lock, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].lock)),
+            0)
       << "incorrect value for obs[1].lock, expected 0, is "
       << last_msg_->obs[1].lock;
-  EXPECT_EQ(last_msg_->obs[1].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.code)),
+            0)
       << "incorrect value for obs[1].sid.code, expected 0, is "
       << last_msg_->obs[1].sid.code;
-  EXPECT_EQ(last_msg_->obs[1].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[1].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.reserved)),
+      0)
       << "incorrect value for obs[1].sid.reserved, expected 0, is "
       << last_msg_->obs[1].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[1].sid.sat, 222)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.sat)),
+            222)
       << "incorrect value for obs[1].sid.sat, expected 222, is "
       << last_msg_->obs[1].sid.sat;
-  EXPECT_EQ(last_msg_->obs[2].L.f, 174)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].L.f)),
+            174)
       << "incorrect value for obs[2].L.f, expected 174, is "
       << last_msg_->obs[2].L.f;
-  EXPECT_EQ(last_msg_->obs[2].L.i, 107851013)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].L.i)),
+            107851013)
       << "incorrect value for obs[2].L.i, expected 107851013, is "
       << last_msg_->obs[2].L.i;
-  EXPECT_EQ(last_msg_->obs[2].P, 2052171351)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].P)),
+            2052171351)
       << "incorrect value for obs[2].P, expected 2052171351, is "
       << last_msg_->obs[2].P;
-  EXPECT_EQ(last_msg_->obs[2].cn0, 170)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].cn0)),
+            170)
       << "incorrect value for obs[2].cn0, expected 170, is "
       << last_msg_->obs[2].cn0;
-  EXPECT_EQ(last_msg_->obs[2].lock, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].lock)),
+            0)
       << "incorrect value for obs[2].lock, expected 0, is "
       << last_msg_->obs[2].lock;
-  EXPECT_EQ(last_msg_->obs[2].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.code)),
+            0)
       << "incorrect value for obs[2].sid.code, expected 0, is "
       << last_msg_->obs[2].sid.code;
-  EXPECT_EQ(last_msg_->obs[2].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[2].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.reserved)),
+      0)
       << "incorrect value for obs[2].sid.reserved, expected 0, is "
       << last_msg_->obs[2].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[2].sid.sat, 225)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.sat)),
+            225)
       << "incorrect value for obs[2].sid.sat, expected 225, is "
       << last_msg_->obs[2].sid.sat;
 }
@@ -709,157 +881,265 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgObsDepB2, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->header.n_obs, 32)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.n_obs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.n_obs)),
+            32)
       << "incorrect value for header.n_obs, expected 32, is "
       << last_msg_->header.n_obs;
-  EXPECT_EQ(last_msg_->header.t.tow, 2568000)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.tow)),
+            2568000)
       << "incorrect value for header.t.tow, expected 2568000, is "
       << last_msg_->header.t.tow;
-  EXPECT_EQ(last_msg_->header.t.wn, 1787)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.wn)),
+            1787)
       << "incorrect value for header.t.wn, expected 1787, is "
       << last_msg_->header.t.wn;
-  EXPECT_EQ(last_msg_->obs[0].L.f, 94)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.f)),
+            94)
       << "incorrect value for obs[0].L.f, expected 94, is "
       << last_msg_->obs[0].L.f;
-  EXPECT_EQ(last_msg_->obs[0].L.i, 117912556)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.i)),
+            117912556)
       << "incorrect value for obs[0].L.i, expected 117912556, is "
       << last_msg_->obs[0].L.i;
-  EXPECT_EQ(last_msg_->obs[0].P, 2243658852)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].P)),
+            2243658852)
       << "incorrect value for obs[0].P, expected 2243658852, is "
       << last_msg_->obs[0].P;
-  EXPECT_EQ(last_msg_->obs[0].cn0, 156)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].cn0)),
+            156)
       << "incorrect value for obs[0].cn0, expected 156, is "
       << last_msg_->obs[0].cn0;
-  EXPECT_EQ(last_msg_->obs[0].lock, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].lock)),
+            0)
       << "incorrect value for obs[0].lock, expected 0, is "
       << last_msg_->obs[0].lock;
-  EXPECT_EQ(last_msg_->obs[0].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.code)),
+            0)
       << "incorrect value for obs[0].sid.code, expected 0, is "
       << last_msg_->obs[0].sid.code;
-  EXPECT_EQ(last_msg_->obs[0].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[0].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.reserved)),
+      0)
       << "incorrect value for obs[0].sid.reserved, expected 0, is "
       << last_msg_->obs[0].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[0].sid.sat, 202)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.sat)),
+            202)
       << "incorrect value for obs[0].sid.sat, expected 202, is "
       << last_msg_->obs[0].sid.sat;
-  EXPECT_EQ(last_msg_->obs[1].L.f, 40)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].L.f)),
+            40)
       << "incorrect value for obs[1].L.f, expected 40, is "
       << last_msg_->obs[1].L.f;
-  EXPECT_EQ(last_msg_->obs[1].L.i, 129900210)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].L.i)),
+            129900210)
       << "incorrect value for obs[1].L.i, expected 129900210, is "
       << last_msg_->obs[1].L.i;
-  EXPECT_EQ(last_msg_->obs[1].P, 2471868513)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].P)),
+            2471868513)
       << "incorrect value for obs[1].P, expected 2471868513, is "
       << last_msg_->obs[1].P;
-  EXPECT_EQ(last_msg_->obs[1].cn0, 140)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].cn0)),
+            140)
       << "incorrect value for obs[1].cn0, expected 140, is "
       << last_msg_->obs[1].cn0;
-  EXPECT_EQ(last_msg_->obs[1].lock, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].lock)),
+            0)
       << "incorrect value for obs[1].lock, expected 0, is "
       << last_msg_->obs[1].lock;
-  EXPECT_EQ(last_msg_->obs[1].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.code)),
+            0)
       << "incorrect value for obs[1].sid.code, expected 0, is "
       << last_msg_->obs[1].sid.code;
-  EXPECT_EQ(last_msg_->obs[1].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[1].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.reserved)),
+      0)
       << "incorrect value for obs[1].sid.reserved, expected 0, is "
       << last_msg_->obs[1].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[1].sid.sat, 203)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.sat)),
+            203)
       << "incorrect value for obs[1].sid.sat, expected 203, is "
       << last_msg_->obs[1].sid.sat;
-  EXPECT_EQ(last_msg_->obs[2].L.f, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].L.f)),
+            2)
       << "incorrect value for obs[2].L.f, expected 2, is "
       << last_msg_->obs[2].L.f;
-  EXPECT_EQ(last_msg_->obs[2].L.i, 122530650)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].L.i)),
+            122530650)
       << "incorrect value for obs[2].L.i, expected 122530650, is "
       << last_msg_->obs[2].L.i;
-  EXPECT_EQ(last_msg_->obs[2].P, 2331537287)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].P)),
+            2331537287)
       << "incorrect value for obs[2].P, expected 2331537287, is "
       << last_msg_->obs[2].P;
-  EXPECT_EQ(last_msg_->obs[2].cn0, 150)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].cn0)),
+            150)
       << "incorrect value for obs[2].cn0, expected 150, is "
       << last_msg_->obs[2].cn0;
-  EXPECT_EQ(last_msg_->obs[2].lock, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].lock)),
+            0)
       << "incorrect value for obs[2].lock, expected 0, is "
       << last_msg_->obs[2].lock;
-  EXPECT_EQ(last_msg_->obs[2].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.code)),
+            0)
       << "incorrect value for obs[2].sid.code, expected 0, is "
       << last_msg_->obs[2].sid.code;
-  EXPECT_EQ(last_msg_->obs[2].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[2].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.reserved)),
+      0)
       << "incorrect value for obs[2].sid.reserved, expected 0, is "
       << last_msg_->obs[2].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[2].sid.sat, 208)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.sat)),
+            208)
       << "incorrect value for obs[2].sid.sat, expected 208, is "
       << last_msg_->obs[2].sid.sat;
-  EXPECT_EQ(last_msg_->obs[3].L.f, 241)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].L.f)),
+            241)
       << "incorrect value for obs[3].L.f, expected 241, is "
       << last_msg_->obs[3].L.f;
-  EXPECT_EQ(last_msg_->obs[3].L.i, 119280830)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].L.i)),
+            119280830)
       << "incorrect value for obs[3].L.i, expected 119280830, is "
       << last_msg_->obs[3].L.i;
-  EXPECT_EQ(last_msg_->obs[3].P, 2269703860)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].P)),
+            2269703860)
       << "incorrect value for obs[3].P, expected 2269703860, is "
       << last_msg_->obs[3].P;
-  EXPECT_EQ(last_msg_->obs[3].cn0, 155)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].cn0)),
+            155)
       << "incorrect value for obs[3].cn0, expected 155, is "
       << last_msg_->obs[3].cn0;
-  EXPECT_EQ(last_msg_->obs[3].lock, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].lock)),
+            0)
       << "incorrect value for obs[3].lock, expected 0, is "
       << last_msg_->obs[3].lock;
-  EXPECT_EQ(last_msg_->obs[3].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].sid.code)),
+            0)
       << "incorrect value for obs[3].sid.code, expected 0, is "
       << last_msg_->obs[3].sid.code;
-  EXPECT_EQ(last_msg_->obs[3].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[3].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].sid.reserved)),
+      0)
       << "incorrect value for obs[3].sid.reserved, expected 0, is "
       << last_msg_->obs[3].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[3].sid.sat, 212)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].sid.sat)),
+            212)
       << "incorrect value for obs[3].sid.sat, expected 212, is "
       << last_msg_->obs[3].sid.sat;
-  EXPECT_EQ(last_msg_->obs[4].L.f, 153)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].L.f)),
+            153)
       << "incorrect value for obs[4].L.f, expected 153, is "
       << last_msg_->obs[4].L.f;
-  EXPECT_EQ(last_msg_->obs[4].L.i, 109691996)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].L.i)),
+            109691996)
       << "incorrect value for obs[4].L.i, expected 109691996, is "
       << last_msg_->obs[4].L.i;
-  EXPECT_EQ(last_msg_->obs[4].P, 2087295247)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].P)),
+            2087295247)
       << "incorrect value for obs[4].P, expected 2087295247, is "
       << last_msg_->obs[4].P;
-  EXPECT_EQ(last_msg_->obs[4].cn0, 168)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].cn0)),
+            168)
       << "incorrect value for obs[4].cn0, expected 168, is "
       << last_msg_->obs[4].cn0;
-  EXPECT_EQ(last_msg_->obs[4].lock, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].lock)),
+            0)
       << "incorrect value for obs[4].lock, expected 0, is "
       << last_msg_->obs[4].lock;
-  EXPECT_EQ(last_msg_->obs[4].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].sid.code)),
+            0)
       << "incorrect value for obs[4].sid.code, expected 0, is "
       << last_msg_->obs[4].sid.code;
-  EXPECT_EQ(last_msg_->obs[4].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[4].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].sid.reserved)),
+      0)
       << "incorrect value for obs[4].sid.reserved, expected 0, is "
       << last_msg_->obs[4].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[4].sid.sat, 217)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].sid.sat)),
+            217)
       << "incorrect value for obs[4].sid.sat, expected 217, is "
       << last_msg_->obs[4].sid.sat;
-  EXPECT_EQ(last_msg_->obs[5].L.f, 41)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].L.f)),
+            41)
       << "incorrect value for obs[5].L.f, expected 41, is "
       << last_msg_->obs[5].L.f;
-  EXPECT_EQ(last_msg_->obs[5].L.i, 123340176)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].L.i)),
+            123340176)
       << "incorrect value for obs[5].L.i, expected 123340176, is "
       << last_msg_->obs[5].L.i;
-  EXPECT_EQ(last_msg_->obs[5].P, 2347022641)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].P)),
+            2347022641)
       << "incorrect value for obs[5].P, expected 2347022641, is "
       << last_msg_->obs[5].P;
-  EXPECT_EQ(last_msg_->obs[5].cn0, 150)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].cn0)),
+            150)
       << "incorrect value for obs[5].cn0, expected 150, is "
       << last_msg_->obs[5].cn0;
-  EXPECT_EQ(last_msg_->obs[5].lock, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].lock)),
+            0)
       << "incorrect value for obs[5].lock, expected 0, is "
       << last_msg_->obs[5].lock;
-  EXPECT_EQ(last_msg_->obs[5].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].sid.code)),
+            0)
       << "incorrect value for obs[5].sid.code, expected 0, is "
       << last_msg_->obs[5].sid.code;
-  EXPECT_EQ(last_msg_->obs[5].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[5].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].sid.reserved)),
+      0)
       << "incorrect value for obs[5].sid.reserved, expected 0, is "
       << last_msg_->obs[5].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[5].sid.sat, 218)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].sid.sat)),
+            218)
       << "incorrect value for obs[5].sid.sat, expected 218, is "
       << last_msg_->obs[5].sid.sat;
 }
@@ -985,85 +1265,142 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgObsDepB3, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->header.n_obs, 33)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.n_obs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.n_obs)),
+            33)
       << "incorrect value for header.n_obs, expected 33, is "
       << last_msg_->header.n_obs;
-  EXPECT_EQ(last_msg_->header.t.tow, 2568000)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.tow)),
+            2568000)
       << "incorrect value for header.t.tow, expected 2568000, is "
       << last_msg_->header.t.tow;
-  EXPECT_EQ(last_msg_->header.t.wn, 1787)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.wn)),
+            1787)
       << "incorrect value for header.t.wn, expected 1787, is "
       << last_msg_->header.t.wn;
-  EXPECT_EQ(last_msg_->obs[0].L.f, 20)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.f)),
+            20)
       << "incorrect value for obs[0].L.f, expected 20, is "
       << last_msg_->obs[0].L.f;
-  EXPECT_EQ(last_msg_->obs[0].L.i, 120255759)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.i)),
+            120255759)
       << "incorrect value for obs[0].L.i, expected 120255759, is "
       << last_msg_->obs[0].L.i;
-  EXPECT_EQ(last_msg_->obs[0].P, 2288358634)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].P)),
+            2288358634)
       << "incorrect value for obs[0].P, expected 2288358634, is "
       << last_msg_->obs[0].P;
-  EXPECT_EQ(last_msg_->obs[0].cn0, 154)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].cn0)),
+            154)
       << "incorrect value for obs[0].cn0, expected 154, is "
       << last_msg_->obs[0].cn0;
-  EXPECT_EQ(last_msg_->obs[0].lock, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].lock)),
+            0)
       << "incorrect value for obs[0].lock, expected 0, is "
       << last_msg_->obs[0].lock;
-  EXPECT_EQ(last_msg_->obs[0].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.code)),
+            0)
       << "incorrect value for obs[0].sid.code, expected 0, is "
       << last_msg_->obs[0].sid.code;
-  EXPECT_EQ(last_msg_->obs[0].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[0].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.reserved)),
+      0)
       << "incorrect value for obs[0].sid.reserved, expected 0, is "
       << last_msg_->obs[0].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[0].sid.sat, 220)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.sat)),
+            220)
       << "incorrect value for obs[0].sid.sat, expected 220, is "
       << last_msg_->obs[0].sid.sat;
-  EXPECT_EQ(last_msg_->obs[1].L.f, 38)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].L.f)),
+            38)
       << "incorrect value for obs[1].L.f, expected 38, is "
       << last_msg_->obs[1].L.f;
-  EXPECT_EQ(last_msg_->obs[1].L.i, 117691920)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].L.i)),
+            117691920)
       << "incorrect value for obs[1].L.i, expected 117691920, is "
       << last_msg_->obs[1].L.i;
-  EXPECT_EQ(last_msg_->obs[1].P, 2239428560)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].P)),
+            2239428560)
       << "incorrect value for obs[1].P, expected 2239428560, is "
       << last_msg_->obs[1].P;
-  EXPECT_EQ(last_msg_->obs[1].cn0, 156)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].cn0)),
+            156)
       << "incorrect value for obs[1].cn0, expected 156, is "
       << last_msg_->obs[1].cn0;
-  EXPECT_EQ(last_msg_->obs[1].lock, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].lock)),
+            0)
       << "incorrect value for obs[1].lock, expected 0, is "
       << last_msg_->obs[1].lock;
-  EXPECT_EQ(last_msg_->obs[1].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.code)),
+            0)
       << "incorrect value for obs[1].sid.code, expected 0, is "
       << last_msg_->obs[1].sid.code;
-  EXPECT_EQ(last_msg_->obs[1].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[1].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.reserved)),
+      0)
       << "incorrect value for obs[1].sid.reserved, expected 0, is "
       << last_msg_->obs[1].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[1].sid.sat, 222)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.sat)),
+            222)
       << "incorrect value for obs[1].sid.sat, expected 222, is "
       << last_msg_->obs[1].sid.sat;
-  EXPECT_EQ(last_msg_->obs[2].L.f, 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].L.f)),
+            7)
       << "incorrect value for obs[2].L.f, expected 7, is "
       << last_msg_->obs[2].L.f;
-  EXPECT_EQ(last_msg_->obs[2].L.i, 107850774)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].L.i)),
+            107850774)
       << "incorrect value for obs[2].L.i, expected 107850774, is "
       << last_msg_->obs[2].L.i;
-  EXPECT_EQ(last_msg_->obs[2].P, 2052167183)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].P)),
+            2052167183)
       << "incorrect value for obs[2].P, expected 2052167183, is "
       << last_msg_->obs[2].P;
-  EXPECT_EQ(last_msg_->obs[2].cn0, 172)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].cn0)),
+            172)
       << "incorrect value for obs[2].cn0, expected 172, is "
       << last_msg_->obs[2].cn0;
-  EXPECT_EQ(last_msg_->obs[2].lock, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].lock)),
+            0)
       << "incorrect value for obs[2].lock, expected 0, is "
       << last_msg_->obs[2].lock;
-  EXPECT_EQ(last_msg_->obs[2].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.code)),
+            0)
       << "incorrect value for obs[2].sid.code, expected 0, is "
       << last_msg_->obs[2].sid.code;
-  EXPECT_EQ(last_msg_->obs[2].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[2].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.reserved)),
+      0)
       << "incorrect value for obs[2].sid.reserved, expected 0, is "
       << last_msg_->obs[2].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[2].sid.sat, 225)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.sat)),
+            225)
       << "incorrect value for obs[2].sid.sat, expected 225, is "
       << last_msg_->obs[2].sid.sat;
 }
@@ -1228,157 +1565,265 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgObsDepB4, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->header.n_obs, 32)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.n_obs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.n_obs)),
+            32)
       << "incorrect value for header.n_obs, expected 32, is "
       << last_msg_->header.n_obs;
-  EXPECT_EQ(last_msg_->header.t.tow, 2568200)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.tow)),
+            2568200)
       << "incorrect value for header.t.tow, expected 2568200, is "
       << last_msg_->header.t.tow;
-  EXPECT_EQ(last_msg_->header.t.wn, 1787)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.wn)),
+            1787)
       << "incorrect value for header.t.wn, expected 1787, is "
       << last_msg_->header.t.wn;
-  EXPECT_EQ(last_msg_->obs[0].L.f, 165)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.f)),
+            165)
       << "incorrect value for obs[0].L.f, expected 165, is "
       << last_msg_->obs[0].L.f;
-  EXPECT_EQ(last_msg_->obs[0].L.i, 117912057)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.i)),
+            117912057)
       << "incorrect value for obs[0].L.i, expected 117912057, is "
       << last_msg_->obs[0].L.i;
-  EXPECT_EQ(last_msg_->obs[0].P, 2243649790)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].P)),
+            2243649790)
       << "incorrect value for obs[0].P, expected 2243649790, is "
       << last_msg_->obs[0].P;
-  EXPECT_EQ(last_msg_->obs[0].cn0, 156)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].cn0)),
+            156)
       << "incorrect value for obs[0].cn0, expected 156, is "
       << last_msg_->obs[0].cn0;
-  EXPECT_EQ(last_msg_->obs[0].lock, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].lock)),
+            0)
       << "incorrect value for obs[0].lock, expected 0, is "
       << last_msg_->obs[0].lock;
-  EXPECT_EQ(last_msg_->obs[0].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.code)),
+            0)
       << "incorrect value for obs[0].sid.code, expected 0, is "
       << last_msg_->obs[0].sid.code;
-  EXPECT_EQ(last_msg_->obs[0].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[0].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.reserved)),
+      0)
       << "incorrect value for obs[0].sid.reserved, expected 0, is "
       << last_msg_->obs[0].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[0].sid.sat, 202)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.sat)),
+            202)
       << "incorrect value for obs[0].sid.sat, expected 202, is "
       << last_msg_->obs[0].sid.sat;
-  EXPECT_EQ(last_msg_->obs[1].L.f, 106)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].L.f)),
+            106)
       << "incorrect value for obs[1].L.f, expected 106, is "
       << last_msg_->obs[1].L.f;
-  EXPECT_EQ(last_msg_->obs[1].L.i, 129900811)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].L.i)),
+            129900811)
       << "incorrect value for obs[1].L.i, expected 129900811, is "
       << last_msg_->obs[1].L.i;
-  EXPECT_EQ(last_msg_->obs[1].P, 2471880049)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].P)),
+            2471880049)
       << "incorrect value for obs[1].P, expected 2471880049, is "
       << last_msg_->obs[1].P;
-  EXPECT_EQ(last_msg_->obs[1].cn0, 143)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].cn0)),
+            143)
       << "incorrect value for obs[1].cn0, expected 143, is "
       << last_msg_->obs[1].cn0;
-  EXPECT_EQ(last_msg_->obs[1].lock, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].lock)),
+            0)
       << "incorrect value for obs[1].lock, expected 0, is "
       << last_msg_->obs[1].lock;
-  EXPECT_EQ(last_msg_->obs[1].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.code)),
+            0)
       << "incorrect value for obs[1].sid.code, expected 0, is "
       << last_msg_->obs[1].sid.code;
-  EXPECT_EQ(last_msg_->obs[1].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[1].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.reserved)),
+      0)
       << "incorrect value for obs[1].sid.reserved, expected 0, is "
       << last_msg_->obs[1].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[1].sid.sat, 203)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.sat)),
+            203)
       << "incorrect value for obs[1].sid.sat, expected 203, is "
       << last_msg_->obs[1].sid.sat;
-  EXPECT_EQ(last_msg_->obs[2].L.f, 159)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].L.f)),
+            159)
       << "incorrect value for obs[2].L.f, expected 159, is "
       << last_msg_->obs[2].L.f;
-  EXPECT_EQ(last_msg_->obs[2].L.i, 122530275)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].L.i)),
+            122530275)
       << "incorrect value for obs[2].L.i, expected 122530275, is "
       << last_msg_->obs[2].L.i;
-  EXPECT_EQ(last_msg_->obs[2].P, 2331530678)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].P)),
+            2331530678)
       << "incorrect value for obs[2].P, expected 2331530678, is "
       << last_msg_->obs[2].P;
-  EXPECT_EQ(last_msg_->obs[2].cn0, 150)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].cn0)),
+            150)
       << "incorrect value for obs[2].cn0, expected 150, is "
       << last_msg_->obs[2].cn0;
-  EXPECT_EQ(last_msg_->obs[2].lock, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].lock)),
+            0)
       << "incorrect value for obs[2].lock, expected 0, is "
       << last_msg_->obs[2].lock;
-  EXPECT_EQ(last_msg_->obs[2].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.code)),
+            0)
       << "incorrect value for obs[2].sid.code, expected 0, is "
       << last_msg_->obs[2].sid.code;
-  EXPECT_EQ(last_msg_->obs[2].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[2].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.reserved)),
+      0)
       << "incorrect value for obs[2].sid.reserved, expected 0, is "
       << last_msg_->obs[2].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[2].sid.sat, 208)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.sat)),
+            208)
       << "incorrect value for obs[2].sid.sat, expected 208, is "
       << last_msg_->obs[2].sid.sat;
-  EXPECT_EQ(last_msg_->obs[3].L.f, 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].L.f)),
+            7)
       << "incorrect value for obs[3].L.f, expected 7, is "
       << last_msg_->obs[3].L.f;
-  EXPECT_EQ(last_msg_->obs[3].L.i, 119281418)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].L.i)),
+            119281418)
       << "incorrect value for obs[3].L.i, expected 119281418, is "
       << last_msg_->obs[3].L.i;
-  EXPECT_EQ(last_msg_->obs[3].P, 2269714449)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].P)),
+            2269714449)
       << "incorrect value for obs[3].P, expected 2269714449, is "
       << last_msg_->obs[3].P;
-  EXPECT_EQ(last_msg_->obs[3].cn0, 156)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].cn0)),
+            156)
       << "incorrect value for obs[3].cn0, expected 156, is "
       << last_msg_->obs[3].cn0;
-  EXPECT_EQ(last_msg_->obs[3].lock, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].lock)),
+            0)
       << "incorrect value for obs[3].lock, expected 0, is "
       << last_msg_->obs[3].lock;
-  EXPECT_EQ(last_msg_->obs[3].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].sid.code)),
+            0)
       << "incorrect value for obs[3].sid.code, expected 0, is "
       << last_msg_->obs[3].sid.code;
-  EXPECT_EQ(last_msg_->obs[3].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[3].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].sid.reserved)),
+      0)
       << "incorrect value for obs[3].sid.reserved, expected 0, is "
       << last_msg_->obs[3].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[3].sid.sat, 212)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].sid.sat)),
+            212)
       << "incorrect value for obs[3].sid.sat, expected 212, is "
       << last_msg_->obs[3].sid.sat;
-  EXPECT_EQ(last_msg_->obs[4].L.f, 186)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].L.f)),
+            186)
       << "incorrect value for obs[4].L.f, expected 186, is "
       << last_msg_->obs[4].L.f;
-  EXPECT_EQ(last_msg_->obs[4].L.i, 109692070)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].L.i)),
+            109692070)
       << "incorrect value for obs[4].L.i, expected 109692070, is "
       << last_msg_->obs[4].L.i;
-  EXPECT_EQ(last_msg_->obs[4].P, 2087295852)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].P)),
+            2087295852)
       << "incorrect value for obs[4].P, expected 2087295852, is "
       << last_msg_->obs[4].P;
-  EXPECT_EQ(last_msg_->obs[4].cn0, 170)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].cn0)),
+            170)
       << "incorrect value for obs[4].cn0, expected 170, is "
       << last_msg_->obs[4].cn0;
-  EXPECT_EQ(last_msg_->obs[4].lock, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].lock)),
+            0)
       << "incorrect value for obs[4].lock, expected 0, is "
       << last_msg_->obs[4].lock;
-  EXPECT_EQ(last_msg_->obs[4].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].sid.code)),
+            0)
       << "incorrect value for obs[4].sid.code, expected 0, is "
       << last_msg_->obs[4].sid.code;
-  EXPECT_EQ(last_msg_->obs[4].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[4].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].sid.reserved)),
+      0)
       << "incorrect value for obs[4].sid.reserved, expected 0, is "
       << last_msg_->obs[4].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[4].sid.sat, 217)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].sid.sat)),
+            217)
       << "incorrect value for obs[4].sid.sat, expected 217, is "
       << last_msg_->obs[4].sid.sat;
-  EXPECT_EQ(last_msg_->obs[5].L.f, 236)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].L.f)),
+            236)
       << "incorrect value for obs[5].L.f, expected 236, is "
       << last_msg_->obs[5].L.f;
-  EXPECT_EQ(last_msg_->obs[5].L.i, 123339597)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].L.i)),
+            123339597)
       << "incorrect value for obs[5].L.i, expected 123339597, is "
       << last_msg_->obs[5].L.i;
-  EXPECT_EQ(last_msg_->obs[5].P, 2347011798)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].P)),
+            2347011798)
       << "incorrect value for obs[5].P, expected 2347011798, is "
       << last_msg_->obs[5].P;
-  EXPECT_EQ(last_msg_->obs[5].cn0, 151)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].cn0)),
+            151)
       << "incorrect value for obs[5].cn0, expected 151, is "
       << last_msg_->obs[5].cn0;
-  EXPECT_EQ(last_msg_->obs[5].lock, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].lock)),
+            0)
       << "incorrect value for obs[5].lock, expected 0, is "
       << last_msg_->obs[5].lock;
-  EXPECT_EQ(last_msg_->obs[5].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].sid.code)),
+            0)
       << "incorrect value for obs[5].sid.code, expected 0, is "
       << last_msg_->obs[5].sid.code;
-  EXPECT_EQ(last_msg_->obs[5].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[5].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].sid.reserved)),
+      0)
       << "incorrect value for obs[5].sid.reserved, expected 0, is "
       << last_msg_->obs[5].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[5].sid.sat, 218)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].sid.sat)),
+            218)
       << "incorrect value for obs[5].sid.sat, expected 218, is "
       << last_msg_->obs[5].sid.sat;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgObsDepC.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgObsDepC.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgObsDepC0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -177,133 +184,224 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgObsDepC0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 38982);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->header.n_obs, 32)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.n_obs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.n_obs)),
+            32)
       << "incorrect value for header.n_obs, expected 32, is "
       << last_msg_->header.n_obs;
-  EXPECT_EQ(last_msg_->header.t.tow, 414670600)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.tow)),
+            414670600)
       << "incorrect value for header.t.tow, expected 414670600, is "
       << last_msg_->header.t.tow;
-  EXPECT_EQ(last_msg_->header.t.wn, 1898)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.wn)),
+            1898)
       << "incorrect value for header.t.wn, expected 1898, is "
       << last_msg_->header.t.wn;
-  EXPECT_EQ(last_msg_->obs[0].L.f, 231)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.f)),
+            231)
       << "incorrect value for obs[0].L.f, expected 231, is "
       << last_msg_->obs[0].L.f;
-  EXPECT_EQ(last_msg_->obs[0].L.i, -565647)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.i)),
+            -565647)
       << "incorrect value for obs[0].L.i, expected -565647, is "
       << last_msg_->obs[0].L.i;
-  EXPECT_EQ(last_msg_->obs[0].P, 1347025534)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].P)),
+            1347025534)
       << "incorrect value for obs[0].P, expected 1347025534, is "
       << last_msg_->obs[0].P;
-  EXPECT_EQ(last_msg_->obs[0].cn0, 163)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].cn0)),
+            163)
       << "incorrect value for obs[0].cn0, expected 163, is "
       << last_msg_->obs[0].cn0;
-  EXPECT_EQ(last_msg_->obs[0].lock, 58853)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].lock)),
+            58853)
       << "incorrect value for obs[0].lock, expected 58853, is "
       << last_msg_->obs[0].lock;
-  EXPECT_EQ(last_msg_->obs[0].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.code)),
+            0)
       << "incorrect value for obs[0].sid.code, expected 0, is "
       << last_msg_->obs[0].sid.code;
-  EXPECT_EQ(last_msg_->obs[0].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[0].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.reserved)),
+      0)
       << "incorrect value for obs[0].sid.reserved, expected 0, is "
       << last_msg_->obs[0].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[0].sid.sat, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.sat)),
+            4)
       << "incorrect value for obs[0].sid.sat, expected 4, is "
       << last_msg_->obs[0].sid.sat;
-  EXPECT_EQ(last_msg_->obs[1].L.f, 196)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].L.f)),
+            196)
       << "incorrect value for obs[1].L.f, expected 196, is "
       << last_msg_->obs[1].L.f;
-  EXPECT_EQ(last_msg_->obs[1].L.i, -355503)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].L.i)),
+            -355503)
       << "incorrect value for obs[1].L.i, expected -355503, is "
       << last_msg_->obs[1].L.i;
-  EXPECT_EQ(last_msg_->obs[1].P, 1180752956)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].P)),
+            1180752956)
       << "incorrect value for obs[1].P, expected 1180752956, is "
       << last_msg_->obs[1].P;
-  EXPECT_EQ(last_msg_->obs[1].cn0, 208)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].cn0)),
+            208)
       << "incorrect value for obs[1].cn0, expected 208, is "
       << last_msg_->obs[1].cn0;
-  EXPECT_EQ(last_msg_->obs[1].lock, 7188)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].lock)),
+            7188)
       << "incorrect value for obs[1].lock, expected 7188, is "
       << last_msg_->obs[1].lock;
-  EXPECT_EQ(last_msg_->obs[1].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.code)),
+            0)
       << "incorrect value for obs[1].sid.code, expected 0, is "
       << last_msg_->obs[1].sid.code;
-  EXPECT_EQ(last_msg_->obs[1].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[1].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.reserved)),
+      0)
       << "incorrect value for obs[1].sid.reserved, expected 0, is "
       << last_msg_->obs[1].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[1].sid.sat, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.sat)),
+            6)
       << "incorrect value for obs[1].sid.sat, expected 6, is "
       << last_msg_->obs[1].sid.sat;
-  EXPECT_EQ(last_msg_->obs[2].L.f, 110)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].L.f)),
+            110)
       << "incorrect value for obs[2].L.f, expected 110, is "
       << last_msg_->obs[2].L.f;
-  EXPECT_EQ(last_msg_->obs[2].L.i, -902116)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].L.i)),
+            -902116)
       << "incorrect value for obs[2].L.i, expected -902116, is "
       << last_msg_->obs[2].L.i;
-  EXPECT_EQ(last_msg_->obs[2].P, 1295924728)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].P)),
+            1295924728)
       << "incorrect value for obs[2].P, expected 1295924728, is "
       << last_msg_->obs[2].P;
-  EXPECT_EQ(last_msg_->obs[2].cn0, 171)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].cn0)),
+            171)
       << "incorrect value for obs[2].cn0, expected 171, is "
       << last_msg_->obs[2].cn0;
-  EXPECT_EQ(last_msg_->obs[2].lock, 45748)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].lock)),
+            45748)
       << "incorrect value for obs[2].lock, expected 45748, is "
       << last_msg_->obs[2].lock;
-  EXPECT_EQ(last_msg_->obs[2].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.code)),
+            0)
       << "incorrect value for obs[2].sid.code, expected 0, is "
       << last_msg_->obs[2].sid.code;
-  EXPECT_EQ(last_msg_->obs[2].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[2].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.reserved)),
+      0)
       << "incorrect value for obs[2].sid.reserved, expected 0, is "
       << last_msg_->obs[2].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[2].sid.sat, 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.sat)),
+            7)
       << "incorrect value for obs[2].sid.sat, expected 7, is "
       << last_msg_->obs[2].sid.sat;
-  EXPECT_EQ(last_msg_->obs[3].L.f, 41)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].L.f)),
+            41)
       << "incorrect value for obs[3].L.f, expected 41, is "
       << last_msg_->obs[3].L.f;
-  EXPECT_EQ(last_msg_->obs[3].L.i, 861612)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].L.i)),
+            861612)
       << "incorrect value for obs[3].L.i, expected 861612, is "
       << last_msg_->obs[3].L.i;
-  EXPECT_EQ(last_msg_->obs[3].P, 1304319213)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].P)),
+            1304319213)
       << "incorrect value for obs[3].P, expected 1304319213, is "
       << last_msg_->obs[3].P;
-  EXPECT_EQ(last_msg_->obs[3].cn0, 170)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].cn0)),
+            170)
       << "incorrect value for obs[3].cn0, expected 170, is "
       << last_msg_->obs[3].cn0;
-  EXPECT_EQ(last_msg_->obs[3].lock, 42217)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].lock)),
+            42217)
       << "incorrect value for obs[3].lock, expected 42217, is "
       << last_msg_->obs[3].lock;
-  EXPECT_EQ(last_msg_->obs[3].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].sid.code)),
+            0)
       << "incorrect value for obs[3].sid.code, expected 0, is "
       << last_msg_->obs[3].sid.code;
-  EXPECT_EQ(last_msg_->obs[3].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[3].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].sid.reserved)),
+      0)
       << "incorrect value for obs[3].sid.reserved, expected 0, is "
       << last_msg_->obs[3].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[3].sid.sat, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].sid.sat)),
+            10)
       << "incorrect value for obs[3].sid.sat, expected 10, is "
       << last_msg_->obs[3].sid.sat;
-  EXPECT_EQ(last_msg_->obs[4].L.f, 19)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].L.f)),
+            19)
       << "incorrect value for obs[4].L.f, expected 19, is "
       << last_msg_->obs[4].L.f;
-  EXPECT_EQ(last_msg_->obs[4].L.i, 1424624)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].L.i)),
+            1424624)
       << "incorrect value for obs[4].L.i, expected 1424624, is "
       << last_msg_->obs[4].L.i;
-  EXPECT_EQ(last_msg_->obs[4].P, 1258902820)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].P)),
+            1258902820)
       << "incorrect value for obs[4].P, expected 1258902820, is "
       << last_msg_->obs[4].P;
-  EXPECT_EQ(last_msg_->obs[4].cn0, 182)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].cn0)),
+            182)
       << "incorrect value for obs[4].cn0, expected 182, is "
       << last_msg_->obs[4].cn0;
-  EXPECT_EQ(last_msg_->obs[4].lock, 53700)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].lock)),
+            53700)
       << "incorrect value for obs[4].lock, expected 53700, is "
       << last_msg_->obs[4].lock;
-  EXPECT_EQ(last_msg_->obs[4].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].sid.code)),
+            0)
       << "incorrect value for obs[4].sid.code, expected 0, is "
       << last_msg_->obs[4].sid.code;
-  EXPECT_EQ(last_msg_->obs[4].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[4].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].sid.reserved)),
+      0)
       << "incorrect value for obs[4].sid.reserved, expected 0, is "
       << last_msg_->obs[4].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[4].sid.sat, 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].sid.sat)),
+            12)
       << "incorrect value for obs[4].sid.sat, expected 12, is "
       << last_msg_->obs[4].sid.sat;
 }
@@ -429,85 +527,142 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgObsDepC1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 38982);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->header.n_obs, 33)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.n_obs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.n_obs)),
+            33)
       << "incorrect value for header.n_obs, expected 33, is "
       << last_msg_->header.n_obs;
-  EXPECT_EQ(last_msg_->header.t.tow, 414670600)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.tow)),
+            414670600)
       << "incorrect value for header.t.tow, expected 414670600, is "
       << last_msg_->header.t.tow;
-  EXPECT_EQ(last_msg_->header.t.wn, 1898)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.wn)),
+            1898)
       << "incorrect value for header.t.wn, expected 1898, is "
       << last_msg_->header.t.wn;
-  EXPECT_EQ(last_msg_->obs[0].L.f, 101)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.f)),
+            101)
       << "incorrect value for obs[0].L.f, expected 101, is "
       << last_msg_->obs[0].L.f;
-  EXPECT_EQ(last_msg_->obs[0].L.i, 1631930)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.i)),
+            1631930)
       << "incorrect value for obs[0].L.i, expected 1631930, is "
       << last_msg_->obs[0].L.i;
-  EXPECT_EQ(last_msg_->obs[0].P, 1296803396)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].P)),
+            1296803396)
       << "incorrect value for obs[0].P, expected 1296803396, is "
       << last_msg_->obs[0].P;
-  EXPECT_EQ(last_msg_->obs[0].cn0, 186)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].cn0)),
+            186)
       << "incorrect value for obs[0].cn0, expected 186, is "
       << last_msg_->obs[0].cn0;
-  EXPECT_EQ(last_msg_->obs[0].lock, 26274)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].lock)),
+            26274)
       << "incorrect value for obs[0].lock, expected 26274, is "
       << last_msg_->obs[0].lock;
-  EXPECT_EQ(last_msg_->obs[0].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.code)),
+            0)
       << "incorrect value for obs[0].sid.code, expected 0, is "
       << last_msg_->obs[0].sid.code;
-  EXPECT_EQ(last_msg_->obs[0].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[0].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.reserved)),
+      0)
       << "incorrect value for obs[0].sid.reserved, expected 0, is "
       << last_msg_->obs[0].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[0].sid.sat, 16)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.sat)),
+            16)
       << "incorrect value for obs[0].sid.sat, expected 16, is "
       << last_msg_->obs[0].sid.sat;
-  EXPECT_EQ(last_msg_->obs[1].L.f, 26)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].L.f)),
+            26)
       << "incorrect value for obs[1].L.f, expected 26, is "
       << last_msg_->obs[1].L.f;
-  EXPECT_EQ(last_msg_->obs[1].L.i, 368202)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].L.i)),
+            368202)
       << "incorrect value for obs[1].L.i, expected 368202, is "
       << last_msg_->obs[1].L.i;
-  EXPECT_EQ(last_msg_->obs[1].P, 1167851351)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].P)),
+            1167851351)
       << "incorrect value for obs[1].P, expected 1167851351, is "
       << last_msg_->obs[1].P;
-  EXPECT_EQ(last_msg_->obs[1].cn0, 190)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].cn0)),
+            190)
       << "incorrect value for obs[1].cn0, expected 190, is "
       << last_msg_->obs[1].cn0;
-  EXPECT_EQ(last_msg_->obs[1].lock, 7886)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].lock)),
+            7886)
       << "incorrect value for obs[1].lock, expected 7886, is "
       << last_msg_->obs[1].lock;
-  EXPECT_EQ(last_msg_->obs[1].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.code)),
+            0)
       << "incorrect value for obs[1].sid.code, expected 0, is "
       << last_msg_->obs[1].sid.code;
-  EXPECT_EQ(last_msg_->obs[1].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[1].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.reserved)),
+      0)
       << "incorrect value for obs[1].sid.reserved, expected 0, is "
       << last_msg_->obs[1].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[1].sid.sat, 27)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.sat)),
+            27)
       << "incorrect value for obs[1].sid.sat, expected 27, is "
       << last_msg_->obs[1].sid.sat;
-  EXPECT_EQ(last_msg_->obs[2].L.f, 114)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].L.f)),
+            114)
       << "incorrect value for obs[2].L.f, expected 114, is "
       << last_msg_->obs[2].L.f;
-  EXPECT_EQ(last_msg_->obs[2].L.i, 202266)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].L.i)),
+            202266)
       << "incorrect value for obs[2].L.i, expected 202266, is "
       << last_msg_->obs[2].L.i;
-  EXPECT_EQ(last_msg_->obs[2].P, 1149000000)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].P)),
+            1149000000)
       << "incorrect value for obs[2].P, expected 1149000000, is "
       << last_msg_->obs[2].P;
-  EXPECT_EQ(last_msg_->obs[2].cn0, 217)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].cn0)),
+            217)
       << "incorrect value for obs[2].cn0, expected 217, is "
       << last_msg_->obs[2].cn0;
-  EXPECT_EQ(last_msg_->obs[2].lock, 18913)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].lock)),
+            18913)
       << "incorrect value for obs[2].lock, expected 18913, is "
       << last_msg_->obs[2].lock;
-  EXPECT_EQ(last_msg_->obs[2].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.code)),
+            0)
       << "incorrect value for obs[2].sid.code, expected 0, is "
       << last_msg_->obs[2].sid.code;
-  EXPECT_EQ(last_msg_->obs[2].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[2].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.reserved)),
+      0)
       << "incorrect value for obs[2].sid.reserved, expected 0, is "
       << last_msg_->obs[2].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[2].sid.sat, 29)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.sat)),
+            29)
       << "incorrect value for obs[2].sid.sat, expected 29, is "
       << last_msg_->obs[2].sid.sat;
 }
@@ -659,133 +814,224 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgObsDepC2, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 0);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->header.n_obs, 32)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.n_obs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.n_obs)),
+            32)
       << "incorrect value for header.n_obs, expected 32, is "
       << last_msg_->header.n_obs;
-  EXPECT_EQ(last_msg_->header.t.tow, 414670600)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.tow)),
+            414670600)
       << "incorrect value for header.t.tow, expected 414670600, is "
       << last_msg_->header.t.tow;
-  EXPECT_EQ(last_msg_->header.t.wn, 1898)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.wn)),
+            1898)
       << "incorrect value for header.t.wn, expected 1898, is "
       << last_msg_->header.t.wn;
-  EXPECT_EQ(last_msg_->obs[0].L.f, 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.f)),
+            30)
       << "incorrect value for obs[0].L.f, expected 30, is "
       << last_msg_->obs[0].L.f;
-  EXPECT_EQ(last_msg_->obs[0].L.i, -505847)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.i)),
+            -505847)
       << "incorrect value for obs[0].L.i, expected -505847, is "
       << last_msg_->obs[0].L.i;
-  EXPECT_EQ(last_msg_->obs[0].P, 1347025881)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].P)),
+            1347025881)
       << "incorrect value for obs[0].P, expected 1347025881, is "
       << last_msg_->obs[0].P;
-  EXPECT_EQ(last_msg_->obs[0].cn0, 168)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].cn0)),
+            168)
       << "incorrect value for obs[0].cn0, expected 168, is "
       << last_msg_->obs[0].cn0;
-  EXPECT_EQ(last_msg_->obs[0].lock, 20849)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].lock)),
+            20849)
       << "incorrect value for obs[0].lock, expected 20849, is "
       << last_msg_->obs[0].lock;
-  EXPECT_EQ(last_msg_->obs[0].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.code)),
+            0)
       << "incorrect value for obs[0].sid.code, expected 0, is "
       << last_msg_->obs[0].sid.code;
-  EXPECT_EQ(last_msg_->obs[0].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[0].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.reserved)),
+      0)
       << "incorrect value for obs[0].sid.reserved, expected 0, is "
       << last_msg_->obs[0].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[0].sid.sat, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.sat)),
+            4)
       << "incorrect value for obs[0].sid.sat, expected 4, is "
       << last_msg_->obs[0].sid.sat;
-  EXPECT_EQ(last_msg_->obs[1].L.f, 115)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].L.f)),
+            115)
       << "incorrect value for obs[1].L.f, expected 115, is "
       << last_msg_->obs[1].L.f;
-  EXPECT_EQ(last_msg_->obs[1].L.i, -300090)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].L.i)),
+            -300090)
       << "incorrect value for obs[1].L.i, expected -300090, is "
       << last_msg_->obs[1].L.i;
-  EXPECT_EQ(last_msg_->obs[1].P, 1180753107)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].P)),
+            1180753107)
       << "incorrect value for obs[1].P, expected 1180753107, is "
       << last_msg_->obs[1].P;
-  EXPECT_EQ(last_msg_->obs[1].cn0, 195)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].cn0)),
+            195)
       << "incorrect value for obs[1].cn0, expected 195, is "
       << last_msg_->obs[1].cn0;
-  EXPECT_EQ(last_msg_->obs[1].lock, 36917)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].lock)),
+            36917)
       << "incorrect value for obs[1].lock, expected 36917, is "
       << last_msg_->obs[1].lock;
-  EXPECT_EQ(last_msg_->obs[1].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.code)),
+            0)
       << "incorrect value for obs[1].sid.code, expected 0, is "
       << last_msg_->obs[1].sid.code;
-  EXPECT_EQ(last_msg_->obs[1].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[1].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.reserved)),
+      0)
       << "incorrect value for obs[1].sid.reserved, expected 0, is "
       << last_msg_->obs[1].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[1].sid.sat, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.sat)),
+            6)
       << "incorrect value for obs[1].sid.sat, expected 6, is "
       << last_msg_->obs[1].sid.sat;
-  EXPECT_EQ(last_msg_->obs[2].L.f, 130)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].L.f)),
+            130)
       << "incorrect value for obs[2].L.f, expected 130, is "
       << last_msg_->obs[2].L.f;
-  EXPECT_EQ(last_msg_->obs[2].L.i, -810712)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].L.i)),
+            -810712)
       << "incorrect value for obs[2].L.i, expected -810712, is "
       << last_msg_->obs[2].L.i;
-  EXPECT_EQ(last_msg_->obs[2].P, 1295924557)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].P)),
+            1295924557)
       << "incorrect value for obs[2].P, expected 1295924557, is "
       << last_msg_->obs[2].P;
-  EXPECT_EQ(last_msg_->obs[2].cn0, 176)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].cn0)),
+            176)
       << "incorrect value for obs[2].cn0, expected 176, is "
       << last_msg_->obs[2].cn0;
-  EXPECT_EQ(last_msg_->obs[2].lock, 36445)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].lock)),
+            36445)
       << "incorrect value for obs[2].lock, expected 36445, is "
       << last_msg_->obs[2].lock;
-  EXPECT_EQ(last_msg_->obs[2].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.code)),
+            0)
       << "incorrect value for obs[2].sid.code, expected 0, is "
       << last_msg_->obs[2].sid.code;
-  EXPECT_EQ(last_msg_->obs[2].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[2].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.reserved)),
+      0)
       << "incorrect value for obs[2].sid.reserved, expected 0, is "
       << last_msg_->obs[2].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[2].sid.sat, 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.sat)),
+            7)
       << "incorrect value for obs[2].sid.sat, expected 7, is "
       << last_msg_->obs[2].sid.sat;
-  EXPECT_EQ(last_msg_->obs[3].L.f, 116)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].L.f)),
+            116)
       << "incorrect value for obs[3].L.f, expected 116, is "
       << last_msg_->obs[3].L.f;
-  EXPECT_EQ(last_msg_->obs[3].L.i, 806232)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].L.i)),
+            806232)
       << "incorrect value for obs[3].L.i, expected 806232, is "
       << last_msg_->obs[3].L.i;
-  EXPECT_EQ(last_msg_->obs[3].P, 1304319489)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].P)),
+            1304319489)
       << "incorrect value for obs[3].P, expected 1304319489, is "
       << last_msg_->obs[3].P;
-  EXPECT_EQ(last_msg_->obs[3].cn0, 199)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].cn0)),
+            199)
       << "incorrect value for obs[3].cn0, expected 199, is "
       << last_msg_->obs[3].cn0;
-  EXPECT_EQ(last_msg_->obs[3].lock, 54757)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].lock)),
+            54757)
       << "incorrect value for obs[3].lock, expected 54757, is "
       << last_msg_->obs[3].lock;
-  EXPECT_EQ(last_msg_->obs[3].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].sid.code)),
+            0)
       << "incorrect value for obs[3].sid.code, expected 0, is "
       << last_msg_->obs[3].sid.code;
-  EXPECT_EQ(last_msg_->obs[3].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[3].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].sid.reserved)),
+      0)
       << "incorrect value for obs[3].sid.reserved, expected 0, is "
       << last_msg_->obs[3].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[3].sid.sat, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].sid.sat)),
+            10)
       << "incorrect value for obs[3].sid.sat, expected 10, is "
       << last_msg_->obs[3].sid.sat;
-  EXPECT_EQ(last_msg_->obs[4].L.f, 120)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].L.f)),
+            120)
       << "incorrect value for obs[4].L.f, expected 120, is "
       << last_msg_->obs[4].L.f;
-  EXPECT_EQ(last_msg_->obs[4].L.i, 1346368)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].L.i)),
+            1346368)
       << "incorrect value for obs[4].L.i, expected 1346368, is "
       << last_msg_->obs[4].L.i;
-  EXPECT_EQ(last_msg_->obs[4].P, 1258902877)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].P)),
+            1258902877)
       << "incorrect value for obs[4].P, expected 1258902877, is "
       << last_msg_->obs[4].P;
-  EXPECT_EQ(last_msg_->obs[4].cn0, 177)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].cn0)),
+            177)
       << "incorrect value for obs[4].cn0, expected 177, is "
       << last_msg_->obs[4].cn0;
-  EXPECT_EQ(last_msg_->obs[4].lock, 49860)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].lock)),
+            49860)
       << "incorrect value for obs[4].lock, expected 49860, is "
       << last_msg_->obs[4].lock;
-  EXPECT_EQ(last_msg_->obs[4].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].sid.code)),
+            0)
       << "incorrect value for obs[4].sid.code, expected 0, is "
       << last_msg_->obs[4].sid.code;
-  EXPECT_EQ(last_msg_->obs[4].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[4].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].sid.reserved)),
+      0)
       << "incorrect value for obs[4].sid.reserved, expected 0, is "
       << last_msg_->obs[4].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[4].sid.sat, 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].sid.sat)),
+            12)
       << "incorrect value for obs[4].sid.sat, expected 12, is "
       << last_msg_->obs[4].sid.sat;
 }
@@ -911,85 +1157,142 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgObsDepC3, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 0);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->header.n_obs, 33)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.n_obs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.n_obs)),
+            33)
       << "incorrect value for header.n_obs, expected 33, is "
       << last_msg_->header.n_obs;
-  EXPECT_EQ(last_msg_->header.t.tow, 414670600)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.tow)),
+            414670600)
       << "incorrect value for header.t.tow, expected 414670600, is "
       << last_msg_->header.t.tow;
-  EXPECT_EQ(last_msg_->header.t.wn, 1898)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.wn)),
+            1898)
       << "incorrect value for header.t.wn, expected 1898, is "
       << last_msg_->header.t.wn;
-  EXPECT_EQ(last_msg_->obs[0].L.f, 90)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.f)),
+            90)
       << "incorrect value for obs[0].L.f, expected 90, is "
       << last_msg_->obs[0].L.f;
-  EXPECT_EQ(last_msg_->obs[0].L.i, 1542284)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.i)),
+            1542284)
       << "incorrect value for obs[0].L.i, expected 1542284, is "
       << last_msg_->obs[0].L.i;
-  EXPECT_EQ(last_msg_->obs[0].P, 1296803654)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].P)),
+            1296803654)
       << "incorrect value for obs[0].P, expected 1296803654, is "
       << last_msg_->obs[0].P;
-  EXPECT_EQ(last_msg_->obs[0].cn0, 187)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].cn0)),
+            187)
       << "incorrect value for obs[0].cn0, expected 187, is "
       << last_msg_->obs[0].cn0;
-  EXPECT_EQ(last_msg_->obs[0].lock, 33182)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].lock)),
+            33182)
       << "incorrect value for obs[0].lock, expected 33182, is "
       << last_msg_->obs[0].lock;
-  EXPECT_EQ(last_msg_->obs[0].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.code)),
+            0)
       << "incorrect value for obs[0].sid.code, expected 0, is "
       << last_msg_->obs[0].sid.code;
-  EXPECT_EQ(last_msg_->obs[0].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[0].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.reserved)),
+      0)
       << "incorrect value for obs[0].sid.reserved, expected 0, is "
       << last_msg_->obs[0].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[0].sid.sat, 16)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.sat)),
+            16)
       << "incorrect value for obs[0].sid.sat, expected 16, is "
       << last_msg_->obs[0].sid.sat;
-  EXPECT_EQ(last_msg_->obs[1].L.f, 17)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].L.f)),
+            17)
       << "incorrect value for obs[1].L.f, expected 17, is "
       << last_msg_->obs[1].L.f;
-  EXPECT_EQ(last_msg_->obs[1].L.i, 372525)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].L.i)),
+            372525)
       << "incorrect value for obs[1].L.i, expected 372525, is "
       << last_msg_->obs[1].L.i;
-  EXPECT_EQ(last_msg_->obs[1].P, 1167851496)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].P)),
+            1167851496)
       << "incorrect value for obs[1].P, expected 1167851496, is "
       << last_msg_->obs[1].P;
-  EXPECT_EQ(last_msg_->obs[1].cn0, 208)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].cn0)),
+            208)
       << "incorrect value for obs[1].cn0, expected 208, is "
       << last_msg_->obs[1].cn0;
-  EXPECT_EQ(last_msg_->obs[1].lock, 14511)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].lock)),
+            14511)
       << "incorrect value for obs[1].lock, expected 14511, is "
       << last_msg_->obs[1].lock;
-  EXPECT_EQ(last_msg_->obs[1].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.code)),
+            0)
       << "incorrect value for obs[1].sid.code, expected 0, is "
       << last_msg_->obs[1].sid.code;
-  EXPECT_EQ(last_msg_->obs[1].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[1].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.reserved)),
+      0)
       << "incorrect value for obs[1].sid.reserved, expected 0, is "
       << last_msg_->obs[1].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[1].sid.sat, 27)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.sat)),
+            27)
       << "incorrect value for obs[1].sid.sat, expected 27, is "
       << last_msg_->obs[1].sid.sat;
-  EXPECT_EQ(last_msg_->obs[2].L.f, 75)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].L.f)),
+            75)
       << "incorrect value for obs[2].L.f, expected 75, is "
       << last_msg_->obs[2].L.f;
-  EXPECT_EQ(last_msg_->obs[2].L.i, 221229)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].L.i)),
+            221229)
       << "incorrect value for obs[2].L.i, expected 221229, is "
       << last_msg_->obs[2].L.i;
-  EXPECT_EQ(last_msg_->obs[2].P, 1149000000)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].P)),
+            1149000000)
       << "incorrect value for obs[2].P, expected 1149000000, is "
       << last_msg_->obs[2].P;
-  EXPECT_EQ(last_msg_->obs[2].cn0, 185)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].cn0)),
+            185)
       << "incorrect value for obs[2].cn0, expected 185, is "
       << last_msg_->obs[2].cn0;
-  EXPECT_EQ(last_msg_->obs[2].lock, 52809)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].lock)),
+            52809)
       << "incorrect value for obs[2].lock, expected 52809, is "
       << last_msg_->obs[2].lock;
-  EXPECT_EQ(last_msg_->obs[2].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.code)),
+            0)
       << "incorrect value for obs[2].sid.code, expected 0, is "
       << last_msg_->obs[2].sid.code;
-  EXPECT_EQ(last_msg_->obs[2].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[2].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.reserved)),
+      0)
       << "incorrect value for obs[2].sid.reserved, expected 0, is "
       << last_msg_->obs[2].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[2].sid.sat, 29)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.sat)),
+            29)
       << "incorrect value for obs[2].sid.sat, expected 29, is "
       << last_msg_->obs[2].sid.sat;
 }
@@ -1141,133 +1444,224 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgObsDepC4, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 38982);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->header.n_obs, 32)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.n_obs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.n_obs)),
+            32)
       << "incorrect value for header.n_obs, expected 32, is "
       << last_msg_->header.n_obs;
-  EXPECT_EQ(last_msg_->header.t.tow, 414670800)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.tow)),
+            414670800)
       << "incorrect value for header.t.tow, expected 414670800, is "
       << last_msg_->header.t.tow;
-  EXPECT_EQ(last_msg_->header.t.wn, 1898)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.wn)),
+            1898)
       << "incorrect value for header.t.wn, expected 1898, is "
       << last_msg_->header.t.wn;
-  EXPECT_EQ(last_msg_->obs[0].L.f, 57)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.f)),
+            57)
       << "incorrect value for obs[0].L.f, expected 57, is "
       << last_msg_->obs[0].L.f;
-  EXPECT_EQ(last_msg_->obs[0].L.i, -565930)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.i)),
+            -565930)
       << "incorrect value for obs[0].L.i, expected -565930, is "
       << last_msg_->obs[0].L.i;
-  EXPECT_EQ(last_msg_->obs[0].P, 1347029036)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].P)),
+            1347029036)
       << "incorrect value for obs[0].P, expected 1347029036, is "
       << last_msg_->obs[0].P;
-  EXPECT_EQ(last_msg_->obs[0].cn0, 158)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].cn0)),
+            158)
       << "incorrect value for obs[0].cn0, expected 158, is "
       << last_msg_->obs[0].cn0;
-  EXPECT_EQ(last_msg_->obs[0].lock, 58853)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].lock)),
+            58853)
       << "incorrect value for obs[0].lock, expected 58853, is "
       << last_msg_->obs[0].lock;
-  EXPECT_EQ(last_msg_->obs[0].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.code)),
+            0)
       << "incorrect value for obs[0].sid.code, expected 0, is "
       << last_msg_->obs[0].sid.code;
-  EXPECT_EQ(last_msg_->obs[0].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[0].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.reserved)),
+      0)
       << "incorrect value for obs[0].sid.reserved, expected 0, is "
       << last_msg_->obs[0].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[0].sid.sat, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.sat)),
+            4)
       << "incorrect value for obs[0].sid.sat, expected 4, is "
       << last_msg_->obs[0].sid.sat;
-  EXPECT_EQ(last_msg_->obs[1].L.f, 221)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].L.f)),
+            221)
       << "incorrect value for obs[1].L.f, expected 221, is "
       << last_msg_->obs[1].L.f;
-  EXPECT_EQ(last_msg_->obs[1].L.i, -355684)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].L.i)),
+            -355684)
       << "incorrect value for obs[1].L.i, expected -355684, is "
       << last_msg_->obs[1].L.i;
-  EXPECT_EQ(last_msg_->obs[1].P, 1180755424)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].P)),
+            1180755424)
       << "incorrect value for obs[1].P, expected 1180755424, is "
       << last_msg_->obs[1].P;
-  EXPECT_EQ(last_msg_->obs[1].cn0, 200)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].cn0)),
+            200)
       << "incorrect value for obs[1].cn0, expected 200, is "
       << last_msg_->obs[1].cn0;
-  EXPECT_EQ(last_msg_->obs[1].lock, 7188)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].lock)),
+            7188)
       << "incorrect value for obs[1].lock, expected 7188, is "
       << last_msg_->obs[1].lock;
-  EXPECT_EQ(last_msg_->obs[1].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.code)),
+            0)
       << "incorrect value for obs[1].sid.code, expected 0, is "
       << last_msg_->obs[1].sid.code;
-  EXPECT_EQ(last_msg_->obs[1].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[1].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.reserved)),
+      0)
       << "incorrect value for obs[1].sid.reserved, expected 0, is "
       << last_msg_->obs[1].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[1].sid.sat, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.sat)),
+            6)
       << "incorrect value for obs[1].sid.sat, expected 6, is "
       << last_msg_->obs[1].sid.sat;
-  EXPECT_EQ(last_msg_->obs[2].L.f, 39)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].L.f)),
+            39)
       << "incorrect value for obs[2].L.f, expected 39, is "
       << last_msg_->obs[2].L.f;
-  EXPECT_EQ(last_msg_->obs[2].L.i, -902563)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].L.i)),
+            -902563)
       << "incorrect value for obs[2].L.i, expected -902563, is "
       << last_msg_->obs[2].L.i;
-  EXPECT_EQ(last_msg_->obs[2].P, 1295929916)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].P)),
+            1295929916)
       << "incorrect value for obs[2].P, expected 1295929916, is "
       << last_msg_->obs[2].P;
-  EXPECT_EQ(last_msg_->obs[2].cn0, 164)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].cn0)),
+            164)
       << "incorrect value for obs[2].cn0, expected 164, is "
       << last_msg_->obs[2].cn0;
-  EXPECT_EQ(last_msg_->obs[2].lock, 45748)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].lock)),
+            45748)
       << "incorrect value for obs[2].lock, expected 45748, is "
       << last_msg_->obs[2].lock;
-  EXPECT_EQ(last_msg_->obs[2].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.code)),
+            0)
       << "incorrect value for obs[2].sid.code, expected 0, is "
       << last_msg_->obs[2].sid.code;
-  EXPECT_EQ(last_msg_->obs[2].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[2].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.reserved)),
+      0)
       << "incorrect value for obs[2].sid.reserved, expected 0, is "
       << last_msg_->obs[2].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[2].sid.sat, 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.sat)),
+            7)
       << "incorrect value for obs[2].sid.sat, expected 7, is "
       << last_msg_->obs[2].sid.sat;
-  EXPECT_EQ(last_msg_->obs[3].L.f, 202)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].L.f)),
+            202)
       << "incorrect value for obs[3].L.f, expected 202, is "
       << last_msg_->obs[3].L.f;
-  EXPECT_EQ(last_msg_->obs[3].L.i, 861998)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].L.i)),
+            861998)
       << "incorrect value for obs[3].L.i, expected 861998, is "
       << last_msg_->obs[3].L.i;
-  EXPECT_EQ(last_msg_->obs[3].P, 1304316382)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].P)),
+            1304316382)
       << "incorrect value for obs[3].P, expected 1304316382, is "
       << last_msg_->obs[3].P;
-  EXPECT_EQ(last_msg_->obs[3].cn0, 181)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].cn0)),
+            181)
       << "incorrect value for obs[3].cn0, expected 181, is "
       << last_msg_->obs[3].cn0;
-  EXPECT_EQ(last_msg_->obs[3].lock, 42217)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].lock)),
+            42217)
       << "incorrect value for obs[3].lock, expected 42217, is "
       << last_msg_->obs[3].lock;
-  EXPECT_EQ(last_msg_->obs[3].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].sid.code)),
+            0)
       << "incorrect value for obs[3].sid.code, expected 0, is "
       << last_msg_->obs[3].sid.code;
-  EXPECT_EQ(last_msg_->obs[3].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[3].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].sid.reserved)),
+      0)
       << "incorrect value for obs[3].sid.reserved, expected 0, is "
       << last_msg_->obs[3].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[3].sid.sat, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].sid.sat)),
+            10)
       << "incorrect value for obs[3].sid.sat, expected 10, is "
       << last_msg_->obs[3].sid.sat;
-  EXPECT_EQ(last_msg_->obs[4].L.f, 249)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].L.f)),
+            249)
       << "incorrect value for obs[4].L.f, expected 249, is "
       << last_msg_->obs[4].L.f;
-  EXPECT_EQ(last_msg_->obs[4].L.i, 1425266)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].L.i)),
+            1425266)
       << "incorrect value for obs[4].L.i, expected 1425266, is "
       << last_msg_->obs[4].L.i;
-  EXPECT_EQ(last_msg_->obs[4].P, 1258897557)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].P)),
+            1258897557)
       << "incorrect value for obs[4].P, expected 1258897557, is "
       << last_msg_->obs[4].P;
-  EXPECT_EQ(last_msg_->obs[4].cn0, 182)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].cn0)),
+            182)
       << "incorrect value for obs[4].cn0, expected 182, is "
       << last_msg_->obs[4].cn0;
-  EXPECT_EQ(last_msg_->obs[4].lock, 53700)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].lock)),
+            53700)
       << "incorrect value for obs[4].lock, expected 53700, is "
       << last_msg_->obs[4].lock;
-  EXPECT_EQ(last_msg_->obs[4].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].sid.code)),
+            0)
       << "incorrect value for obs[4].sid.code, expected 0, is "
       << last_msg_->obs[4].sid.code;
-  EXPECT_EQ(last_msg_->obs[4].sid.reserved, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[4].sid.reserved)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].sid.reserved)),
+      0)
       << "incorrect value for obs[4].sid.reserved, expected 0, is "
       << last_msg_->obs[4].sid.reserved;
-  EXPECT_EQ(last_msg_->obs[4].sid.sat, 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].sid.sat)),
+            12)
       << "incorrect value for obs[4].sid.sat, expected 12, is "
       << last_msg_->obs[4].sid.sat;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgOsr.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgOsr.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgOsr0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -297,376 +304,653 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgOsr0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 0);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->header.n_obs, 64)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.n_obs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.n_obs)),
+            64)
       << "incorrect value for header.n_obs, expected 64, is "
       << last_msg_->header.n_obs;
-  EXPECT_EQ(last_msg_->header.t.ns_residual, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->header.t.ns_residual)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->header.t.ns_residual)),
+      0)
       << "incorrect value for header.t.ns_residual, expected 0, is "
       << last_msg_->header.t.ns_residual;
-  EXPECT_EQ(last_msg_->header.t.tow, 501867000)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.tow)),
+            501867000)
       << "incorrect value for header.t.tow, expected 501867000, is "
       << last_msg_->header.t.tow;
-  EXPECT_EQ(last_msg_->header.t.wn, 2152)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.wn)),
+            2152)
       << "incorrect value for header.t.wn, expected 2152, is "
       << last_msg_->header.t.wn;
-  EXPECT_EQ(last_msg_->obs[0].L.f, 66)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.f)),
+            66)
       << "incorrect value for obs[0].L.f, expected 66, is "
       << last_msg_->obs[0].L.f;
-  EXPECT_EQ(last_msg_->obs[0].L.i, 121567974)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.i)),
+            121567974)
       << "incorrect value for obs[0].L.i, expected 121567974, is "
       << last_msg_->obs[0].L.i;
-  EXPECT_EQ(last_msg_->obs[0].P, 1156681547)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].P)),
+            1156681547)
       << "incorrect value for obs[0].P, expected 1156681547, is "
       << last_msg_->obs[0].P;
-  EXPECT_EQ(last_msg_->obs[0].flags, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].flags)),
+            3)
       << "incorrect value for obs[0].flags, expected 3, is "
       << last_msg_->obs[0].flags;
-  EXPECT_EQ(last_msg_->obs[0].iono_std, 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].iono_std)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].iono_std)),
+            13)
       << "incorrect value for obs[0].iono_std, expected 13, is "
       << last_msg_->obs[0].iono_std;
-  EXPECT_EQ(last_msg_->obs[0].lock, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].lock)),
+            15)
       << "incorrect value for obs[0].lock, expected 15, is "
       << last_msg_->obs[0].lock;
-  EXPECT_EQ(last_msg_->obs[0].range_std, 7)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[0].range_std)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].range_std)),
+      7)
       << "incorrect value for obs[0].range_std, expected 7, is "
       << last_msg_->obs[0].range_std;
-  EXPECT_EQ(last_msg_->obs[0].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.code)),
+            0)
       << "incorrect value for obs[0].sid.code, expected 0, is "
       << last_msg_->obs[0].sid.code;
-  EXPECT_EQ(last_msg_->obs[0].sid.sat, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].sid.sat)),
+            1)
       << "incorrect value for obs[0].sid.sat, expected 1, is "
       << last_msg_->obs[0].sid.sat;
-  EXPECT_EQ(last_msg_->obs[0].tropo_std, 7)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[0].tropo_std)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].tropo_std)),
+      7)
       << "incorrect value for obs[0].tropo_std, expected 7, is "
       << last_msg_->obs[0].tropo_std;
-  EXPECT_EQ(last_msg_->obs[1].L.f, 75)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].L.f)),
+            75)
       << "incorrect value for obs[1].L.f, expected 75, is "
       << last_msg_->obs[1].L.f;
-  EXPECT_EQ(last_msg_->obs[1].L.i, 111817196)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].L.i)),
+            111817196)
       << "incorrect value for obs[1].L.i, expected 111817196, is "
       << last_msg_->obs[1].L.i;
-  EXPECT_EQ(last_msg_->obs[1].P, 1063905486)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].P)),
+            1063905486)
       << "incorrect value for obs[1].P, expected 1063905486, is "
       << last_msg_->obs[1].P;
-  EXPECT_EQ(last_msg_->obs[1].flags, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].flags)),
+            3)
       << "incorrect value for obs[1].flags, expected 3, is "
       << last_msg_->obs[1].flags;
-  EXPECT_EQ(last_msg_->obs[1].iono_std, 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].iono_std)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].iono_std)),
+            13)
       << "incorrect value for obs[1].iono_std, expected 13, is "
       << last_msg_->obs[1].iono_std;
-  EXPECT_EQ(last_msg_->obs[1].lock, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].lock)),
+            15)
       << "incorrect value for obs[1].lock, expected 15, is "
       << last_msg_->obs[1].lock;
-  EXPECT_EQ(last_msg_->obs[1].range_std, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[1].range_std)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].range_std)),
+      3)
       << "incorrect value for obs[1].range_std, expected 3, is "
       << last_msg_->obs[1].range_std;
-  EXPECT_EQ(last_msg_->obs[1].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.code)),
+            0)
       << "incorrect value for obs[1].sid.code, expected 0, is "
       << last_msg_->obs[1].sid.code;
-  EXPECT_EQ(last_msg_->obs[1].sid.sat, 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].sid.sat)),
+            13)
       << "incorrect value for obs[1].sid.sat, expected 13, is "
       << last_msg_->obs[1].sid.sat;
-  EXPECT_EQ(last_msg_->obs[1].tropo_std, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[1].tropo_std)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].tropo_std)),
+      3)
       << "incorrect value for obs[1].tropo_std, expected 3, is "
       << last_msg_->obs[1].tropo_std;
-  EXPECT_EQ(last_msg_->obs[2].L.f, 128)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].L.f)),
+            128)
       << "incorrect value for obs[2].L.f, expected 128, is "
       << last_msg_->obs[2].L.f;
-  EXPECT_EQ(last_msg_->obs[2].L.i, 110692129)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].L.i)),
+            110692129)
       << "incorrect value for obs[2].L.i, expected 110692129, is "
       << last_msg_->obs[2].L.i;
-  EXPECT_EQ(last_msg_->obs[2].P, 1053200685)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].P)),
+            1053200685)
       << "incorrect value for obs[2].P, expected 1053200685, is "
       << last_msg_->obs[2].P;
-  EXPECT_EQ(last_msg_->obs[2].flags, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].flags)),
+            3)
       << "incorrect value for obs[2].flags, expected 3, is "
       << last_msg_->obs[2].flags;
-  EXPECT_EQ(last_msg_->obs[2].iono_std, 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].iono_std)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].iono_std)),
+            13)
       << "incorrect value for obs[2].iono_std, expected 13, is "
       << last_msg_->obs[2].iono_std;
-  EXPECT_EQ(last_msg_->obs[2].lock, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].lock)),
+            15)
       << "incorrect value for obs[2].lock, expected 15, is "
       << last_msg_->obs[2].lock;
-  EXPECT_EQ(last_msg_->obs[2].range_std, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[2].range_std)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].range_std)),
+      3)
       << "incorrect value for obs[2].range_std, expected 3, is "
       << last_msg_->obs[2].range_std;
-  EXPECT_EQ(last_msg_->obs[2].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.code)),
+            0)
       << "incorrect value for obs[2].sid.code, expected 0, is "
       << last_msg_->obs[2].sid.code;
-  EXPECT_EQ(last_msg_->obs[2].sid.sat, 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].sid.sat)),
+            14)
       << "incorrect value for obs[2].sid.sat, expected 14, is "
       << last_msg_->obs[2].sid.sat;
-  EXPECT_EQ(last_msg_->obs[2].tropo_std, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[2].tropo_std)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].tropo_std)),
+      3)
       << "incorrect value for obs[2].tropo_std, expected 3, is "
       << last_msg_->obs[2].tropo_std;
-  EXPECT_EQ(last_msg_->obs[3].L.f, 127)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].L.f)),
+            127)
       << "incorrect value for obs[3].L.f, expected 127, is "
       << last_msg_->obs[3].L.f;
-  EXPECT_EQ(last_msg_->obs[3].L.i, 119549583)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].L.i)),
+            119549583)
       << "incorrect value for obs[3].L.i, expected 119549583, is "
       << last_msg_->obs[3].L.i;
-  EXPECT_EQ(last_msg_->obs[3].P, 1137476697)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].P)),
+            1137476697)
       << "incorrect value for obs[3].P, expected 1137476697, is "
       << last_msg_->obs[3].P;
-  EXPECT_EQ(last_msg_->obs[3].flags, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].flags)),
+            3)
       << "incorrect value for obs[3].flags, expected 3, is "
       << last_msg_->obs[3].flags;
-  EXPECT_EQ(last_msg_->obs[3].iono_std, 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].iono_std)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].iono_std)),
+            13)
       << "incorrect value for obs[3].iono_std, expected 13, is "
       << last_msg_->obs[3].iono_std;
-  EXPECT_EQ(last_msg_->obs[3].lock, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].lock)),
+            15)
       << "incorrect value for obs[3].lock, expected 15, is "
       << last_msg_->obs[3].lock;
-  EXPECT_EQ(last_msg_->obs[3].range_std, 5)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[3].range_std)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].range_std)),
+      5)
       << "incorrect value for obs[3].range_std, expected 5, is "
       << last_msg_->obs[3].range_std;
-  EXPECT_EQ(last_msg_->obs[3].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].sid.code)),
+            0)
       << "incorrect value for obs[3].sid.code, expected 0, is "
       << last_msg_->obs[3].sid.code;
-  EXPECT_EQ(last_msg_->obs[3].sid.sat, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].sid.sat)),
+            15)
       << "incorrect value for obs[3].sid.sat, expected 15, is "
       << last_msg_->obs[3].sid.sat;
-  EXPECT_EQ(last_msg_->obs[3].tropo_std, 5)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[3].tropo_std)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].tropo_std)),
+      5)
       << "incorrect value for obs[3].tropo_std, expected 5, is "
       << last_msg_->obs[3].tropo_std;
-  EXPECT_EQ(last_msg_->obs[4].L.f, 55)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].L.f)),
+            55)
       << "incorrect value for obs[4].L.f, expected 55, is "
       << last_msg_->obs[4].L.f;
-  EXPECT_EQ(last_msg_->obs[4].L.i, 106934294)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].L.i)),
+            106934294)
       << "incorrect value for obs[4].L.i, expected 106934294, is "
       << last_msg_->obs[4].L.i;
-  EXPECT_EQ(last_msg_->obs[4].P, 1017446132)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].P)),
+            1017446132)
       << "incorrect value for obs[4].P, expected 1017446132, is "
       << last_msg_->obs[4].P;
-  EXPECT_EQ(last_msg_->obs[4].flags, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].flags)),
+            3)
       << "incorrect value for obs[4].flags, expected 3, is "
       << last_msg_->obs[4].flags;
-  EXPECT_EQ(last_msg_->obs[4].iono_std, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].iono_std)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].iono_std)),
+            0)
       << "incorrect value for obs[4].iono_std, expected 0, is "
       << last_msg_->obs[4].iono_std;
-  EXPECT_EQ(last_msg_->obs[4].lock, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].lock)),
+            15)
       << "incorrect value for obs[4].lock, expected 15, is "
       << last_msg_->obs[4].lock;
-  EXPECT_EQ(last_msg_->obs[4].range_std, 2)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[4].range_std)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].range_std)),
+      2)
       << "incorrect value for obs[4].range_std, expected 2, is "
       << last_msg_->obs[4].range_std;
-  EXPECT_EQ(last_msg_->obs[4].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].sid.code)),
+            0)
       << "incorrect value for obs[4].sid.code, expected 0, is "
       << last_msg_->obs[4].sid.code;
-  EXPECT_EQ(last_msg_->obs[4].sid.sat, 17)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].sid.sat)),
+            17)
       << "incorrect value for obs[4].sid.sat, expected 17, is "
       << last_msg_->obs[4].sid.sat;
-  EXPECT_EQ(last_msg_->obs[4].tropo_std, 2)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[4].tropo_std)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].tropo_std)),
+      2)
       << "incorrect value for obs[4].tropo_std, expected 2, is "
       << last_msg_->obs[4].tropo_std;
-  EXPECT_EQ(last_msg_->obs[5].L.f, 108)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].L.f)),
+            108)
       << "incorrect value for obs[5].L.f, expected 108, is "
       << last_msg_->obs[5].L.f;
-  EXPECT_EQ(last_msg_->obs[5].L.i, 110024343)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].L.i)),
+            110024343)
       << "incorrect value for obs[5].L.i, expected 110024343, is "
       << last_msg_->obs[5].L.i;
-  EXPECT_EQ(last_msg_->obs[5].P, 1046846826)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].P)),
+            1046846826)
       << "incorrect value for obs[5].P, expected 1046846826, is "
       << last_msg_->obs[5].P;
-  EXPECT_EQ(last_msg_->obs[5].flags, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].flags)),
+            3)
       << "incorrect value for obs[5].flags, expected 3, is "
       << last_msg_->obs[5].flags;
-  EXPECT_EQ(last_msg_->obs[5].iono_std, 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].iono_std)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].iono_std)),
+            13)
       << "incorrect value for obs[5].iono_std, expected 13, is "
       << last_msg_->obs[5].iono_std;
-  EXPECT_EQ(last_msg_->obs[5].lock, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].lock)),
+            15)
       << "incorrect value for obs[5].lock, expected 15, is "
       << last_msg_->obs[5].lock;
-  EXPECT_EQ(last_msg_->obs[5].range_std, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[5].range_std)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].range_std)),
+      3)
       << "incorrect value for obs[5].range_std, expected 3, is "
       << last_msg_->obs[5].range_std;
-  EXPECT_EQ(last_msg_->obs[5].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].sid.code)),
+            0)
       << "incorrect value for obs[5].sid.code, expected 0, is "
       << last_msg_->obs[5].sid.code;
-  EXPECT_EQ(last_msg_->obs[5].sid.sat, 19)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].sid.sat)),
+            19)
       << "incorrect value for obs[5].sid.sat, expected 19, is "
       << last_msg_->obs[5].sid.sat;
-  EXPECT_EQ(last_msg_->obs[5].tropo_std, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[5].tropo_std)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].tropo_std)),
+      3)
       << "incorrect value for obs[5].tropo_std, expected 3, is "
       << last_msg_->obs[5].tropo_std;
-  EXPECT_EQ(last_msg_->obs[6].L.f, 206)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[6].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[6].L.f)),
+            206)
       << "incorrect value for obs[6].L.f, expected 206, is "
       << last_msg_->obs[6].L.f;
-  EXPECT_EQ(last_msg_->obs[6].L.i, 111507381)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[6].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[6].L.i)),
+            111507381)
       << "incorrect value for obs[6].L.i, expected 111507381, is "
       << last_msg_->obs[6].L.i;
-  EXPECT_EQ(last_msg_->obs[6].P, 1060957521)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[6].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[6].P)),
+            1060957521)
       << "incorrect value for obs[6].P, expected 1060957521, is "
       << last_msg_->obs[6].P;
-  EXPECT_EQ(last_msg_->obs[6].flags, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[6].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[6].flags)),
+            3)
       << "incorrect value for obs[6].flags, expected 3, is "
       << last_msg_->obs[6].flags;
-  EXPECT_EQ(last_msg_->obs[6].iono_std, 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[6].iono_std)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[6].iono_std)),
+            13)
       << "incorrect value for obs[6].iono_std, expected 13, is "
       << last_msg_->obs[6].iono_std;
-  EXPECT_EQ(last_msg_->obs[6].lock, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[6].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[6].lock)),
+            15)
       << "incorrect value for obs[6].lock, expected 15, is "
       << last_msg_->obs[6].lock;
-  EXPECT_EQ(last_msg_->obs[6].range_std, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[6].range_std)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[6].range_std)),
+      3)
       << "incorrect value for obs[6].range_std, expected 3, is "
       << last_msg_->obs[6].range_std;
-  EXPECT_EQ(last_msg_->obs[6].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[6].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[6].sid.code)),
+            0)
       << "incorrect value for obs[6].sid.code, expected 0, is "
       << last_msg_->obs[6].sid.code;
-  EXPECT_EQ(last_msg_->obs[6].sid.sat, 28)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[6].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[6].sid.sat)),
+            28)
       << "incorrect value for obs[6].sid.sat, expected 28, is "
       << last_msg_->obs[6].sid.sat;
-  EXPECT_EQ(last_msg_->obs[6].tropo_std, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[6].tropo_std)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[6].tropo_std)),
+      3)
       << "incorrect value for obs[6].tropo_std, expected 3, is "
       << last_msg_->obs[6].tropo_std;
-  EXPECT_EQ(last_msg_->obs[7].L.f, 200)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[7].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[7].L.f)),
+            200)
       << "incorrect value for obs[7].L.f, expected 200, is "
       << last_msg_->obs[7].L.f;
-  EXPECT_EQ(last_msg_->obs[7].L.i, 113614775)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[7].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[7].L.i)),
+            113614775)
       << "incorrect value for obs[7].L.i, expected 113614775, is "
       << last_msg_->obs[7].L.i;
-  EXPECT_EQ(last_msg_->obs[7].P, 1081009286)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[7].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[7].P)),
+            1081009286)
       << "incorrect value for obs[7].P, expected 1081009286, is "
       << last_msg_->obs[7].P;
-  EXPECT_EQ(last_msg_->obs[7].flags, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[7].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[7].flags)),
+            3)
       << "incorrect value for obs[7].flags, expected 3, is "
       << last_msg_->obs[7].flags;
-  EXPECT_EQ(last_msg_->obs[7].iono_std, 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[7].iono_std)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[7].iono_std)),
+            13)
       << "incorrect value for obs[7].iono_std, expected 13, is "
       << last_msg_->obs[7].iono_std;
-  EXPECT_EQ(last_msg_->obs[7].lock, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[7].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[7].lock)),
+            15)
       << "incorrect value for obs[7].lock, expected 15, is "
       << last_msg_->obs[7].lock;
-  EXPECT_EQ(last_msg_->obs[7].range_std, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[7].range_std)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[7].range_std)),
+      3)
       << "incorrect value for obs[7].range_std, expected 3, is "
       << last_msg_->obs[7].range_std;
-  EXPECT_EQ(last_msg_->obs[7].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[7].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[7].sid.code)),
+            0)
       << "incorrect value for obs[7].sid.code, expected 0, is "
       << last_msg_->obs[7].sid.code;
-  EXPECT_EQ(last_msg_->obs[7].sid.sat, 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[7].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[7].sid.sat)),
+            30)
       << "incorrect value for obs[7].sid.sat, expected 30, is "
       << last_msg_->obs[7].sid.sat;
-  EXPECT_EQ(last_msg_->obs[7].tropo_std, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[7].tropo_std)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[7].tropo_std)),
+      3)
       << "incorrect value for obs[7].tropo_std, expected 3, is "
       << last_msg_->obs[7].tropo_std;
-  EXPECT_EQ(last_msg_->obs[8].L.f, 170)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[8].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[8].L.f)),
+            170)
       << "incorrect value for obs[8].L.f, expected 170, is "
       << last_msg_->obs[8].L.f;
-  EXPECT_EQ(last_msg_->obs[8].L.i, 94728270)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[8].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[8].L.i)),
+            94728270)
       << "incorrect value for obs[8].L.i, expected 94728270, is "
       << last_msg_->obs[8].L.i;
-  EXPECT_EQ(last_msg_->obs[8].P, 1156681781)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[8].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[8].P)),
+            1156681781)
       << "incorrect value for obs[8].P, expected 1156681781, is "
       << last_msg_->obs[8].P;
-  EXPECT_EQ(last_msg_->obs[8].flags, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[8].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[8].flags)),
+            3)
       << "incorrect value for obs[8].flags, expected 3, is "
       << last_msg_->obs[8].flags;
-  EXPECT_EQ(last_msg_->obs[8].iono_std, 21)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[8].iono_std)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[8].iono_std)),
+            21)
       << "incorrect value for obs[8].iono_std, expected 21, is "
       << last_msg_->obs[8].iono_std;
-  EXPECT_EQ(last_msg_->obs[8].lock, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[8].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[8].lock)),
+            15)
       << "incorrect value for obs[8].lock, expected 15, is "
       << last_msg_->obs[8].lock;
-  EXPECT_EQ(last_msg_->obs[8].range_std, 7)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[8].range_std)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[8].range_std)),
+      7)
       << "incorrect value for obs[8].range_std, expected 7, is "
       << last_msg_->obs[8].range_std;
-  EXPECT_EQ(last_msg_->obs[8].sid.code, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[8].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[8].sid.code)),
+            6)
       << "incorrect value for obs[8].sid.code, expected 6, is "
       << last_msg_->obs[8].sid.code;
-  EXPECT_EQ(last_msg_->obs[8].sid.sat, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[8].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[8].sid.sat)),
+            1)
       << "incorrect value for obs[8].sid.sat, expected 1, is "
       << last_msg_->obs[8].sid.sat;
-  EXPECT_EQ(last_msg_->obs[8].tropo_std, 7)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[8].tropo_std)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[8].tropo_std)),
+      7)
       << "incorrect value for obs[8].tropo_std, expected 7, is "
       << last_msg_->obs[8].tropo_std;
-  EXPECT_EQ(last_msg_->obs[9].L.f, 129)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[9].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[9].L.f)),
+            129)
       << "incorrect value for obs[9].L.f, expected 129, is "
       << last_msg_->obs[9].L.f;
-  EXPECT_EQ(last_msg_->obs[9].L.i, 87130275)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[9].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[9].L.i)),
+            87130275)
       << "incorrect value for obs[9].L.i, expected 87130275, is "
       << last_msg_->obs[9].L.i;
-  EXPECT_EQ(last_msg_->obs[9].P, 1063905531)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[9].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[9].P)),
+            1063905531)
       << "incorrect value for obs[9].P, expected 1063905531, is "
       << last_msg_->obs[9].P;
-  EXPECT_EQ(last_msg_->obs[9].flags, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[9].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[9].flags)),
+            3)
       << "incorrect value for obs[9].flags, expected 3, is "
       << last_msg_->obs[9].flags;
-  EXPECT_EQ(last_msg_->obs[9].iono_std, 21)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[9].iono_std)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[9].iono_std)),
+            21)
       << "incorrect value for obs[9].iono_std, expected 21, is "
       << last_msg_->obs[9].iono_std;
-  EXPECT_EQ(last_msg_->obs[9].lock, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[9].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[9].lock)),
+            15)
       << "incorrect value for obs[9].lock, expected 15, is "
       << last_msg_->obs[9].lock;
-  EXPECT_EQ(last_msg_->obs[9].range_std, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[9].range_std)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[9].range_std)),
+      3)
       << "incorrect value for obs[9].range_std, expected 3, is "
       << last_msg_->obs[9].range_std;
-  EXPECT_EQ(last_msg_->obs[9].sid.code, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[9].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[9].sid.code)),
+            6)
       << "incorrect value for obs[9].sid.code, expected 6, is "
       << last_msg_->obs[9].sid.code;
-  EXPECT_EQ(last_msg_->obs[9].sid.sat, 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[9].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[9].sid.sat)),
+            13)
       << "incorrect value for obs[9].sid.sat, expected 13, is "
       << last_msg_->obs[9].sid.sat;
-  EXPECT_EQ(last_msg_->obs[9].tropo_std, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[9].tropo_std)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[9].tropo_std)),
+      3)
       << "incorrect value for obs[9].tropo_std, expected 3, is "
       << last_msg_->obs[9].tropo_std;
-  EXPECT_EQ(last_msg_->obs[10].L.f, 46)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[10].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[10].L.f)),
+            46)
       << "incorrect value for obs[10].L.f, expected 46, is "
       << last_msg_->obs[10].L.f;
-  EXPECT_EQ(last_msg_->obs[10].L.i, 86253605)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[10].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[10].L.i)),
+            86253605)
       << "incorrect value for obs[10].L.i, expected 86253605, is "
       << last_msg_->obs[10].L.i;
-  EXPECT_EQ(last_msg_->obs[10].P, 1053200752)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[10].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[10].P)),
+            1053200752)
       << "incorrect value for obs[10].P, expected 1053200752, is "
       << last_msg_->obs[10].P;
-  EXPECT_EQ(last_msg_->obs[10].flags, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[10].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[10].flags)),
+            3)
       << "incorrect value for obs[10].flags, expected 3, is "
       << last_msg_->obs[10].flags;
-  EXPECT_EQ(last_msg_->obs[10].iono_std, 21)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[10].iono_std)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[10].iono_std)),
+      21)
       << "incorrect value for obs[10].iono_std, expected 21, is "
       << last_msg_->obs[10].iono_std;
-  EXPECT_EQ(last_msg_->obs[10].lock, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[10].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[10].lock)),
+            15)
       << "incorrect value for obs[10].lock, expected 15, is "
       << last_msg_->obs[10].lock;
-  EXPECT_EQ(last_msg_->obs[10].range_std, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[10].range_std)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[10].range_std)),
+      3)
       << "incorrect value for obs[10].range_std, expected 3, is "
       << last_msg_->obs[10].range_std;
-  EXPECT_EQ(last_msg_->obs[10].sid.code, 6)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[10].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[10].sid.code)),
+      6)
       << "incorrect value for obs[10].sid.code, expected 6, is "
       << last_msg_->obs[10].sid.code;
-  EXPECT_EQ(last_msg_->obs[10].sid.sat, 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[10].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[10].sid.sat)),
+            14)
       << "incorrect value for obs[10].sid.sat, expected 14, is "
       << last_msg_->obs[10].sid.sat;
-  EXPECT_EQ(last_msg_->obs[10].tropo_std, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[10].tropo_std)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[10].tropo_std)),
+      3)
       << "incorrect value for obs[10].tropo_std, expected 3, is "
       << last_msg_->obs[10].tropo_std;
-  EXPECT_EQ(last_msg_->obs[11].L.f, 95)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[11].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[11].L.f)),
+            95)
       << "incorrect value for obs[11].L.f, expected 95, is "
       << last_msg_->obs[11].L.f;
-  EXPECT_EQ(last_msg_->obs[11].L.i, 93155512)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[11].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[11].L.i)),
+            93155512)
       << "incorrect value for obs[11].L.i, expected 93155512, is "
       << last_msg_->obs[11].L.i;
-  EXPECT_EQ(last_msg_->obs[11].P, 1137476774)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[11].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[11].P)),
+            1137476774)
       << "incorrect value for obs[11].P, expected 1137476774, is "
       << last_msg_->obs[11].P;
-  EXPECT_EQ(last_msg_->obs[11].flags, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[11].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[11].flags)),
+            3)
       << "incorrect value for obs[11].flags, expected 3, is "
       << last_msg_->obs[11].flags;
-  EXPECT_EQ(last_msg_->obs[11].iono_std, 21)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[11].iono_std)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[11].iono_std)),
+      21)
       << "incorrect value for obs[11].iono_std, expected 21, is "
       << last_msg_->obs[11].iono_std;
-  EXPECT_EQ(last_msg_->obs[11].lock, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[11].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[11].lock)),
+            15)
       << "incorrect value for obs[11].lock, expected 15, is "
       << last_msg_->obs[11].lock;
-  EXPECT_EQ(last_msg_->obs[11].range_std, 5)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[11].range_std)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[11].range_std)),
+      5)
       << "incorrect value for obs[11].range_std, expected 5, is "
       << last_msg_->obs[11].range_std;
-  EXPECT_EQ(last_msg_->obs[11].sid.code, 6)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[11].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[11].sid.code)),
+      6)
       << "incorrect value for obs[11].sid.code, expected 6, is "
       << last_msg_->obs[11].sid.code;
-  EXPECT_EQ(last_msg_->obs[11].sid.sat, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[11].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[11].sid.sat)),
+            15)
       << "incorrect value for obs[11].sid.sat, expected 15, is "
       << last_msg_->obs[11].sid.sat;
-  EXPECT_EQ(last_msg_->obs[11].tropo_std, 5)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs[11].tropo_std)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs[11].tropo_std)),
+      5)
       << "incorrect value for obs[11].tropo_std, expected 5, is "
       << last_msg_->obs[11].tropo_std;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgSvAzEl.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgSvAzEl.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgSvAzEl0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -381,400 +388,720 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgSvAzEl0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 31183);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->azel[0].az, 160)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[0].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[0].az)),
+            160)
       << "incorrect value for azel[0].az, expected 160, is "
       << last_msg_->azel[0].az;
-  EXPECT_EQ(last_msg_->azel[0].el, 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[0].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[0].el)),
+            12)
       << "incorrect value for azel[0].el, expected 12, is "
       << last_msg_->azel[0].el;
-  EXPECT_EQ(last_msg_->azel[0].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[0].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[0].sid.code)),
+      0)
       << "incorrect value for azel[0].sid.code, expected 0, is "
       << last_msg_->azel[0].sid.code;
-  EXPECT_EQ(last_msg_->azel[0].sid.sat, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[0].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[0].sid.sat)),
+            8)
       << "incorrect value for azel[0].sid.sat, expected 8, is "
       << last_msg_->azel[0].sid.sat;
-  EXPECT_EQ(last_msg_->azel[1].az, 139)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[1].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[1].az)),
+            139)
       << "incorrect value for azel[1].az, expected 139, is "
       << last_msg_->azel[1].az;
-  EXPECT_EQ(last_msg_->azel[1].el, 66)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[1].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[1].el)),
+            66)
       << "incorrect value for azel[1].el, expected 66, is "
       << last_msg_->azel[1].el;
-  EXPECT_EQ(last_msg_->azel[1].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[1].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[1].sid.code)),
+      0)
       << "incorrect value for azel[1].sid.code, expected 0, is "
       << last_msg_->azel[1].sid.code;
-  EXPECT_EQ(last_msg_->azel[1].sid.sat, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[1].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[1].sid.sat)),
+            10)
       << "incorrect value for azel[1].sid.sat, expected 10, is "
       << last_msg_->azel[1].sid.sat;
-  EXPECT_EQ(last_msg_->azel[2].az, 16)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[2].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[2].az)),
+            16)
       << "incorrect value for azel[2].az, expected 16, is "
       << last_msg_->azel[2].az;
-  EXPECT_EQ(last_msg_->azel[2].el, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[2].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[2].el)),
+            1)
       << "incorrect value for azel[2].el, expected 1, is "
       << last_msg_->azel[2].el;
-  EXPECT_EQ(last_msg_->azel[2].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[2].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[2].sid.code)),
+      0)
       << "incorrect value for azel[2].sid.code, expected 0, is "
       << last_msg_->azel[2].sid.code;
-  EXPECT_EQ(last_msg_->azel[2].sid.sat, 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[2].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[2].sid.sat)),
+            13)
       << "incorrect value for azel[2].sid.sat, expected 13, is "
       << last_msg_->azel[2].sid.sat;
-  EXPECT_EQ(last_msg_->azel[3].az, 24)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[3].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[3].az)),
+            24)
       << "incorrect value for azel[3].az, expected 24, is "
       << last_msg_->azel[3].az;
-  EXPECT_EQ(last_msg_->azel[3].el, 25)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[3].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[3].el)),
+            25)
       << "incorrect value for azel[3].el, expected 25, is "
       << last_msg_->azel[3].el;
-  EXPECT_EQ(last_msg_->azel[3].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[3].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[3].sid.code)),
+      0)
       << "incorrect value for azel[3].sid.code, expected 0, is "
       << last_msg_->azel[3].sid.code;
-  EXPECT_EQ(last_msg_->azel[3].sid.sat, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[3].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[3].sid.sat)),
+            15)
       << "incorrect value for azel[3].sid.sat, expected 15, is "
       << last_msg_->azel[3].sid.sat;
-  EXPECT_EQ(last_msg_->azel[4].az, 127)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[4].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[4].az)),
+            127)
       << "incorrect value for azel[4].az, expected 127, is "
       << last_msg_->azel[4].az;
-  EXPECT_EQ(last_msg_->azel[4].el, 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[4].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[4].el)),
+            18)
       << "incorrect value for azel[4].el, expected 18, is "
       << last_msg_->azel[4].el;
-  EXPECT_EQ(last_msg_->azel[4].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[4].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[4].sid.code)),
+      0)
       << "incorrect value for azel[4].sid.code, expected 0, is "
       << last_msg_->azel[4].sid.code;
-  EXPECT_EQ(last_msg_->azel[4].sid.sat, 16)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[4].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[4].sid.sat)),
+            16)
       << "incorrect value for azel[4].sid.sat, expected 16, is "
       << last_msg_->azel[4].sid.sat;
-  EXPECT_EQ(last_msg_->azel[5].az, 42)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[5].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[5].az)),
+            42)
       << "incorrect value for azel[5].az, expected 42, is "
       << last_msg_->azel[5].az;
-  EXPECT_EQ(last_msg_->azel[5].el, 53)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[5].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[5].el)),
+            53)
       << "incorrect value for azel[5].el, expected 53, is "
       << last_msg_->azel[5].el;
-  EXPECT_EQ(last_msg_->azel[5].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[5].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[5].sid.code)),
+      0)
       << "incorrect value for azel[5].sid.code, expected 0, is "
       << last_msg_->azel[5].sid.code;
-  EXPECT_EQ(last_msg_->azel[5].sid.sat, 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[5].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[5].sid.sat)),
+            18)
       << "incorrect value for azel[5].sid.sat, expected 18, is "
       << last_msg_->azel[5].sid.sat;
-  EXPECT_EQ(last_msg_->azel[6].az, 31)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[6].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[6].az)),
+            31)
       << "incorrect value for azel[6].az, expected 31, is "
       << last_msg_->azel[6].az;
-  EXPECT_EQ(last_msg_->azel[6].el, 16)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[6].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[6].el)),
+            16)
       << "incorrect value for azel[6].el, expected 16, is "
       << last_msg_->azel[6].el;
-  EXPECT_EQ(last_msg_->azel[6].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[6].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[6].sid.code)),
+      0)
       << "incorrect value for azel[6].sid.code, expected 0, is "
       << last_msg_->azel[6].sid.code;
-  EXPECT_EQ(last_msg_->azel[6].sid.sat, 20)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[6].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[6].sid.sat)),
+            20)
       << "incorrect value for azel[6].sid.sat, expected 20, is "
       << last_msg_->azel[6].sid.sat;
-  EXPECT_EQ(last_msg_->azel[7].az, 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[7].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[7].az)),
+            12)
       << "incorrect value for azel[7].az, expected 12, is "
       << last_msg_->azel[7].az;
-  EXPECT_EQ(last_msg_->azel[7].el, 67)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[7].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[7].el)),
+            67)
       << "incorrect value for azel[7].el, expected 67, is "
       << last_msg_->azel[7].el;
-  EXPECT_EQ(last_msg_->azel[7].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[7].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[7].sid.code)),
+      0)
       << "incorrect value for azel[7].sid.code, expected 0, is "
       << last_msg_->azel[7].sid.code;
-  EXPECT_EQ(last_msg_->azel[7].sid.sat, 23)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[7].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[7].sid.sat)),
+            23)
       << "incorrect value for azel[7].sid.sat, expected 23, is "
       << last_msg_->azel[7].sid.sat;
-  EXPECT_EQ(last_msg_->azel[8].az, 47)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[8].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[8].az)),
+            47)
       << "incorrect value for azel[8].az, expected 47, is "
       << last_msg_->azel[8].az;
-  EXPECT_EQ(last_msg_->azel[8].el, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[8].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[8].el)),
+            10)
       << "incorrect value for azel[8].el, expected 10, is "
       << last_msg_->azel[8].el;
-  EXPECT_EQ(last_msg_->azel[8].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[8].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[8].sid.code)),
+      0)
       << "incorrect value for azel[8].sid.code, expected 0, is "
       << last_msg_->azel[8].sid.code;
-  EXPECT_EQ(last_msg_->azel[8].sid.sat, 24)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[8].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[8].sid.sat)),
+            24)
       << "incorrect value for azel[8].sid.sat, expected 24, is "
       << last_msg_->azel[8].sid.sat;
-  EXPECT_EQ(last_msg_->azel[9].az, 116)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[9].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[9].az)),
+            116)
       << "incorrect value for azel[9].az, expected 116, is "
       << last_msg_->azel[9].az;
-  EXPECT_EQ(last_msg_->azel[9].el, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[9].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[9].el)),
+            8)
       << "incorrect value for azel[9].el, expected 8, is "
       << last_msg_->azel[9].el;
-  EXPECT_EQ(last_msg_->azel[9].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[9].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[9].sid.code)),
+      0)
       << "incorrect value for azel[9].sid.code, expected 0, is "
       << last_msg_->azel[9].sid.code;
-  EXPECT_EQ(last_msg_->azel[9].sid.sat, 26)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[9].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[9].sid.sat)),
+            26)
       << "incorrect value for azel[9].sid.sat, expected 26, is "
       << last_msg_->azel[9].sid.sat;
-  EXPECT_EQ(last_msg_->azel[10].az, 153)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[10].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[10].az)),
+            153)
       << "incorrect value for azel[10].az, expected 153, is "
       << last_msg_->azel[10].az;
-  EXPECT_EQ(last_msg_->azel[10].el, 43)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[10].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[10].el)),
+            43)
       << "incorrect value for azel[10].el, expected 43, is "
       << last_msg_->azel[10].el;
-  EXPECT_EQ(last_msg_->azel[10].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[10].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[10].sid.code)),
+      0)
       << "incorrect value for azel[10].sid.code, expected 0, is "
       << last_msg_->azel[10].sid.code;
-  EXPECT_EQ(last_msg_->azel[10].sid.sat, 27)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[10].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[10].sid.sat)),
+      27)
       << "incorrect value for azel[10].sid.sat, expected 27, is "
       << last_msg_->azel[10].sid.sat;
-  EXPECT_EQ(last_msg_->azel[11].az, 77)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[11].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[11].az)),
+            77)
       << "incorrect value for azel[11].az, expected 77, is "
       << last_msg_->azel[11].az;
-  EXPECT_EQ(last_msg_->azel[11].el, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[11].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[11].el)),
+            10)
       << "incorrect value for azel[11].el, expected 10, is "
       << last_msg_->azel[11].el;
-  EXPECT_EQ(last_msg_->azel[11].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[11].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[11].sid.code)),
+      0)
       << "incorrect value for azel[11].sid.code, expected 0, is "
       << last_msg_->azel[11].sid.code;
-  EXPECT_EQ(last_msg_->azel[11].sid.sat, 29)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[11].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[11].sid.sat)),
+      29)
       << "incorrect value for azel[11].sid.sat, expected 29, is "
       << last_msg_->azel[11].sid.sat;
-  EXPECT_EQ(last_msg_->azel[12].az, 94)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[12].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[12].az)),
+            94)
       << "incorrect value for azel[12].az, expected 94, is "
       << last_msg_->azel[12].az;
-  EXPECT_EQ(last_msg_->azel[12].el, 26)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[12].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[12].el)),
+            26)
       << "incorrect value for azel[12].el, expected 26, is "
       << last_msg_->azel[12].el;
-  EXPECT_EQ(last_msg_->azel[12].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[12].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[12].sid.code)),
+      0)
       << "incorrect value for azel[12].sid.code, expected 0, is "
       << last_msg_->azel[12].sid.code;
-  EXPECT_EQ(last_msg_->azel[12].sid.sat, 32)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[12].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[12].sid.sat)),
+      32)
       << "incorrect value for azel[12].sid.sat, expected 32, is "
       << last_msg_->azel[12].sid.sat;
-  EXPECT_EQ(last_msg_->azel[13].az, 16)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[13].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[13].az)),
+            16)
       << "incorrect value for azel[13].az, expected 16, is "
       << last_msg_->azel[13].az;
-  EXPECT_EQ(last_msg_->azel[13].el, 58)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[13].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[13].el)),
+            58)
       << "incorrect value for azel[13].el, expected 58, is "
       << last_msg_->azel[13].el;
-  EXPECT_EQ(last_msg_->azel[13].sid.code, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[13].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[13].sid.code)),
+      3)
       << "incorrect value for azel[13].sid.code, expected 3, is "
       << last_msg_->azel[13].sid.code;
-  EXPECT_EQ(last_msg_->azel[13].sid.sat, 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[13].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[13].sid.sat)),
+      1)
       << "incorrect value for azel[13].sid.sat, expected 1, is "
       << last_msg_->azel[13].sid.sat;
-  EXPECT_EQ(last_msg_->azel[14].az, 108)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[14].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[14].az)),
+            108)
       << "incorrect value for azel[14].az, expected 108, is "
       << last_msg_->azel[14].az;
-  EXPECT_EQ(last_msg_->azel[14].el, 53)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[14].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[14].el)),
+            53)
       << "incorrect value for azel[14].el, expected 53, is "
       << last_msg_->azel[14].el;
-  EXPECT_EQ(last_msg_->azel[14].sid.code, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[14].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[14].sid.code)),
+      3)
       << "incorrect value for azel[14].sid.code, expected 3, is "
       << last_msg_->azel[14].sid.code;
-  EXPECT_EQ(last_msg_->azel[14].sid.sat, 2)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[14].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[14].sid.sat)),
+      2)
       << "incorrect value for azel[14].sid.sat, expected 2, is "
       << last_msg_->azel[14].sid.sat;
-  EXPECT_EQ(last_msg_->azel[15].az, 17)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[15].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[15].az)),
+            17)
       << "incorrect value for azel[15].az, expected 17, is "
       << last_msg_->azel[15].az;
-  EXPECT_EQ(last_msg_->azel[15].el, 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[15].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[15].el)),
+            13)
       << "incorrect value for azel[15].el, expected 13, is "
       << last_msg_->azel[15].el;
-  EXPECT_EQ(last_msg_->azel[15].sid.code, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[15].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[15].sid.code)),
+      3)
       << "incorrect value for azel[15].sid.code, expected 3, is "
       << last_msg_->azel[15].sid.code;
-  EXPECT_EQ(last_msg_->azel[15].sid.sat, 8)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[15].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[15].sid.sat)),
+      8)
       << "incorrect value for azel[15].sid.sat, expected 8, is "
       << last_msg_->azel[15].sid.sat;
-  EXPECT_EQ(last_msg_->azel[16].az, 165)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[16].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[16].az)),
+            165)
       << "incorrect value for azel[16].az, expected 165, is "
       << last_msg_->azel[16].az;
-  EXPECT_EQ(last_msg_->azel[16].el, 40)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[16].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[16].el)),
+            40)
       << "incorrect value for azel[16].el, expected 40, is "
       << last_msg_->azel[16].el;
-  EXPECT_EQ(last_msg_->azel[16].sid.code, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[16].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[16].sid.code)),
+      3)
       << "incorrect value for azel[16].sid.code, expected 3, is "
       << last_msg_->azel[16].sid.code;
-  EXPECT_EQ(last_msg_->azel[16].sid.sat, 17)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[16].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[16].sid.sat)),
+      17)
       << "incorrect value for azel[16].sid.sat, expected 17, is "
       << last_msg_->azel[16].sid.sat;
-  EXPECT_EQ(last_msg_->azel[17].az, 63)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[17].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[17].az)),
+            63)
       << "incorrect value for azel[17].az, expected 63, is "
       << last_msg_->azel[17].az;
-  EXPECT_EQ(last_msg_->azel[17].el, 35)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[17].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[17].el)),
+            35)
       << "incorrect value for azel[17].el, expected 35, is "
       << last_msg_->azel[17].el;
-  EXPECT_EQ(last_msg_->azel[17].sid.code, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[17].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[17].sid.code)),
+      3)
       << "incorrect value for azel[17].sid.code, expected 3, is "
       << last_msg_->azel[17].sid.code;
-  EXPECT_EQ(last_msg_->azel[17].sid.sat, 23)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[17].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[17].sid.sat)),
+      23)
       << "incorrect value for azel[17].sid.sat, expected 23, is "
       << last_msg_->azel[17].sid.sat;
-  EXPECT_EQ(last_msg_->azel[18].az, 41)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[18].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[18].az)),
+            41)
       << "incorrect value for azel[18].az, expected 41, is "
       << last_msg_->azel[18].az;
-  EXPECT_EQ(last_msg_->azel[18].el, 73)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[18].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[18].el)),
+            73)
       << "incorrect value for azel[18].el, expected 73, is "
       << last_msg_->azel[18].el;
-  EXPECT_EQ(last_msg_->azel[18].sid.code, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[18].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[18].sid.code)),
+      3)
       << "incorrect value for azel[18].sid.code, expected 3, is "
       << last_msg_->azel[18].sid.code;
-  EXPECT_EQ(last_msg_->azel[18].sid.sat, 24)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[18].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[18].sid.sat)),
+      24)
       << "incorrect value for azel[18].sid.sat, expected 24, is "
       << last_msg_->azel[18].sid.sat;
-  EXPECT_EQ(last_msg_->azel[19].az, 114)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[19].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[19].az)),
+            114)
       << "incorrect value for azel[19].az, expected 114, is "
       << last_msg_->azel[19].az;
-  EXPECT_EQ(last_msg_->azel[19].el, 26)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[19].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[19].el)),
+            26)
       << "incorrect value for azel[19].el, expected 26, is "
       << last_msg_->azel[19].el;
-  EXPECT_EQ(last_msg_->azel[19].sid.code, 12)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[19].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[19].sid.code)),
+      12)
       << "incorrect value for azel[19].sid.code, expected 12, is "
       << last_msg_->azel[19].sid.code;
-  EXPECT_EQ(last_msg_->azel[19].sid.sat, 20)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[19].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[19].sid.sat)),
+      20)
       << "incorrect value for azel[19].sid.sat, expected 20, is "
       << last_msg_->azel[19].sid.sat;
-  EXPECT_EQ(last_msg_->azel[20].az, 72)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[20].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[20].az)),
+            72)
       << "incorrect value for azel[20].az, expected 72, is "
       << last_msg_->azel[20].az;
-  EXPECT_EQ(last_msg_->azel[20].el, 54)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[20].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[20].el)),
+            54)
       << "incorrect value for azel[20].el, expected 54, is "
       << last_msg_->azel[20].el;
-  EXPECT_EQ(last_msg_->azel[20].sid.code, 12)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[20].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[20].sid.code)),
+      12)
       << "incorrect value for azel[20].sid.code, expected 12, is "
       << last_msg_->azel[20].sid.code;
-  EXPECT_EQ(last_msg_->azel[20].sid.sat, 27)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[20].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[20].sid.sat)),
+      27)
       << "incorrect value for azel[20].sid.sat, expected 27, is "
       << last_msg_->azel[20].sid.sat;
-  EXPECT_EQ(last_msg_->azel[21].az, 69)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[21].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[21].az)),
+            69)
       << "incorrect value for azel[21].az, expected 69, is "
       << last_msg_->azel[21].az;
-  EXPECT_EQ(last_msg_->azel[21].el, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[21].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[21].el)),
+            3)
       << "incorrect value for azel[21].el, expected 3, is "
       << last_msg_->azel[21].el;
-  EXPECT_EQ(last_msg_->azel[21].sid.code, 12)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[21].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[21].sid.code)),
+      12)
       << "incorrect value for azel[21].sid.code, expected 12, is "
       << last_msg_->azel[21].sid.code;
-  EXPECT_EQ(last_msg_->azel[21].sid.sat, 28)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[21].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[21].sid.sat)),
+      28)
       << "incorrect value for azel[21].sid.sat, expected 28, is "
       << last_msg_->azel[21].sid.sat;
-  EXPECT_EQ(last_msg_->azel[22].az, 158)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[22].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[22].az)),
+            158)
       << "incorrect value for azel[22].az, expected 158, is "
       << last_msg_->azel[22].az;
-  EXPECT_EQ(last_msg_->azel[22].el, 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[22].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[22].el)),
+            14)
       << "incorrect value for azel[22].el, expected 14, is "
       << last_msg_->azel[22].el;
-  EXPECT_EQ(last_msg_->azel[22].sid.code, 12)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[22].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[22].sid.code)),
+      12)
       << "incorrect value for azel[22].sid.code, expected 12, is "
       << last_msg_->azel[22].sid.code;
-  EXPECT_EQ(last_msg_->azel[22].sid.sat, 29)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[22].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[22].sid.sat)),
+      29)
       << "incorrect value for azel[22].sid.sat, expected 29, is "
       << last_msg_->azel[22].sid.sat;
-  EXPECT_EQ(last_msg_->azel[23].az, 152)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[23].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[23].az)),
+            152)
       << "incorrect value for azel[23].az, expected 152, is "
       << last_msg_->azel[23].az;
-  EXPECT_EQ(last_msg_->azel[23].el, 68)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[23].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[23].el)),
+            68)
       << "incorrect value for azel[23].el, expected 68, is "
       << last_msg_->azel[23].el;
-  EXPECT_EQ(last_msg_->azel[23].sid.code, 12)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[23].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[23].sid.code)),
+      12)
       << "incorrect value for azel[23].sid.code, expected 12, is "
       << last_msg_->azel[23].sid.code;
-  EXPECT_EQ(last_msg_->azel[23].sid.sat, 30)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[23].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[23].sid.sat)),
+      30)
       << "incorrect value for azel[23].sid.sat, expected 30, is "
       << last_msg_->azel[23].sid.sat;
-  EXPECT_EQ(last_msg_->azel[24].az, 120)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[24].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[24].az)),
+            120)
       << "incorrect value for azel[24].az, expected 120, is "
       << last_msg_->azel[24].az;
-  EXPECT_EQ(last_msg_->azel[24].el, 82)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[24].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[24].el)),
+            82)
       << "incorrect value for azel[24].el, expected 82, is "
       << last_msg_->azel[24].el;
-  EXPECT_EQ(last_msg_->azel[24].sid.code, 12)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[24].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[24].sid.code)),
+      12)
       << "incorrect value for azel[24].sid.code, expected 12, is "
       << last_msg_->azel[24].sid.code;
-  EXPECT_EQ(last_msg_->azel[24].sid.sat, 32)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[24].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[24].sid.sat)),
+      32)
       << "incorrect value for azel[24].sid.sat, expected 32, is "
       << last_msg_->azel[24].sid.sat;
-  EXPECT_EQ(last_msg_->azel[25].az, 131)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[25].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[25].az)),
+            131)
       << "incorrect value for azel[25].az, expected 131, is "
       << last_msg_->azel[25].az;
-  EXPECT_EQ(last_msg_->azel[25].el, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[25].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[25].el)),
+            6)
       << "incorrect value for azel[25].el, expected 6, is "
       << last_msg_->azel[25].el;
-  EXPECT_EQ(last_msg_->azel[25].sid.code, 14)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[25].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[25].sid.code)),
+      14)
       << "incorrect value for azel[25].sid.code, expected 14, is "
       << last_msg_->azel[25].sid.code;
-  EXPECT_EQ(last_msg_->azel[25].sid.sat, 2)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[25].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[25].sid.sat)),
+      2)
       << "incorrect value for azel[25].sid.sat, expected 2, is "
       << last_msg_->azel[25].sid.sat;
-  EXPECT_EQ(last_msg_->azel[26].az, 27)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[26].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[26].az)),
+            27)
       << "incorrect value for azel[26].az, expected 27, is "
       << last_msg_->azel[26].az;
-  EXPECT_EQ(last_msg_->azel[26].el, 44)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[26].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[26].el)),
+            44)
       << "incorrect value for azel[26].el, expected 44, is "
       << last_msg_->azel[26].el;
-  EXPECT_EQ(last_msg_->azel[26].sid.code, 14)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[26].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[26].sid.code)),
+      14)
       << "incorrect value for azel[26].sid.code, expected 14, is "
       << last_msg_->azel[26].sid.code;
-  EXPECT_EQ(last_msg_->azel[26].sid.sat, 4)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[26].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[26].sid.sat)),
+      4)
       << "incorrect value for azel[26].sid.sat, expected 4, is "
       << last_msg_->azel[26].sid.sat;
-  EXPECT_EQ(last_msg_->azel[27].az, 101)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[27].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[27].az)),
+            101)
       << "incorrect value for azel[27].az, expected 101, is "
       << last_msg_->azel[27].az;
-  EXPECT_EQ(last_msg_->azel[27].el, 21)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[27].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[27].el)),
+            21)
       << "incorrect value for azel[27].el, expected 21, is "
       << last_msg_->azel[27].el;
-  EXPECT_EQ(last_msg_->azel[27].sid.code, 14)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[27].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[27].sid.code)),
+      14)
       << "incorrect value for azel[27].sid.code, expected 14, is "
       << last_msg_->azel[27].sid.code;
-  EXPECT_EQ(last_msg_->azel[27].sid.sat, 5)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[27].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[27].sid.sat)),
+      5)
       << "incorrect value for azel[27].sid.sat, expected 5, is "
       << last_msg_->azel[27].sid.sat;
-  EXPECT_EQ(last_msg_->azel[28].az, 81)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[28].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[28].az)),
+            81)
       << "incorrect value for azel[28].az, expected 81, is "
       << last_msg_->azel[28].az;
-  EXPECT_EQ(last_msg_->azel[28].el, 65)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[28].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[28].el)),
+            65)
       << "incorrect value for azel[28].el, expected 65, is "
       << last_msg_->azel[28].el;
-  EXPECT_EQ(last_msg_->azel[28].sid.code, 14)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[28].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[28].sid.code)),
+      14)
       << "incorrect value for azel[28].sid.code, expected 14, is "
       << last_msg_->azel[28].sid.code;
-  EXPECT_EQ(last_msg_->azel[28].sid.sat, 9)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[28].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[28].sid.sat)),
+      9)
       << "incorrect value for azel[28].sid.sat, expected 9, is "
       << last_msg_->azel[28].sid.sat;
-  EXPECT_EQ(last_msg_->azel[29].az, 49)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[29].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[29].az)),
+            49)
       << "incorrect value for azel[29].az, expected 49, is "
       << last_msg_->azel[29].az;
-  EXPECT_EQ(last_msg_->azel[29].el, 56)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[29].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[29].el)),
+            56)
       << "incorrect value for azel[29].el, expected 56, is "
       << last_msg_->azel[29].el;
-  EXPECT_EQ(last_msg_->azel[29].sid.code, 14)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[29].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[29].sid.code)),
+      14)
       << "incorrect value for azel[29].sid.code, expected 14, is "
       << last_msg_->azel[29].sid.code;
-  EXPECT_EQ(last_msg_->azel[29].sid.sat, 11)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[29].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[29].sid.sat)),
+      11)
       << "incorrect value for azel[29].sid.sat, expected 11, is "
       << last_msg_->azel[29].sid.sat;
-  EXPECT_EQ(last_msg_->azel[30].az, 59)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[30].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[30].az)),
+            59)
       << "incorrect value for azel[30].az, expected 59, is "
       << last_msg_->azel[30].az;
-  EXPECT_EQ(last_msg_->azel[30].el, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[30].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[30].el)),
+            6)
       << "incorrect value for azel[30].el, expected 6, is "
       << last_msg_->azel[30].el;
-  EXPECT_EQ(last_msg_->azel[30].sid.code, 14)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[30].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[30].sid.code)),
+      14)
       << "incorrect value for azel[30].sid.code, expected 14, is "
       << last_msg_->azel[30].sid.code;
-  EXPECT_EQ(last_msg_->azel[30].sid.sat, 12)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[30].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[30].sid.sat)),
+      12)
       << "incorrect value for azel[30].sid.sat, expected 12, is "
       << last_msg_->azel[30].sid.sat;
-  EXPECT_EQ(last_msg_->azel[31].az, 154)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[31].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[31].az)),
+            154)
       << "incorrect value for azel[31].az, expected 154, is "
       << last_msg_->azel[31].az;
-  EXPECT_EQ(last_msg_->azel[31].el, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[31].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[31].el)),
+            4)
       << "incorrect value for azel[31].el, expected 4, is "
       << last_msg_->azel[31].el;
-  EXPECT_EQ(last_msg_->azel[31].sid.code, 14)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[31].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[31].sid.code)),
+      14)
       << "incorrect value for azel[31].sid.code, expected 14, is "
       << last_msg_->azel[31].sid.code;
-  EXPECT_EQ(last_msg_->azel[31].sid.sat, 30)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[31].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[31].sid.sat)),
+      30)
       << "incorrect value for azel[31].sid.sat, expected 30, is "
       << last_msg_->azel[31].sid.sat;
-  EXPECT_EQ(last_msg_->azel[32].az, 165)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[32].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[32].az)),
+            165)
       << "incorrect value for azel[32].az, expected 165, is "
       << last_msg_->azel[32].az;
-  EXPECT_EQ(last_msg_->azel[32].el, 62)
+  EXPECT_EQ(get_as<decltype(last_msg_->azel[32].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->azel[32].el)),
+            62)
       << "incorrect value for azel[32].el, expected 62, is "
       << last_msg_->azel[32].el;
-  EXPECT_EQ(last_msg_->azel[32].sid.code, 14)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[32].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[32].sid.code)),
+      14)
       << "incorrect value for azel[32].sid.code, expected 14, is "
       << last_msg_->azel[32].sid.code;
-  EXPECT_EQ(last_msg_->azel[32].sid.sat, 36)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->azel[32].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->azel[32].sid.sat)),
+      36)
       << "incorrect value for azel[32].sid.sat, expected 36, is "
       << last_msg_->azel[32].sid.sat;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_observation_MsgSvConfigurationGpsDep.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_MsgSvConfigurationGpsDep.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_MsgSvConfigurationGpsDep0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -114,13 +121,19 @@ TEST_F(Test_legacy_auto_check_sbp_observation_MsgSvConfigurationGpsDep0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 123);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->l2c_mask, 2808462402)
+  EXPECT_EQ(get_as<decltype(last_msg_->l2c_mask)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->l2c_mask)),
+            2808462402)
       << "incorrect value for l2c_mask, expected 2808462402, is "
       << last_msg_->l2c_mask;
-  EXPECT_EQ(last_msg_->t_nmct.tow, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->t_nmct.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->t_nmct.tow)),
+            0)
       << "incorrect value for t_nmct.tow, expected 0, is "
       << last_msg_->t_nmct.tow;
-  EXPECT_EQ(last_msg_->t_nmct.wn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->t_nmct.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->t_nmct.wn)),
+            0)
       << "incorrect value for t_nmct.wn, expected 0, is "
       << last_msg_->t_nmct.wn;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_observation_msgEphemerisDepB.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_msgEphemerisDepB.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_msgEphemerisDepB0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -178,7 +185,9 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgEphemerisDepB0, Test) {
   EXPECT_LT((last_msg_->ecc * 100 - 0.0111326099141 * 100), 0.05)
       << "incorrect value for ecc, expected 0.0111326099141, is "
       << last_msg_->ecc;
-  EXPECT_EQ(last_msg_->healthy, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->healthy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->healthy)),
+            1)
       << "incorrect value for healthy, expected 1, is " << last_msg_->healthy;
   EXPECT_LT((last_msg_->inc * 100 - 0.939552483058 * 100), 0.05)
       << "incorrect value for inc, expected 0.939552483058, is "
@@ -186,7 +195,9 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgEphemerisDepB0, Test) {
   EXPECT_LT((last_msg_->inc_dot * 100 - -3.29656588663e-10 * 100), 0.05)
       << "incorrect value for inc_dot, expected -3.29656588663e-10, is "
       << last_msg_->inc_dot;
-  EXPECT_EQ(last_msg_->iode, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->iode)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iode)),
+            0)
       << "incorrect value for iode, expected 0, is " << last_msg_->iode;
   EXPECT_LT((last_msg_->m0 * 100 - 2.46734839563 * 100), 0.05)
       << "incorrect value for m0, expected 2.46734839563, is " << last_msg_->m0;
@@ -196,7 +207,9 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgEphemerisDepB0, Test) {
   EXPECT_LT((last_msg_->omegadot * 100 - -8.20105589261e-09 * 100), 0.05)
       << "incorrect value for omegadot, expected -8.20105589261e-09, is "
       << last_msg_->omegadot;
-  EXPECT_EQ(last_msg_->prn, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->prn)),
+            3)
       << "incorrect value for prn, expected 3, is " << last_msg_->prn;
   EXPECT_LT((last_msg_->sqrta * 100 - 5153.71430397 * 100), 0.05)
       << "incorrect value for sqrta, expected 5153.71430397, is "
@@ -207,14 +220,20 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgEphemerisDepB0, Test) {
   EXPECT_LT((last_msg_->toc_tow * 100 - 410400.0 * 100), 0.05)
       << "incorrect value for toc_tow, expected 410400.0, is "
       << last_msg_->toc_tow;
-  EXPECT_EQ(last_msg_->toc_wn, 1838)
+  EXPECT_EQ(get_as<decltype(last_msg_->toc_wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->toc_wn)),
+            1838)
       << "incorrect value for toc_wn, expected 1838, is " << last_msg_->toc_wn;
   EXPECT_LT((last_msg_->toe_tow * 100 - 410400.0 * 100), 0.05)
       << "incorrect value for toe_tow, expected 410400.0, is "
       << last_msg_->toe_tow;
-  EXPECT_EQ(last_msg_->toe_wn, 1838)
+  EXPECT_EQ(get_as<decltype(last_msg_->toe_wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->toe_wn)),
+            1838)
       << "incorrect value for toe_wn, expected 1838, is " << last_msg_->toe_wn;
-  EXPECT_EQ(last_msg_->valid, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->valid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->valid)),
+            1)
       << "incorrect value for valid, expected 1, is " << last_msg_->valid;
   EXPECT_LT((last_msg_->w * 100 - 1.05250472004 * 100), 0.05)
       << "incorrect value for w, expected 1.05250472004, is " << last_msg_->w;
@@ -368,7 +387,9 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgEphemerisDepB1, Test) {
   EXPECT_LT((last_msg_->ecc * 100 - 0.00792274158448 * 100), 0.05)
       << "incorrect value for ecc, expected 0.00792274158448, is "
       << last_msg_->ecc;
-  EXPECT_EQ(last_msg_->healthy, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->healthy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->healthy)),
+            1)
       << "incorrect value for healthy, expected 1, is " << last_msg_->healthy;
   EXPECT_LT((last_msg_->inc * 100 - 0.966901291823 * 100), 0.05)
       << "incorrect value for inc, expected 0.966901291823, is "
@@ -376,7 +397,9 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgEphemerisDepB1, Test) {
   EXPECT_LT((last_msg_->inc_dot * 100 - 2.62510934634e-10 * 100), 0.05)
       << "incorrect value for inc_dot, expected 2.62510934634e-10, is "
       << last_msg_->inc_dot;
-  EXPECT_EQ(last_msg_->iode, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->iode)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iode)),
+            0)
       << "incorrect value for iode, expected 0, is " << last_msg_->iode;
   EXPECT_LT((last_msg_->m0 * 100 - -1.58816085572 * 100), 0.05)
       << "incorrect value for m0, expected -1.58816085572, is "
@@ -387,7 +410,9 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgEphemerisDepB1, Test) {
   EXPECT_LT((last_msg_->omegadot * 100 - -8.29570269217e-09 * 100), 0.05)
       << "incorrect value for omegadot, expected -8.29570269217e-09, is "
       << last_msg_->omegadot;
-  EXPECT_EQ(last_msg_->prn, 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->prn)),
+            13)
       << "incorrect value for prn, expected 13, is " << last_msg_->prn;
   EXPECT_LT((last_msg_->sqrta * 100 - 5153.57085609 * 100), 0.05)
       << "incorrect value for sqrta, expected 5153.57085609, is "
@@ -398,14 +423,20 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgEphemerisDepB1, Test) {
   EXPECT_LT((last_msg_->toc_tow * 100 - 410400.0 * 100), 0.05)
       << "incorrect value for toc_tow, expected 410400.0, is "
       << last_msg_->toc_tow;
-  EXPECT_EQ(last_msg_->toc_wn, 1838)
+  EXPECT_EQ(get_as<decltype(last_msg_->toc_wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->toc_wn)),
+            1838)
       << "incorrect value for toc_wn, expected 1838, is " << last_msg_->toc_wn;
   EXPECT_LT((last_msg_->toe_tow * 100 - 410400.0 * 100), 0.05)
       << "incorrect value for toe_tow, expected 410400.0, is "
       << last_msg_->toe_tow;
-  EXPECT_EQ(last_msg_->toe_wn, 1838)
+  EXPECT_EQ(get_as<decltype(last_msg_->toe_wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->toe_wn)),
+            1838)
       << "incorrect value for toe_wn, expected 1838, is " << last_msg_->toe_wn;
-  EXPECT_EQ(last_msg_->valid, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->valid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->valid)),
+            1)
       << "incorrect value for valid, expected 1, is " << last_msg_->valid;
   EXPECT_LT((last_msg_->w * 100 - -1.97360228379 * 100), 0.05)
       << "incorrect value for w, expected -1.97360228379, is " << last_msg_->w;
@@ -559,7 +590,9 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgEphemerisDepB2, Test) {
   EXPECT_LT((last_msg_->ecc * 100 - 0.00404041714501 * 100), 0.05)
       << "incorrect value for ecc, expected 0.00404041714501, is "
       << last_msg_->ecc;
-  EXPECT_EQ(last_msg_->healthy, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->healthy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->healthy)),
+            1)
       << "incorrect value for healthy, expected 1, is " << last_msg_->healthy;
   EXPECT_LT((last_msg_->inc * 100 - 0.96190219207 * 100), 0.05)
       << "incorrect value for inc, expected 0.96190219207, is "
@@ -567,7 +600,9 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgEphemerisDepB2, Test) {
   EXPECT_LT((last_msg_->inc_dot * 100 - -3.36442585613e-10 * 100), 0.05)
       << "incorrect value for inc_dot, expected -3.36442585613e-10, is "
       << last_msg_->inc_dot;
-  EXPECT_EQ(last_msg_->iode, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->iode)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iode)),
+            0)
       << "incorrect value for iode, expected 0, is " << last_msg_->iode;
   EXPECT_LT((last_msg_->m0 * 100 - 2.70552550587 * 100), 0.05)
       << "incorrect value for m0, expected 2.70552550587, is " << last_msg_->m0;
@@ -577,7 +612,9 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgEphemerisDepB2, Test) {
   EXPECT_LT((last_msg_->omegadot * 100 - -8.08212236712e-09 * 100), 0.05)
       << "incorrect value for omegadot, expected -8.08212236712e-09, is "
       << last_msg_->omegadot;
-  EXPECT_EQ(last_msg_->prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->prn)),
+            0)
       << "incorrect value for prn, expected 0, is " << last_msg_->prn;
   EXPECT_LT((last_msg_->sqrta * 100 - 5153.66935349 * 100), 0.05)
       << "incorrect value for sqrta, expected 5153.66935349, is "
@@ -588,14 +625,20 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgEphemerisDepB2, Test) {
   EXPECT_LT((last_msg_->toc_tow * 100 - 410400.0 * 100), 0.05)
       << "incorrect value for toc_tow, expected 410400.0, is "
       << last_msg_->toc_tow;
-  EXPECT_EQ(last_msg_->toc_wn, 1838)
+  EXPECT_EQ(get_as<decltype(last_msg_->toc_wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->toc_wn)),
+            1838)
       << "incorrect value for toc_wn, expected 1838, is " << last_msg_->toc_wn;
   EXPECT_LT((last_msg_->toe_tow * 100 - 410400.0 * 100), 0.05)
       << "incorrect value for toe_tow, expected 410400.0, is "
       << last_msg_->toe_tow;
-  EXPECT_EQ(last_msg_->toe_wn, 1838)
+  EXPECT_EQ(get_as<decltype(last_msg_->toe_wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->toe_wn)),
+            1838)
       << "incorrect value for toe_wn, expected 1838, is " << last_msg_->toe_wn;
-  EXPECT_EQ(last_msg_->valid, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->valid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->valid)),
+            1)
       << "incorrect value for valid, expected 1, is " << last_msg_->valid;
   EXPECT_LT((last_msg_->w * 100 - 0.378735666146 * 100), 0.05)
       << "incorrect value for w, expected 0.378735666146, is " << last_msg_->w;
@@ -749,7 +792,9 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgEphemerisDepB3, Test) {
   EXPECT_LT((last_msg_->ecc * 100 - 0.00792274158448 * 100), 0.05)
       << "incorrect value for ecc, expected 0.00792274158448, is "
       << last_msg_->ecc;
-  EXPECT_EQ(last_msg_->healthy, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->healthy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->healthy)),
+            1)
       << "incorrect value for healthy, expected 1, is " << last_msg_->healthy;
   EXPECT_LT((last_msg_->inc * 100 - 0.966901291823 * 100), 0.05)
       << "incorrect value for inc, expected 0.966901291823, is "
@@ -757,7 +802,9 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgEphemerisDepB3, Test) {
   EXPECT_LT((last_msg_->inc_dot * 100 - 2.62510934634e-10 * 100), 0.05)
       << "incorrect value for inc_dot, expected 2.62510934634e-10, is "
       << last_msg_->inc_dot;
-  EXPECT_EQ(last_msg_->iode, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->iode)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iode)),
+            0)
       << "incorrect value for iode, expected 0, is " << last_msg_->iode;
   EXPECT_LT((last_msg_->m0 * 100 - -1.58816085572 * 100), 0.05)
       << "incorrect value for m0, expected -1.58816085572, is "
@@ -768,7 +815,9 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgEphemerisDepB3, Test) {
   EXPECT_LT((last_msg_->omegadot * 100 - -8.29570269217e-09 * 100), 0.05)
       << "incorrect value for omegadot, expected -8.29570269217e-09, is "
       << last_msg_->omegadot;
-  EXPECT_EQ(last_msg_->prn, 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->prn)),
+            13)
       << "incorrect value for prn, expected 13, is " << last_msg_->prn;
   EXPECT_LT((last_msg_->sqrta * 100 - 5153.57085609 * 100), 0.05)
       << "incorrect value for sqrta, expected 5153.57085609, is "
@@ -779,14 +828,20 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgEphemerisDepB3, Test) {
   EXPECT_LT((last_msg_->toc_tow * 100 - 410400.0 * 100), 0.05)
       << "incorrect value for toc_tow, expected 410400.0, is "
       << last_msg_->toc_tow;
-  EXPECT_EQ(last_msg_->toc_wn, 1838)
+  EXPECT_EQ(get_as<decltype(last_msg_->toc_wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->toc_wn)),
+            1838)
       << "incorrect value for toc_wn, expected 1838, is " << last_msg_->toc_wn;
   EXPECT_LT((last_msg_->toe_tow * 100 - 410400.0 * 100), 0.05)
       << "incorrect value for toe_tow, expected 410400.0, is "
       << last_msg_->toe_tow;
-  EXPECT_EQ(last_msg_->toe_wn, 1838)
+  EXPECT_EQ(get_as<decltype(last_msg_->toe_wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->toe_wn)),
+            1838)
       << "incorrect value for toe_wn, expected 1838, is " << last_msg_->toe_wn;
-  EXPECT_EQ(last_msg_->valid, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->valid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->valid)),
+            1)
       << "incorrect value for valid, expected 1, is " << last_msg_->valid;
   EXPECT_LT((last_msg_->w * 100 - -1.97360228379 * 100), 0.05)
       << "incorrect value for w, expected -1.97360228379, is " << last_msg_->w;
@@ -940,7 +995,9 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgEphemerisDepB4, Test) {
   EXPECT_LT((last_msg_->ecc * 100 - 0.00992374494672 * 100), 0.05)
       << "incorrect value for ecc, expected 0.00992374494672, is "
       << last_msg_->ecc;
-  EXPECT_EQ(last_msg_->healthy, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->healthy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->healthy)),
+            1)
       << "incorrect value for healthy, expected 1, is " << last_msg_->healthy;
   EXPECT_LT((last_msg_->inc * 100 - 0.948751322181 * 100), 0.05)
       << "incorrect value for inc, expected 0.948751322181, is "
@@ -948,7 +1005,9 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgEphemerisDepB4, Test) {
   EXPECT_LT((last_msg_->inc_dot * 100 - 3.00012496725e-10 * 100), 0.05)
       << "incorrect value for inc_dot, expected 3.00012496725e-10, is "
       << last_msg_->inc_dot;
-  EXPECT_EQ(last_msg_->iode, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->iode)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iode)),
+            0)
       << "incorrect value for iode, expected 0, is " << last_msg_->iode;
   EXPECT_LT((last_msg_->m0 * 100 - -2.66616027191 * 100), 0.05)
       << "incorrect value for m0, expected -2.66616027191, is "
@@ -959,7 +1018,9 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgEphemerisDepB4, Test) {
   EXPECT_LT((last_msg_->omegadot * 100 - -8.4599952499e-09 * 100), 0.05)
       << "incorrect value for omegadot, expected -8.4599952499e-09, is "
       << last_msg_->omegadot;
-  EXPECT_EQ(last_msg_->prn, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->prn)),
+            22)
       << "incorrect value for prn, expected 22, is " << last_msg_->prn;
   EXPECT_LT((last_msg_->sqrta * 100 - 5153.63666725 * 100), 0.05)
       << "incorrect value for sqrta, expected 5153.63666725, is "
@@ -970,14 +1031,20 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgEphemerisDepB4, Test) {
   EXPECT_LT((last_msg_->toc_tow * 100 - 410400.0 * 100), 0.05)
       << "incorrect value for toc_tow, expected 410400.0, is "
       << last_msg_->toc_tow;
-  EXPECT_EQ(last_msg_->toc_wn, 1838)
+  EXPECT_EQ(get_as<decltype(last_msg_->toc_wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->toc_wn)),
+            1838)
       << "incorrect value for toc_wn, expected 1838, is " << last_msg_->toc_wn;
   EXPECT_LT((last_msg_->toe_tow * 100 - 410400.0 * 100), 0.05)
       << "incorrect value for toe_tow, expected 410400.0, is "
       << last_msg_->toe_tow;
-  EXPECT_EQ(last_msg_->toe_wn, 1838)
+  EXPECT_EQ(get_as<decltype(last_msg_->toe_wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->toe_wn)),
+            1838)
       << "incorrect value for toe_wn, expected 1838, is " << last_msg_->toe_wn;
-  EXPECT_EQ(last_msg_->valid, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->valid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->valid)),
+            1)
       << "incorrect value for valid, expected 1, is " << last_msg_->valid;
   EXPECT_LT((last_msg_->w * 100 - -2.70212414527 * 100), 0.05)
       << "incorrect value for w, expected -2.70212414527, is " << last_msg_->w;
@@ -1131,7 +1198,9 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgEphemerisDepB5, Test) {
   EXPECT_LT((last_msg_->ecc * 100 - 0.00817864493001 * 100), 0.05)
       << "incorrect value for ecc, expected 0.00817864493001, is "
       << last_msg_->ecc;
-  EXPECT_EQ(last_msg_->healthy, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->healthy)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->healthy)),
+            1)
       << "incorrect value for healthy, expected 1, is " << last_msg_->healthy;
   EXPECT_LT((last_msg_->inc * 100 - 0.975512201725 * 100), 0.05)
       << "incorrect value for inc, expected 0.975512201725, is "
@@ -1139,7 +1208,9 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgEphemerisDepB5, Test) {
   EXPECT_LT((last_msg_->inc_dot * 100 - -5.88238788221e-10 * 100), 0.05)
       << "incorrect value for inc_dot, expected -5.88238788221e-10, is "
       << last_msg_->inc_dot;
-  EXPECT_EQ(last_msg_->iode, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->iode)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iode)),
+            0)
       << "incorrect value for iode, expected 0, is " << last_msg_->iode;
   EXPECT_LT((last_msg_->m0 * 100 - 1.94018234598 * 100), 0.05)
       << "incorrect value for m0, expected 1.94018234598, is " << last_msg_->m0;
@@ -1149,7 +1220,9 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgEphemerisDepB5, Test) {
   EXPECT_LT((last_msg_->omegadot * 100 - -7.96247452617e-09 * 100), 0.05)
       << "incorrect value for omegadot, expected -7.96247452617e-09, is "
       << last_msg_->omegadot;
-  EXPECT_EQ(last_msg_->prn, 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->prn)),
+            30)
       << "incorrect value for prn, expected 30, is " << last_msg_->prn;
   EXPECT_LT((last_msg_->sqrta * 100 - 5153.75399208 * 100), 0.05)
       << "incorrect value for sqrta, expected 5153.75399208, is "
@@ -1160,14 +1233,20 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgEphemerisDepB5, Test) {
   EXPECT_LT((last_msg_->toc_tow * 100 - 410400.0 * 100), 0.05)
       << "incorrect value for toc_tow, expected 410400.0, is "
       << last_msg_->toc_tow;
-  EXPECT_EQ(last_msg_->toc_wn, 1838)
+  EXPECT_EQ(get_as<decltype(last_msg_->toc_wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->toc_wn)),
+            1838)
       << "incorrect value for toc_wn, expected 1838, is " << last_msg_->toc_wn;
   EXPECT_LT((last_msg_->toe_tow * 100 - 410400.0 * 100), 0.05)
       << "incorrect value for toe_tow, expected 410400.0, is "
       << last_msg_->toe_tow;
-  EXPECT_EQ(last_msg_->toe_wn, 1838)
+  EXPECT_EQ(get_as<decltype(last_msg_->toe_wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->toe_wn)),
+            1838)
       << "incorrect value for toe_wn, expected 1838, is " << last_msg_->toe_wn;
-  EXPECT_EQ(last_msg_->valid, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->valid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->valid)),
+            1)
       << "incorrect value for valid, expected 1, is " << last_msg_->valid;
   EXPECT_LT((last_msg_->w * 100 - -0.523790171609 * 100), 0.05)
       << "incorrect value for w, expected -0.523790171609, is " << last_msg_->w;

--- a/c/test/legacy/cpp/auto_check_sbp_observation_msgEphemerisQzss.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_msgEphemerisQzss.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_msgEphemerisQzss0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -173,28 +180,44 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgEphemerisQzss0, Test) {
   EXPECT_LT((last_msg_->c_us * 100 - 8.24779272079e-06 * 100), 0.05)
       << "incorrect value for c_us, expected 8.24779272079e-06, is "
       << last_msg_->c_us;
-  EXPECT_EQ(last_msg_->common.fit_interval, 14400)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.fit_interval)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.fit_interval)),
+      14400)
       << "incorrect value for common.fit_interval, expected 14400, is "
       << last_msg_->common.fit_interval;
-  EXPECT_EQ(last_msg_->common.health_bits, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->common.health_bits)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->common.health_bits)),
+      0)
       << "incorrect value for common.health_bits, expected 0, is "
       << last_msg_->common.health_bits;
-  EXPECT_EQ(last_msg_->common.sid.code, 31)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.code)),
+            31)
       << "incorrect value for common.sid.code, expected 31, is "
       << last_msg_->common.sid.code;
-  EXPECT_EQ(last_msg_->common.sid.sat, 193)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.sid.sat)),
+            193)
       << "incorrect value for common.sid.sat, expected 193, is "
       << last_msg_->common.sid.sat;
-  EXPECT_EQ(last_msg_->common.toe.tow, 450000)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toe.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toe.tow)),
+            450000)
       << "incorrect value for common.toe.tow, expected 450000, is "
       << last_msg_->common.toe.tow;
-  EXPECT_EQ(last_msg_->common.toe.wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.toe.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.toe.wn)),
+            2154)
       << "incorrect value for common.toe.wn, expected 2154, is "
       << last_msg_->common.toe.wn;
   EXPECT_LT((last_msg_->common.ura * 100 - 2.0 * 100), 0.05)
       << "incorrect value for common.ura, expected 2.0, is "
       << last_msg_->common.ura;
-  EXPECT_EQ(last_msg_->common.valid, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->common.valid)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->common.valid)),
+            0)
       << "incorrect value for common.valid, expected 0, is "
       << last_msg_->common.valid;
   EXPECT_LT((last_msg_->dn * 100 - 2.67832584874e-09 * 100), 0.05)
@@ -209,9 +232,13 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgEphemerisQzss0, Test) {
   EXPECT_LT((last_msg_->inc_dot * 100 - 2.0000833115e-11 * 100), 0.05)
       << "incorrect value for inc_dot, expected 2.0000833115e-11, is "
       << last_msg_->inc_dot;
-  EXPECT_EQ(last_msg_->iodc, 817)
+  EXPECT_EQ(get_as<decltype(last_msg_->iodc)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iodc)),
+            817)
       << "incorrect value for iodc, expected 817, is " << last_msg_->iodc;
-  EXPECT_EQ(last_msg_->iode, 49)
+  EXPECT_EQ(get_as<decltype(last_msg_->iode)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iode)),
+            49)
       << "incorrect value for iode, expected 49, is " << last_msg_->iode;
   EXPECT_LT((last_msg_->m0 * 100 - 0.30694242159 * 100), 0.05)
       << "incorrect value for m0, expected 0.30694242159, is " << last_msg_->m0;
@@ -227,10 +254,14 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgEphemerisQzss0, Test) {
   EXPECT_LT((last_msg_->tgd * 100 - -5.58793544769e-09 * 100), 0.05)
       << "incorrect value for tgd, expected -5.58793544769e-09, is "
       << last_msg_->tgd;
-  EXPECT_EQ(last_msg_->toc.tow, 450000)
+  EXPECT_EQ(get_as<decltype(last_msg_->toc.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->toc.tow)),
+            450000)
       << "incorrect value for toc.tow, expected 450000, is "
       << last_msg_->toc.tow;
-  EXPECT_EQ(last_msg_->toc.wn, 2154)
+  EXPECT_EQ(get_as<decltype(last_msg_->toc.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->toc.wn)),
+            2154)
       << "incorrect value for toc.wn, expected 2154, is " << last_msg_->toc.wn;
   EXPECT_LT((last_msg_->w * 100 - -1.56620796909 * 100), 0.05)
       << "incorrect value for w, expected -1.56620796909, is " << last_msg_->w;

--- a/c/test/legacy/cpp/auto_check_sbp_observation_msgObsDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_observation_msgObsDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/observation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_observation_msgObsDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -189,139 +196,229 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgObsDepA0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->header.n_obs, 32)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.n_obs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.n_obs)),
+            32)
       << "incorrect value for header.n_obs, expected 32, is "
       << last_msg_->header.n_obs;
-  EXPECT_EQ(last_msg_->header.t.tow, 407084600)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.tow)),
+            407084600)
       << "incorrect value for header.t.tow, expected 407084600, is "
       << last_msg_->header.t.tow;
-  EXPECT_EQ(last_msg_->header.t.wn, 1838)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.wn)),
+            1838)
       << "incorrect value for header.t.wn, expected 1838, is "
       << last_msg_->header.t.wn;
-  EXPECT_EQ(last_msg_->obs[0].L.f, 33)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.f)),
+            33)
       << "incorrect value for obs[0].L.f, expected 33, is "
       << last_msg_->obs[0].L.f;
-  EXPECT_EQ(last_msg_->obs[0].L.i, -36108)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.i)),
+            -36108)
       << "incorrect value for obs[0].L.i, expected -36108, is "
       << last_msg_->obs[0].L.i;
-  EXPECT_EQ(last_msg_->obs[0].P, 2046421816)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].P)),
+            2046421816)
       << "incorrect value for obs[0].P, expected 2046421816, is "
       << last_msg_->obs[0].P;
-  EXPECT_EQ(last_msg_->obs[0].cn0, 46)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].cn0)),
+            46)
       << "incorrect value for obs[0].cn0, expected 46, is "
       << last_msg_->obs[0].cn0;
-  EXPECT_EQ(last_msg_->obs[0].lock, 55875)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].lock)),
+            55875)
       << "incorrect value for obs[0].lock, expected 55875, is "
       << last_msg_->obs[0].lock;
-  EXPECT_EQ(last_msg_->obs[0].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].prn)),
+            0)
       << "incorrect value for obs[0].prn, expected 0, is "
       << last_msg_->obs[0].prn;
-  EXPECT_EQ(last_msg_->obs[1].L.f, 98)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].L.f)),
+            98)
       << "incorrect value for obs[1].L.f, expected 98, is "
       << last_msg_->obs[1].L.f;
-  EXPECT_EQ(last_msg_->obs[1].L.i, 203030)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].L.i)),
+            203030)
       << "incorrect value for obs[1].L.i, expected 203030, is "
       << last_msg_->obs[1].L.i;
-  EXPECT_EQ(last_msg_->obs[1].P, 2085014510)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].P)),
+            2085014510)
       << "incorrect value for obs[1].P, expected 2085014510, is "
       << last_msg_->obs[1].P;
-  EXPECT_EQ(last_msg_->obs[1].cn0, 43)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].cn0)),
+            43)
       << "incorrect value for obs[1].cn0, expected 43, is "
       << last_msg_->obs[1].cn0;
-  EXPECT_EQ(last_msg_->obs[1].lock, 40376)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].lock)),
+            40376)
       << "incorrect value for obs[1].lock, expected 40376, is "
       << last_msg_->obs[1].lock;
-  EXPECT_EQ(last_msg_->obs[1].prn, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].prn)),
+            2)
       << "incorrect value for obs[1].prn, expected 2, is "
       << last_msg_->obs[1].prn;
-  EXPECT_EQ(last_msg_->obs[2].L.f, 185)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].L.f)),
+            185)
       << "incorrect value for obs[2].L.f, expected 185, is "
       << last_msg_->obs[2].L.f;
-  EXPECT_EQ(last_msg_->obs[2].L.i, -178306)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].L.i)),
+            -178306)
       << "incorrect value for obs[2].L.i, expected -178306, is "
       << last_msg_->obs[2].L.i;
-  EXPECT_EQ(last_msg_->obs[2].P, 2110096816)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].P)),
+            2110096816)
       << "incorrect value for obs[2].P, expected 2110096816, is "
       << last_msg_->obs[2].P;
-  EXPECT_EQ(last_msg_->obs[2].cn0, 39)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].cn0)),
+            39)
       << "incorrect value for obs[2].cn0, expected 39, is "
       << last_msg_->obs[2].cn0;
-  EXPECT_EQ(last_msg_->obs[2].lock, 14148)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].lock)),
+            14148)
       << "incorrect value for obs[2].lock, expected 14148, is "
       << last_msg_->obs[2].lock;
-  EXPECT_EQ(last_msg_->obs[2].prn, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].prn)),
+            3)
       << "incorrect value for obs[2].prn, expected 3, is "
       << last_msg_->obs[2].prn;
-  EXPECT_EQ(last_msg_->obs[3].L.f, 139)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].L.f)),
+            139)
       << "incorrect value for obs[3].L.f, expected 139, is "
       << last_msg_->obs[3].L.f;
-  EXPECT_EQ(last_msg_->obs[3].L.i, -137374)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].L.i)),
+            -137374)
       << "incorrect value for obs[3].L.i, expected -137374, is "
       << last_msg_->obs[3].L.i;
-  EXPECT_EQ(last_msg_->obs[3].P, 2208476476)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].P)),
+            2208476476)
       << "incorrect value for obs[3].P, expected 2208476476, is "
       << last_msg_->obs[3].P;
-  EXPECT_EQ(last_msg_->obs[3].cn0, 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].cn0)),
+            30)
       << "incorrect value for obs[3].cn0, expected 30, is "
       << last_msg_->obs[3].cn0;
-  EXPECT_EQ(last_msg_->obs[3].lock, 4129)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].lock)),
+            4129)
       << "incorrect value for obs[3].lock, expected 4129, is "
       << last_msg_->obs[3].lock;
-  EXPECT_EQ(last_msg_->obs[3].prn, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].prn)),
+            10)
       << "incorrect value for obs[3].prn, expected 10, is "
       << last_msg_->obs[3].prn;
-  EXPECT_EQ(last_msg_->obs[4].L.f, 40)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].L.f)),
+            40)
       << "incorrect value for obs[4].L.f, expected 40, is "
       << last_msg_->obs[4].L.f;
-  EXPECT_EQ(last_msg_->obs[4].L.i, -167638)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].L.i)),
+            -167638)
       << "incorrect value for obs[4].L.i, expected -167638, is "
       << last_msg_->obs[4].L.i;
-  EXPECT_EQ(last_msg_->obs[4].P, 2298000000)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].P)),
+            2298000000)
       << "incorrect value for obs[4].P, expected 2298000000, is "
       << last_msg_->obs[4].P;
-  EXPECT_EQ(last_msg_->obs[4].cn0, 20)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].cn0)),
+            20)
       << "incorrect value for obs[4].cn0, expected 20, is "
       << last_msg_->obs[4].cn0;
-  EXPECT_EQ(last_msg_->obs[4].lock, 18218)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].lock)),
+            18218)
       << "incorrect value for obs[4].lock, expected 18218, is "
       << last_msg_->obs[4].lock;
-  EXPECT_EQ(last_msg_->obs[4].prn, 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].prn)),
+            13)
       << "incorrect value for obs[4].prn, expected 13, is "
       << last_msg_->obs[4].prn;
-  EXPECT_EQ(last_msg_->obs[5].L.f, 64)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].L.f)),
+            64)
       << "incorrect value for obs[5].L.f, expected 64, is "
       << last_msg_->obs[5].L.f;
-  EXPECT_EQ(last_msg_->obs[5].L.i, 209919)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].L.i)),
+            209919)
       << "incorrect value for obs[5].L.i, expected 209919, is "
       << last_msg_->obs[5].L.i;
-  EXPECT_EQ(last_msg_->obs[5].P, 2266101494)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].P)),
+            2266101494)
       << "incorrect value for obs[5].P, expected 2266101494, is "
       << last_msg_->obs[5].P;
-  EXPECT_EQ(last_msg_->obs[5].cn0, 27)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].cn0)),
+            27)
       << "incorrect value for obs[5].cn0, expected 27, is "
       << last_msg_->obs[5].cn0;
-  EXPECT_EQ(last_msg_->obs[5].lock, 63852)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].lock)),
+            63852)
       << "incorrect value for obs[5].lock, expected 63852, is "
       << last_msg_->obs[5].lock;
-  EXPECT_EQ(last_msg_->obs[5].prn, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].prn)),
+            22)
       << "incorrect value for obs[5].prn, expected 22, is "
       << last_msg_->obs[5].prn;
-  EXPECT_EQ(last_msg_->obs[6].L.f, 31)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[6].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[6].L.f)),
+            31)
       << "incorrect value for obs[6].L.f, expected 31, is "
       << last_msg_->obs[6].L.f;
-  EXPECT_EQ(last_msg_->obs[6].L.i, -53117)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[6].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[6].L.i)),
+            -53117)
       << "incorrect value for obs[6].L.i, expected -53117, is "
       << last_msg_->obs[6].L.i;
-  EXPECT_EQ(last_msg_->obs[6].P, 1987193298)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[6].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[6].P)),
+            1987193298)
       << "incorrect value for obs[6].P, expected 1987193298, is "
       << last_msg_->obs[6].P;
-  EXPECT_EQ(last_msg_->obs[6].cn0, 52)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[6].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[6].cn0)),
+            52)
       << "incorrect value for obs[6].cn0, expected 52, is "
       << last_msg_->obs[6].cn0;
-  EXPECT_EQ(last_msg_->obs[6].lock, 15074)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[6].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[6].lock)),
+            15074)
       << "incorrect value for obs[6].lock, expected 15074, is "
       << last_msg_->obs[6].lock;
-  EXPECT_EQ(last_msg_->obs[6].prn, 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[6].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[6].prn)),
+            30)
       << "incorrect value for obs[6].prn, expected 30, is "
       << last_msg_->obs[6].prn;
 }
@@ -419,31 +516,49 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgObsDepA1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->header.n_obs, 33)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.n_obs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.n_obs)),
+            33)
       << "incorrect value for header.n_obs, expected 33, is "
       << last_msg_->header.n_obs;
-  EXPECT_EQ(last_msg_->header.t.tow, 407084600)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.tow)),
+            407084600)
       << "incorrect value for header.t.tow, expected 407084600, is "
       << last_msg_->header.t.tow;
-  EXPECT_EQ(last_msg_->header.t.wn, 1838)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.wn)),
+            1838)
       << "incorrect value for header.t.wn, expected 1838, is "
       << last_msg_->header.t.wn;
-  EXPECT_EQ(last_msg_->obs[0].L.f, 147)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.f)),
+            147)
       << "incorrect value for obs[0].L.f, expected 147, is "
       << last_msg_->obs[0].L.f;
-  EXPECT_EQ(last_msg_->obs[0].L.i, 8294)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.i)),
+            8294)
       << "incorrect value for obs[0].L.i, expected 8294, is "
       << last_msg_->obs[0].L.i;
-  EXPECT_EQ(last_msg_->obs[0].P, 1973695572)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].P)),
+            1973695572)
       << "incorrect value for obs[0].P, expected 1973695572, is "
       << last_msg_->obs[0].P;
-  EXPECT_EQ(last_msg_->obs[0].cn0, 62)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].cn0)),
+            62)
       << "incorrect value for obs[0].cn0, expected 62, is "
       << last_msg_->obs[0].cn0;
-  EXPECT_EQ(last_msg_->obs[0].lock, 64062)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].lock)),
+            64062)
       << "incorrect value for obs[0].lock, expected 64062, is "
       << last_msg_->obs[0].lock;
-  EXPECT_EQ(last_msg_->obs[0].prn, 31)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].prn)),
+            31)
       << "incorrect value for obs[0].prn, expected 31, is "
       << last_msg_->obs[0].prn;
 }
@@ -607,139 +722,229 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgObsDepA2, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->header.n_obs, 32)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.n_obs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.n_obs)),
+            32)
       << "incorrect value for header.n_obs, expected 32, is "
       << last_msg_->header.n_obs;
-  EXPECT_EQ(last_msg_->header.t.tow, 407084800)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.tow)),
+            407084800)
       << "incorrect value for header.t.tow, expected 407084800, is "
       << last_msg_->header.t.tow;
-  EXPECT_EQ(last_msg_->header.t.wn, 1838)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.wn)),
+            1838)
       << "incorrect value for header.t.wn, expected 1838, is "
       << last_msg_->header.t.wn;
-  EXPECT_EQ(last_msg_->obs[0].L.f, 141)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.f)),
+            141)
       << "incorrect value for obs[0].L.f, expected 141, is "
       << last_msg_->obs[0].L.f;
-  EXPECT_EQ(last_msg_->obs[0].L.i, -36207)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.i)),
+            -36207)
       << "incorrect value for obs[0].L.i, expected -36207, is "
       << last_msg_->obs[0].L.i;
-  EXPECT_EQ(last_msg_->obs[0].P, 2046415136)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].P)),
+            2046415136)
       << "incorrect value for obs[0].P, expected 2046415136, is "
       << last_msg_->obs[0].P;
-  EXPECT_EQ(last_msg_->obs[0].cn0, 45)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].cn0)),
+            45)
       << "incorrect value for obs[0].cn0, expected 45, is "
       << last_msg_->obs[0].cn0;
-  EXPECT_EQ(last_msg_->obs[0].lock, 55875)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].lock)),
+            55875)
       << "incorrect value for obs[0].lock, expected 55875, is "
       << last_msg_->obs[0].lock;
-  EXPECT_EQ(last_msg_->obs[0].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].prn)),
+            0)
       << "incorrect value for obs[0].prn, expected 0, is "
       << last_msg_->obs[0].prn;
-  EXPECT_EQ(last_msg_->obs[1].L.f, 159)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].L.f)),
+            159)
       << "incorrect value for obs[1].L.f, expected 159, is "
       << last_msg_->obs[1].L.f;
-  EXPECT_EQ(last_msg_->obs[1].L.i, 203599)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].L.i)),
+            203599)
       << "incorrect value for obs[1].L.i, expected 203599, is "
       << last_msg_->obs[1].L.i;
-  EXPECT_EQ(last_msg_->obs[1].P, 2084995249)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].P)),
+            2084995249)
       << "incorrect value for obs[1].P, expected 2084995249, is "
       << last_msg_->obs[1].P;
-  EXPECT_EQ(last_msg_->obs[1].cn0, 44)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].cn0)),
+            44)
       << "incorrect value for obs[1].cn0, expected 44, is "
       << last_msg_->obs[1].cn0;
-  EXPECT_EQ(last_msg_->obs[1].lock, 40376)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].lock)),
+            40376)
       << "incorrect value for obs[1].lock, expected 40376, is "
       << last_msg_->obs[1].lock;
-  EXPECT_EQ(last_msg_->obs[1].prn, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].prn)),
+            2)
       << "incorrect value for obs[1].prn, expected 2, is "
       << last_msg_->obs[1].prn;
-  EXPECT_EQ(last_msg_->obs[2].L.f, 77)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].L.f)),
+            77)
       << "incorrect value for obs[2].L.f, expected 77, is "
       << last_msg_->obs[2].L.f;
-  EXPECT_EQ(last_msg_->obs[2].L.i, -178769)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].L.i)),
+            -178769)
       << "incorrect value for obs[2].L.i, expected -178769, is "
       << last_msg_->obs[2].L.i;
-  EXPECT_EQ(last_msg_->obs[2].P, 2110097211)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].P)),
+            2110097211)
       << "incorrect value for obs[2].P, expected 2110097211, is "
       << last_msg_->obs[2].P;
-  EXPECT_EQ(last_msg_->obs[2].cn0, 40)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].cn0)),
+            40)
       << "incorrect value for obs[2].cn0, expected 40, is "
       << last_msg_->obs[2].cn0;
-  EXPECT_EQ(last_msg_->obs[2].lock, 14148)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].lock)),
+            14148)
       << "incorrect value for obs[2].lock, expected 14148, is "
       << last_msg_->obs[2].lock;
-  EXPECT_EQ(last_msg_->obs[2].prn, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].prn)),
+            3)
       << "incorrect value for obs[2].prn, expected 3, is "
       << last_msg_->obs[2].prn;
-  EXPECT_EQ(last_msg_->obs[3].L.f, 20)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].L.f)),
+            20)
       << "incorrect value for obs[3].L.f, expected 20, is "
       << last_msg_->obs[3].L.f;
-  EXPECT_EQ(last_msg_->obs[3].L.i, -137807)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].L.i)),
+            -137807)
       << "incorrect value for obs[3].L.i, expected -137807, is "
       << last_msg_->obs[3].L.i;
-  EXPECT_EQ(last_msg_->obs[3].P, 2208476371)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].P)),
+            2208476371)
       << "incorrect value for obs[3].P, expected 2208476371, is "
       << last_msg_->obs[3].P;
-  EXPECT_EQ(last_msg_->obs[3].cn0, 31)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].cn0)),
+            31)
       << "incorrect value for obs[3].cn0, expected 31, is "
       << last_msg_->obs[3].cn0;
-  EXPECT_EQ(last_msg_->obs[3].lock, 4129)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].lock)),
+            4129)
       << "incorrect value for obs[3].lock, expected 4129, is "
       << last_msg_->obs[3].lock;
-  EXPECT_EQ(last_msg_->obs[3].prn, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].prn)),
+            10)
       << "incorrect value for obs[3].prn, expected 10, is "
       << last_msg_->obs[3].prn;
-  EXPECT_EQ(last_msg_->obs[4].L.f, 94)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].L.f)),
+            94)
       << "incorrect value for obs[4].L.f, expected 94, is "
       << last_msg_->obs[4].L.f;
-  EXPECT_EQ(last_msg_->obs[4].L.i, -168076)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].L.i)),
+            -168076)
       << "incorrect value for obs[4].L.i, expected -168076, is "
       << last_msg_->obs[4].L.i;
-  EXPECT_EQ(last_msg_->obs[4].P, 2298000000)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].P)),
+            2298000000)
       << "incorrect value for obs[4].P, expected 2298000000, is "
       << last_msg_->obs[4].P;
-  EXPECT_EQ(last_msg_->obs[4].cn0, 21)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].cn0)),
+            21)
       << "incorrect value for obs[4].cn0, expected 21, is "
       << last_msg_->obs[4].cn0;
-  EXPECT_EQ(last_msg_->obs[4].lock, 18218)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].lock)),
+            18218)
       << "incorrect value for obs[4].lock, expected 18218, is "
       << last_msg_->obs[4].lock;
-  EXPECT_EQ(last_msg_->obs[4].prn, 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].prn)),
+            13)
       << "incorrect value for obs[4].prn, expected 13, is "
       << last_msg_->obs[4].prn;
-  EXPECT_EQ(last_msg_->obs[5].L.f, 214)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].L.f)),
+            214)
       << "incorrect value for obs[5].L.f, expected 214, is "
       << last_msg_->obs[5].L.f;
-  EXPECT_EQ(last_msg_->obs[5].L.i, 210469)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].L.i)),
+            210469)
       << "incorrect value for obs[5].L.i, expected 210469, is "
       << last_msg_->obs[5].L.i;
-  EXPECT_EQ(last_msg_->obs[5].P, 2266082742)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].P)),
+            2266082742)
       << "incorrect value for obs[5].P, expected 2266082742, is "
       << last_msg_->obs[5].P;
-  EXPECT_EQ(last_msg_->obs[5].cn0, 27)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].cn0)),
+            27)
       << "incorrect value for obs[5].cn0, expected 27, is "
       << last_msg_->obs[5].cn0;
-  EXPECT_EQ(last_msg_->obs[5].lock, 63852)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].lock)),
+            63852)
       << "incorrect value for obs[5].lock, expected 63852, is "
       << last_msg_->obs[5].lock;
-  EXPECT_EQ(last_msg_->obs[5].prn, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[5].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[5].prn)),
+            22)
       << "incorrect value for obs[5].prn, expected 22, is "
       << last_msg_->obs[5].prn;
-  EXPECT_EQ(last_msg_->obs[6].L.f, 129)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[6].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[6].L.f)),
+            129)
       << "incorrect value for obs[6].L.f, expected 129, is "
       << last_msg_->obs[6].L.f;
-  EXPECT_EQ(last_msg_->obs[6].L.i, -53264)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[6].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[6].L.i)),
+            -53264)
       << "incorrect value for obs[6].L.i, expected -53264, is "
       << last_msg_->obs[6].L.i;
-  EXPECT_EQ(last_msg_->obs[6].P, 1987187803)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[6].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[6].P)),
+            1987187803)
       << "incorrect value for obs[6].P, expected 1987187803, is "
       << last_msg_->obs[6].P;
-  EXPECT_EQ(last_msg_->obs[6].cn0, 52)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[6].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[6].cn0)),
+            52)
       << "incorrect value for obs[6].cn0, expected 52, is "
       << last_msg_->obs[6].cn0;
-  EXPECT_EQ(last_msg_->obs[6].lock, 15074)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[6].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[6].lock)),
+            15074)
       << "incorrect value for obs[6].lock, expected 15074, is "
       << last_msg_->obs[6].lock;
-  EXPECT_EQ(last_msg_->obs[6].prn, 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[6].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[6].prn)),
+            30)
       << "incorrect value for obs[6].prn, expected 30, is "
       << last_msg_->obs[6].prn;
 }
@@ -837,31 +1042,49 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgObsDepA3, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->header.n_obs, 33)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.n_obs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.n_obs)),
+            33)
       << "incorrect value for header.n_obs, expected 33, is "
       << last_msg_->header.n_obs;
-  EXPECT_EQ(last_msg_->header.t.tow, 407084800)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.tow)),
+            407084800)
       << "incorrect value for header.t.tow, expected 407084800, is "
       << last_msg_->header.t.tow;
-  EXPECT_EQ(last_msg_->header.t.wn, 1838)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.wn)),
+            1838)
       << "incorrect value for header.t.wn, expected 1838, is "
       << last_msg_->header.t.wn;
-  EXPECT_EQ(last_msg_->obs[0].L.f, 222)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.f)),
+            222)
       << "incorrect value for obs[0].L.f, expected 222, is "
       << last_msg_->obs[0].L.f;
-  EXPECT_EQ(last_msg_->obs[0].L.i, 8312)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.i)),
+            8312)
       << "incorrect value for obs[0].L.i, expected 8312, is "
       << last_msg_->obs[0].L.i;
-  EXPECT_EQ(last_msg_->obs[0].P, 1973687089)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].P)),
+            1973687089)
       << "incorrect value for obs[0].P, expected 1973687089, is "
       << last_msg_->obs[0].P;
-  EXPECT_EQ(last_msg_->obs[0].cn0, 63)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].cn0)),
+            63)
       << "incorrect value for obs[0].cn0, expected 63, is "
       << last_msg_->obs[0].cn0;
-  EXPECT_EQ(last_msg_->obs[0].lock, 64062)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].lock)),
+            64062)
       << "incorrect value for obs[0].lock, expected 64062, is "
       << last_msg_->obs[0].lock;
-  EXPECT_EQ(last_msg_->obs[0].prn, 31)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].prn)),
+            31)
       << "incorrect value for obs[0].prn, expected 31, is "
       << last_msg_->obs[0].prn;
 }
@@ -1003,103 +1226,169 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgObsDepA4, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->header.n_obs, 16)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.n_obs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.n_obs)),
+            16)
       << "incorrect value for header.n_obs, expected 16, is "
       << last_msg_->header.n_obs;
-  EXPECT_EQ(last_msg_->header.t.tow, 407151200)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.tow)),
+            407151200)
       << "incorrect value for header.t.tow, expected 407151200, is "
       << last_msg_->header.t.tow;
-  EXPECT_EQ(last_msg_->header.t.wn, 1838)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.wn)),
+            1838)
       << "incorrect value for header.t.wn, expected 1838, is "
       << last_msg_->header.t.wn;
-  EXPECT_EQ(last_msg_->obs[0].L.f, 189)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.f)),
+            189)
       << "incorrect value for obs[0].L.f, expected 189, is "
       << last_msg_->obs[0].L.f;
-  EXPECT_EQ(last_msg_->obs[0].L.i, -27527)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.i)),
+            -27527)
       << "incorrect value for obs[0].L.i, expected -27527, is "
       << last_msg_->obs[0].L.i;
-  EXPECT_EQ(last_msg_->obs[0].P, 2044298327)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].P)),
+            2044298327)
       << "incorrect value for obs[0].P, expected 2044298327, is "
       << last_msg_->obs[0].P;
-  EXPECT_EQ(last_msg_->obs[0].cn0, 43)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].cn0)),
+            43)
       << "incorrect value for obs[0].cn0, expected 43, is "
       << last_msg_->obs[0].cn0;
-  EXPECT_EQ(last_msg_->obs[0].lock, 37807)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].lock)),
+            37807)
       << "incorrect value for obs[0].lock, expected 37807, is "
       << last_msg_->obs[0].lock;
-  EXPECT_EQ(last_msg_->obs[0].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].prn)),
+            0)
       << "incorrect value for obs[0].prn, expected 0, is "
       << last_msg_->obs[0].prn;
-  EXPECT_EQ(last_msg_->obs[1].L.f, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].L.f)),
+            1)
       << "incorrect value for obs[1].L.f, expected 1, is "
       << last_msg_->obs[1].L.f;
-  EXPECT_EQ(last_msg_->obs[1].L.i, -123030)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].L.i)),
+            -123030)
       << "incorrect value for obs[1].L.i, expected -123030, is "
       << last_msg_->obs[1].L.i;
-  EXPECT_EQ(last_msg_->obs[1].P, 2110275716)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].P)),
+            2110275716)
       << "incorrect value for obs[1].P, expected 2110275716, is "
       << last_msg_->obs[1].P;
-  EXPECT_EQ(last_msg_->obs[1].cn0, 41)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].cn0)),
+            41)
       << "incorrect value for obs[1].cn0, expected 41, is "
       << last_msg_->obs[1].cn0;
-  EXPECT_EQ(last_msg_->obs[1].lock, 45326)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].lock)),
+            45326)
       << "incorrect value for obs[1].lock, expected 45326, is "
       << last_msg_->obs[1].lock;
-  EXPECT_EQ(last_msg_->obs[1].prn, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].prn)),
+            3)
       << "incorrect value for obs[1].prn, expected 3, is "
       << last_msg_->obs[1].prn;
-  EXPECT_EQ(last_msg_->obs[2].L.f, 166)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].L.f)),
+            166)
       << "incorrect value for obs[2].L.f, expected 166, is "
       << last_msg_->obs[2].L.f;
-  EXPECT_EQ(last_msg_->obs[2].L.i, -113594)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].L.i)),
+            -113594)
       << "incorrect value for obs[2].L.i, expected -113594, is "
       << last_msg_->obs[2].L.i;
-  EXPECT_EQ(last_msg_->obs[2].P, 2298000000)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].P)),
+            2298000000)
       << "incorrect value for obs[2].P, expected 2298000000, is "
       << last_msg_->obs[2].P;
-  EXPECT_EQ(last_msg_->obs[2].cn0, 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].cn0)),
+            18)
       << "incorrect value for obs[2].cn0, expected 18, is "
       << last_msg_->obs[2].cn0;
-  EXPECT_EQ(last_msg_->obs[2].lock, 34232)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].lock)),
+            34232)
       << "incorrect value for obs[2].lock, expected 34232, is "
       << last_msg_->obs[2].lock;
-  EXPECT_EQ(last_msg_->obs[2].prn, 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].prn)),
+            13)
       << "incorrect value for obs[2].prn, expected 13, is "
       << last_msg_->obs[2].prn;
-  EXPECT_EQ(last_msg_->obs[3].L.f, 249)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].L.f)),
+            249)
       << "incorrect value for obs[3].L.f, expected 249, is "
       << last_msg_->obs[3].L.f;
-  EXPECT_EQ(last_msg_->obs[3].L.i, 137478)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].L.i)),
+            137478)
       << "incorrect value for obs[3].L.i, expected 137478, is "
       << last_msg_->obs[3].L.i;
-  EXPECT_EQ(last_msg_->obs[3].P, 2259844888)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].P)),
+            2259844888)
       << "incorrect value for obs[3].P, expected 2259844888, is "
       << last_msg_->obs[3].P;
-  EXPECT_EQ(last_msg_->obs[3].cn0, 28)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].cn0)),
+            28)
       << "incorrect value for obs[3].cn0, expected 28, is "
       << last_msg_->obs[3].cn0;
-  EXPECT_EQ(last_msg_->obs[3].lock, 24609)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].lock)),
+            24609)
       << "incorrect value for obs[3].lock, expected 24609, is "
       << last_msg_->obs[3].lock;
-  EXPECT_EQ(last_msg_->obs[3].prn, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].prn)),
+            22)
       << "incorrect value for obs[3].prn, expected 22, is "
       << last_msg_->obs[3].prn;
-  EXPECT_EQ(last_msg_->obs[4].L.f, 203)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].L.f)),
+            203)
       << "incorrect value for obs[4].L.f, expected 203, is "
       << last_msg_->obs[4].L.f;
-  EXPECT_EQ(last_msg_->obs[4].L.i, -36797)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].L.i)),
+            -36797)
       << "incorrect value for obs[4].L.i, expected -36797, is "
       << last_msg_->obs[4].L.i;
-  EXPECT_EQ(last_msg_->obs[4].P, 1985374378)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].P)),
+            1985374378)
       << "incorrect value for obs[4].P, expected 1985374378, is "
       << last_msg_->obs[4].P;
-  EXPECT_EQ(last_msg_->obs[4].cn0, 56)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].cn0)),
+            56)
       << "incorrect value for obs[4].cn0, expected 56, is "
       << last_msg_->obs[4].cn0;
-  EXPECT_EQ(last_msg_->obs[4].lock, 22736)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].lock)),
+            22736)
       << "incorrect value for obs[4].lock, expected 22736, is "
       << last_msg_->obs[4].lock;
-  EXPECT_EQ(last_msg_->obs[4].prn, 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].prn)),
+            30)
       << "incorrect value for obs[4].prn, expected 30, is "
       << last_msg_->obs[4].prn;
 }
@@ -1241,103 +1530,169 @@ TEST_F(Test_legacy_auto_check_sbp_observation_msgObsDepA5, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->header.n_obs, 16)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.n_obs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.n_obs)),
+            16)
       << "incorrect value for header.n_obs, expected 16, is "
       << last_msg_->header.n_obs;
-  EXPECT_EQ(last_msg_->header.t.tow, 407151400)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.tow)),
+            407151400)
       << "incorrect value for header.t.tow, expected 407151400, is "
       << last_msg_->header.t.tow;
-  EXPECT_EQ(last_msg_->header.t.wn, 1838)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.t.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.t.wn)),
+            1838)
       << "incorrect value for header.t.wn, expected 1838, is "
       << last_msg_->header.t.wn;
-  EXPECT_EQ(last_msg_->obs[0].L.f, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.f)),
+            1)
       << "incorrect value for obs[0].L.f, expected 1, is "
       << last_msg_->obs[0].L.f;
-  EXPECT_EQ(last_msg_->obs[0].L.i, -27634)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].L.i)),
+            -27634)
       << "incorrect value for obs[0].L.i, expected -27634, is "
       << last_msg_->obs[0].L.i;
-  EXPECT_EQ(last_msg_->obs[0].P, 2044291972)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].P)),
+            2044291972)
       << "incorrect value for obs[0].P, expected 2044291972, is "
       << last_msg_->obs[0].P;
-  EXPECT_EQ(last_msg_->obs[0].cn0, 44)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].cn0)),
+            44)
       << "incorrect value for obs[0].cn0, expected 44, is "
       << last_msg_->obs[0].cn0;
-  EXPECT_EQ(last_msg_->obs[0].lock, 37807)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].lock)),
+            37807)
       << "incorrect value for obs[0].lock, expected 37807, is "
       << last_msg_->obs[0].lock;
-  EXPECT_EQ(last_msg_->obs[0].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[0].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[0].prn)),
+            0)
       << "incorrect value for obs[0].prn, expected 0, is "
       << last_msg_->obs[0].prn;
-  EXPECT_EQ(last_msg_->obs[1].L.f, 153)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].L.f)),
+            153)
       << "incorrect value for obs[1].L.f, expected 153, is "
       << last_msg_->obs[1].L.f;
-  EXPECT_EQ(last_msg_->obs[1].L.i, -123500)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].L.i)),
+            -123500)
       << "incorrect value for obs[1].L.i, expected -123500, is "
       << last_msg_->obs[1].L.i;
-  EXPECT_EQ(last_msg_->obs[1].P, 2110276225)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].P)),
+            2110276225)
       << "incorrect value for obs[1].P, expected 2110276225, is "
       << last_msg_->obs[1].P;
-  EXPECT_EQ(last_msg_->obs[1].cn0, 41)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].cn0)),
+            41)
       << "incorrect value for obs[1].cn0, expected 41, is "
       << last_msg_->obs[1].cn0;
-  EXPECT_EQ(last_msg_->obs[1].lock, 45326)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].lock)),
+            45326)
       << "incorrect value for obs[1].lock, expected 45326, is "
       << last_msg_->obs[1].lock;
-  EXPECT_EQ(last_msg_->obs[1].prn, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[1].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[1].prn)),
+            3)
       << "incorrect value for obs[1].prn, expected 3, is "
       << last_msg_->obs[1].prn;
-  EXPECT_EQ(last_msg_->obs[2].L.f, 222)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].L.f)),
+            222)
       << "incorrect value for obs[2].L.f, expected 222, is "
       << last_msg_->obs[2].L.f;
-  EXPECT_EQ(last_msg_->obs[2].L.i, -114033)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].L.i)),
+            -114033)
       << "incorrect value for obs[2].L.i, expected -114033, is "
       << last_msg_->obs[2].L.i;
-  EXPECT_EQ(last_msg_->obs[2].P, 2298000000)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].P)),
+            2298000000)
       << "incorrect value for obs[2].P, expected 2298000000, is "
       << last_msg_->obs[2].P;
-  EXPECT_EQ(last_msg_->obs[2].cn0, 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].cn0)),
+            18)
       << "incorrect value for obs[2].cn0, expected 18, is "
       << last_msg_->obs[2].cn0;
-  EXPECT_EQ(last_msg_->obs[2].lock, 34232)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].lock)),
+            34232)
       << "incorrect value for obs[2].lock, expected 34232, is "
       << last_msg_->obs[2].lock;
-  EXPECT_EQ(last_msg_->obs[2].prn, 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[2].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[2].prn)),
+            13)
       << "incorrect value for obs[2].prn, expected 13, is "
       << last_msg_->obs[2].prn;
-  EXPECT_EQ(last_msg_->obs[3].L.f, 237)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].L.f)),
+            237)
       << "incorrect value for obs[3].L.f, expected 237, is "
       << last_msg_->obs[3].L.f;
-  EXPECT_EQ(last_msg_->obs[3].L.i, 138026)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].L.i)),
+            138026)
       << "incorrect value for obs[3].L.i, expected 138026, is "
       << last_msg_->obs[3].L.i;
-  EXPECT_EQ(last_msg_->obs[3].P, 2259826078)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].P)),
+            2259826078)
       << "incorrect value for obs[3].P, expected 2259826078, is "
       << last_msg_->obs[3].P;
-  EXPECT_EQ(last_msg_->obs[3].cn0, 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].cn0)),
+            30)
       << "incorrect value for obs[3].cn0, expected 30, is "
       << last_msg_->obs[3].cn0;
-  EXPECT_EQ(last_msg_->obs[3].lock, 24609)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].lock)),
+            24609)
       << "incorrect value for obs[3].lock, expected 24609, is "
       << last_msg_->obs[3].lock;
-  EXPECT_EQ(last_msg_->obs[3].prn, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[3].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[3].prn)),
+            22)
       << "incorrect value for obs[3].prn, expected 22, is "
       << last_msg_->obs[3].prn;
-  EXPECT_EQ(last_msg_->obs[4].L.f, 45)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].L.f)),
+            45)
       << "incorrect value for obs[4].L.f, expected 45, is "
       << last_msg_->obs[4].L.f;
-  EXPECT_EQ(last_msg_->obs[4].L.i, -36952)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].L.i)),
+            -36952)
       << "incorrect value for obs[4].L.i, expected -36952, is "
       << last_msg_->obs[4].L.i;
-  EXPECT_EQ(last_msg_->obs[4].P, 1985368870)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].P)),
+            1985368870)
       << "incorrect value for obs[4].P, expected 1985368870, is "
       << last_msg_->obs[4].P;
-  EXPECT_EQ(last_msg_->obs[4].cn0, 56)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].cn0)),
+            56)
       << "incorrect value for obs[4].cn0, expected 56, is "
       << last_msg_->obs[4].cn0;
-  EXPECT_EQ(last_msg_->obs[4].lock, 22736)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].lock)),
+            22736)
       << "incorrect value for obs[4].lock, expected 22736, is "
       << last_msg_->obs[4].lock;
-  EXPECT_EQ(last_msg_->obs[4].prn, 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs[4].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs[4].prn)),
+            30)
       << "incorrect value for obs[4].prn, expected 30, is "
       << last_msg_->obs[4].prn;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_orientation_MsgAngularRate.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_orientation_MsgAngularRate.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/orientation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_orientation_MsgAngularRate0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -115,14 +122,24 @@ TEST_F(Test_legacy_auto_check_sbp_orientation_MsgAngularRate0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->tow, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            2)
       << "incorrect value for tow, expected 2, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->x, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            2)
       << "incorrect value for x, expected 2, is " << last_msg_->x;
-  EXPECT_EQ(last_msg_->y, 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            5)
       << "incorrect value for y, expected 5, is " << last_msg_->y;
-  EXPECT_EQ(last_msg_->z, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            2)
       << "incorrect value for z, expected 2, is " << last_msg_->z;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_orientation_MsgBaselineHeading.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_orientation_MsgBaselineHeading.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/orientation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_orientation_MsgBaselineHeading0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -115,13 +122,21 @@ TEST_F(Test_legacy_auto_check_sbp_orientation_MsgBaselineHeading0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 24019);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 91)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            91)
       << "incorrect value for flags, expected 91, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->heading, 1036342316)
+  EXPECT_EQ(get_as<decltype(last_msg_->heading)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->heading)),
+            1036342316)
       << "incorrect value for heading, expected 1036342316, is "
       << last_msg_->heading;
-  EXPECT_EQ(last_msg_->n_sats, 91)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            91)
       << "incorrect value for n_sats, expected 91, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->tow, 3289197980)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            3289197980)
       << "incorrect value for tow, expected 3289197980, is " << last_msg_->tow;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_orientation_MsgOrientEuler.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_orientation_MsgOrientEuler.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/orientation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_orientation_MsgOrientEuler0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -118,21 +125,31 @@ TEST_F(Test_legacy_auto_check_sbp_orientation_MsgOrientEuler0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            3)
       << "incorrect value for flags, expected 3, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->pitch, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->pitch)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pitch)),
+            2)
       << "incorrect value for pitch, expected 2, is " << last_msg_->pitch;
   EXPECT_LT((last_msg_->pitch_accuracy * 100 - 3.0 * 100), 0.05)
       << "incorrect value for pitch_accuracy, expected 3.0, is "
       << last_msg_->pitch_accuracy;
-  EXPECT_EQ(last_msg_->roll, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->roll)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->roll)),
+            1)
       << "incorrect value for roll, expected 1, is " << last_msg_->roll;
   EXPECT_LT((last_msg_->roll_accuracy * 100 - 7.0 * 100), 0.05)
       << "incorrect value for roll_accuracy, expected 7.0, is "
       << last_msg_->roll_accuracy;
-  EXPECT_EQ(last_msg_->tow, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            1)
       << "incorrect value for tow, expected 1, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->yaw, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->yaw)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->yaw)),
+            8)
       << "incorrect value for yaw, expected 8, is " << last_msg_->yaw;
   EXPECT_LT((last_msg_->yaw_accuracy * 100 - 7.0 * 100), 0.05)
       << "incorrect value for yaw_accuracy, expected 7.0, is "

--- a/c/test/legacy/cpp/auto_check_sbp_orientation_MsgOrientQuat.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_orientation_MsgOrientQuat.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/orientation.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_orientation_MsgOrientQuat0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -121,26 +128,38 @@ TEST_F(Test_legacy_auto_check_sbp_orientation_MsgOrientQuat0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            1)
       << "incorrect value for flags, expected 1, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->tow, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            0)
       << "incorrect value for tow, expected 0, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->w, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->w)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->w)),
+            3)
       << "incorrect value for w, expected 3, is " << last_msg_->w;
   EXPECT_LT((last_msg_->w_accuracy * 100 - 3.0 * 100), 0.05)
       << "incorrect value for w_accuracy, expected 3.0, is "
       << last_msg_->w_accuracy;
-  EXPECT_EQ(last_msg_->x, 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->x)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->x)),
+            7)
       << "incorrect value for x, expected 7, is " << last_msg_->x;
   EXPECT_LT((last_msg_->x_accuracy * 100 - 4.0 * 100), 0.05)
       << "incorrect value for x_accuracy, expected 4.0, is "
       << last_msg_->x_accuracy;
-  EXPECT_EQ(last_msg_->y, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->y)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->y)),
+            8)
       << "incorrect value for y, expected 8, is " << last_msg_->y;
   EXPECT_LT((last_msg_->y_accuracy * 100 - 8.0 * 100), 0.05)
       << "incorrect value for y_accuracy, expected 8.0, is "
       << last_msg_->y_accuracy;
-  EXPECT_EQ(last_msg_->z, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->z)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->z)),
+            4)
       << "incorrect value for z, expected 4, is " << last_msg_->z;
   EXPECT_LT((last_msg_->z_accuracy * 100 - 3.0 * 100), 0.05)
       << "incorrect value for z_accuracy, expected 3.0, is "

--- a/c/test/legacy/cpp/auto_check_sbp_piksi_MsgAlmanac.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_piksi_MsgAlmanac.cc
@@ -29,3 +29,10 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/piksi.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}

--- a/c/test/legacy/cpp/auto_check_sbp_piksi_MsgCellModemStatus.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_piksi_MsgCellModemStatus.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/piksi.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_piksi_MsgCellModemStatus0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -1380,760 +1387,1262 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgCellModemStatus0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 6931);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->reserved[0], 123)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[0])),
+            123)
       << "incorrect value for reserved[0], expected 123, is "
       << last_msg_->reserved[0];
-  EXPECT_EQ(last_msg_->reserved[1], 242)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[1])),
+            242)
       << "incorrect value for reserved[1], expected 242, is "
       << last_msg_->reserved[1];
-  EXPECT_EQ(last_msg_->reserved[2], 46)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[2])),
+            46)
       << "incorrect value for reserved[2], expected 46, is "
       << last_msg_->reserved[2];
-  EXPECT_EQ(last_msg_->reserved[3], 52)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[3])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[3])),
+            52)
       << "incorrect value for reserved[3], expected 52, is "
       << last_msg_->reserved[3];
-  EXPECT_EQ(last_msg_->reserved[4], 64)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[4])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[4])),
+            64)
       << "incorrect value for reserved[4], expected 64, is "
       << last_msg_->reserved[4];
-  EXPECT_EQ(last_msg_->reserved[5], 176)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[5])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[5])),
+            176)
       << "incorrect value for reserved[5], expected 176, is "
       << last_msg_->reserved[5];
-  EXPECT_EQ(last_msg_->reserved[6], 154)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[6])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[6])),
+            154)
       << "incorrect value for reserved[6], expected 154, is "
       << last_msg_->reserved[6];
-  EXPECT_EQ(last_msg_->reserved[7], 98)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[7])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[7])),
+            98)
       << "incorrect value for reserved[7], expected 98, is "
       << last_msg_->reserved[7];
-  EXPECT_EQ(last_msg_->reserved[8], 43)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[8])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[8])),
+            43)
       << "incorrect value for reserved[8], expected 43, is "
       << last_msg_->reserved[8];
-  EXPECT_EQ(last_msg_->reserved[9], 132)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[9])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[9])),
+            132)
       << "incorrect value for reserved[9], expected 132, is "
       << last_msg_->reserved[9];
-  EXPECT_EQ(last_msg_->reserved[10], 196)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[10])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[10])),
+            196)
       << "incorrect value for reserved[10], expected 196, is "
       << last_msg_->reserved[10];
-  EXPECT_EQ(last_msg_->reserved[11], 89)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[11])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[11])),
+            89)
       << "incorrect value for reserved[11], expected 89, is "
       << last_msg_->reserved[11];
-  EXPECT_EQ(last_msg_->reserved[12], 253)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[12])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[12])),
+            253)
       << "incorrect value for reserved[12], expected 253, is "
       << last_msg_->reserved[12];
-  EXPECT_EQ(last_msg_->reserved[13], 161)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[13])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[13])),
+            161)
       << "incorrect value for reserved[13], expected 161, is "
       << last_msg_->reserved[13];
-  EXPECT_EQ(last_msg_->reserved[14], 250)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[14])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[14])),
+            250)
       << "incorrect value for reserved[14], expected 250, is "
       << last_msg_->reserved[14];
-  EXPECT_EQ(last_msg_->reserved[15], 174)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[15])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[15])),
+            174)
       << "incorrect value for reserved[15], expected 174, is "
       << last_msg_->reserved[15];
-  EXPECT_EQ(last_msg_->reserved[16], 204)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[16])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[16])),
+            204)
       << "incorrect value for reserved[16], expected 204, is "
       << last_msg_->reserved[16];
-  EXPECT_EQ(last_msg_->reserved[17], 110)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[17])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[17])),
+            110)
       << "incorrect value for reserved[17], expected 110, is "
       << last_msg_->reserved[17];
-  EXPECT_EQ(last_msg_->reserved[18], 47)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[18])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[18])),
+            47)
       << "incorrect value for reserved[18], expected 47, is "
       << last_msg_->reserved[18];
-  EXPECT_EQ(last_msg_->reserved[19], 38)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[19])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[19])),
+            38)
       << "incorrect value for reserved[19], expected 38, is "
       << last_msg_->reserved[19];
-  EXPECT_EQ(last_msg_->reserved[20], 187)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[20])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[20])),
+            187)
       << "incorrect value for reserved[20], expected 187, is "
       << last_msg_->reserved[20];
-  EXPECT_EQ(last_msg_->reserved[21], 63)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[21])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[21])),
+            63)
       << "incorrect value for reserved[21], expected 63, is "
       << last_msg_->reserved[21];
-  EXPECT_EQ(last_msg_->reserved[22], 102)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[22])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[22])),
+            102)
       << "incorrect value for reserved[22], expected 102, is "
       << last_msg_->reserved[22];
-  EXPECT_EQ(last_msg_->reserved[23], 177)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[23])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[23])),
+            177)
       << "incorrect value for reserved[23], expected 177, is "
       << last_msg_->reserved[23];
-  EXPECT_EQ(last_msg_->reserved[24], 162)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[24])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[24])),
+            162)
       << "incorrect value for reserved[24], expected 162, is "
       << last_msg_->reserved[24];
-  EXPECT_EQ(last_msg_->reserved[25], 49)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[25])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[25])),
+            49)
       << "incorrect value for reserved[25], expected 49, is "
       << last_msg_->reserved[25];
-  EXPECT_EQ(last_msg_->reserved[26], 80)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[26])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[26])),
+            80)
       << "incorrect value for reserved[26], expected 80, is "
       << last_msg_->reserved[26];
-  EXPECT_EQ(last_msg_->reserved[27], 194)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[27])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[27])),
+            194)
       << "incorrect value for reserved[27], expected 194, is "
       << last_msg_->reserved[27];
-  EXPECT_EQ(last_msg_->reserved[28], 37)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[28])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[28])),
+            37)
       << "incorrect value for reserved[28], expected 37, is "
       << last_msg_->reserved[28];
-  EXPECT_EQ(last_msg_->reserved[29], 107)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[29])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[29])),
+            107)
       << "incorrect value for reserved[29], expected 107, is "
       << last_msg_->reserved[29];
-  EXPECT_EQ(last_msg_->reserved[30], 60)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[30])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[30])),
+            60)
       << "incorrect value for reserved[30], expected 60, is "
       << last_msg_->reserved[30];
-  EXPECT_EQ(last_msg_->reserved[31], 225)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[31])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[31])),
+            225)
       << "incorrect value for reserved[31], expected 225, is "
       << last_msg_->reserved[31];
-  EXPECT_EQ(last_msg_->reserved[32], 52)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[32])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[32])),
+            52)
       << "incorrect value for reserved[32], expected 52, is "
       << last_msg_->reserved[32];
-  EXPECT_EQ(last_msg_->reserved[33], 101)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[33])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[33])),
+            101)
       << "incorrect value for reserved[33], expected 101, is "
       << last_msg_->reserved[33];
-  EXPECT_EQ(last_msg_->reserved[34], 178)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[34])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[34])),
+            178)
       << "incorrect value for reserved[34], expected 178, is "
       << last_msg_->reserved[34];
-  EXPECT_EQ(last_msg_->reserved[35], 142)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[35])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[35])),
+            142)
       << "incorrect value for reserved[35], expected 142, is "
       << last_msg_->reserved[35];
-  EXPECT_EQ(last_msg_->reserved[36], 246)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[36])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[36])),
+            246)
       << "incorrect value for reserved[36], expected 246, is "
       << last_msg_->reserved[36];
-  EXPECT_EQ(last_msg_->reserved[37], 21)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[37])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[37])),
+            21)
       << "incorrect value for reserved[37], expected 21, is "
       << last_msg_->reserved[37];
-  EXPECT_EQ(last_msg_->reserved[38], 17)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[38])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[38])),
+            17)
       << "incorrect value for reserved[38], expected 17, is "
       << last_msg_->reserved[38];
-  EXPECT_EQ(last_msg_->reserved[39], 93)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[39])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[39])),
+            93)
       << "incorrect value for reserved[39], expected 93, is "
       << last_msg_->reserved[39];
-  EXPECT_EQ(last_msg_->reserved[40], 75)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[40])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[40])),
+            75)
       << "incorrect value for reserved[40], expected 75, is "
       << last_msg_->reserved[40];
-  EXPECT_EQ(last_msg_->reserved[41], 169)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[41])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[41])),
+            169)
       << "incorrect value for reserved[41], expected 169, is "
       << last_msg_->reserved[41];
-  EXPECT_EQ(last_msg_->reserved[42], 86)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[42])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[42])),
+            86)
       << "incorrect value for reserved[42], expected 86, is "
       << last_msg_->reserved[42];
-  EXPECT_EQ(last_msg_->reserved[43], 16)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[43])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[43])),
+            16)
       << "incorrect value for reserved[43], expected 16, is "
       << last_msg_->reserved[43];
-  EXPECT_EQ(last_msg_->reserved[44], 209)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[44])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[44])),
+            209)
       << "incorrect value for reserved[44], expected 209, is "
       << last_msg_->reserved[44];
-  EXPECT_EQ(last_msg_->reserved[45], 80)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[45])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[45])),
+            80)
       << "incorrect value for reserved[45], expected 80, is "
       << last_msg_->reserved[45];
-  EXPECT_EQ(last_msg_->reserved[46], 243)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[46])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[46])),
+            243)
       << "incorrect value for reserved[46], expected 243, is "
       << last_msg_->reserved[46];
-  EXPECT_EQ(last_msg_->reserved[47], 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[47])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[47])),
+            30)
       << "incorrect value for reserved[47], expected 30, is "
       << last_msg_->reserved[47];
-  EXPECT_EQ(last_msg_->reserved[48], 206)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[48])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[48])),
+            206)
       << "incorrect value for reserved[48], expected 206, is "
       << last_msg_->reserved[48];
-  EXPECT_EQ(last_msg_->reserved[49], 220)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[49])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[49])),
+            220)
       << "incorrect value for reserved[49], expected 220, is "
       << last_msg_->reserved[49];
-  EXPECT_EQ(last_msg_->reserved[50], 206)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[50])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[50])),
+            206)
       << "incorrect value for reserved[50], expected 206, is "
       << last_msg_->reserved[50];
-  EXPECT_EQ(last_msg_->reserved[51], 115)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[51])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[51])),
+            115)
       << "incorrect value for reserved[51], expected 115, is "
       << last_msg_->reserved[51];
-  EXPECT_EQ(last_msg_->reserved[52], 47)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[52])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[52])),
+            47)
       << "incorrect value for reserved[52], expected 47, is "
       << last_msg_->reserved[52];
-  EXPECT_EQ(last_msg_->reserved[53], 154)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[53])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[53])),
+            154)
       << "incorrect value for reserved[53], expected 154, is "
       << last_msg_->reserved[53];
-  EXPECT_EQ(last_msg_->reserved[54], 91)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[54])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[54])),
+            91)
       << "incorrect value for reserved[54], expected 91, is "
       << last_msg_->reserved[54];
-  EXPECT_EQ(last_msg_->reserved[55], 227)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[55])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[55])),
+            227)
       << "incorrect value for reserved[55], expected 227, is "
       << last_msg_->reserved[55];
-  EXPECT_EQ(last_msg_->reserved[56], 88)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[56])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[56])),
+            88)
       << "incorrect value for reserved[56], expected 88, is "
       << last_msg_->reserved[56];
-  EXPECT_EQ(last_msg_->reserved[57], 11)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[57])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[57])),
+            11)
       << "incorrect value for reserved[57], expected 11, is "
       << last_msg_->reserved[57];
-  EXPECT_EQ(last_msg_->reserved[58], 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[58])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[58])),
+            1)
       << "incorrect value for reserved[58], expected 1, is "
       << last_msg_->reserved[58];
-  EXPECT_EQ(last_msg_->reserved[59], 85)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[59])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[59])),
+            85)
       << "incorrect value for reserved[59], expected 85, is "
       << last_msg_->reserved[59];
-  EXPECT_EQ(last_msg_->reserved[60], 146)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[60])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[60])),
+            146)
       << "incorrect value for reserved[60], expected 146, is "
       << last_msg_->reserved[60];
-  EXPECT_EQ(last_msg_->reserved[61], 100)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[61])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[61])),
+            100)
       << "incorrect value for reserved[61], expected 100, is "
       << last_msg_->reserved[61];
-  EXPECT_EQ(last_msg_->reserved[62], 190)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[62])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[62])),
+            190)
       << "incorrect value for reserved[62], expected 190, is "
       << last_msg_->reserved[62];
-  EXPECT_EQ(last_msg_->reserved[63], 232)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[63])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[63])),
+            232)
       << "incorrect value for reserved[63], expected 232, is "
       << last_msg_->reserved[63];
-  EXPECT_EQ(last_msg_->reserved[64], 207)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[64])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[64])),
+            207)
       << "incorrect value for reserved[64], expected 207, is "
       << last_msg_->reserved[64];
-  EXPECT_EQ(last_msg_->reserved[65], 61)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[65])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[65])),
+            61)
       << "incorrect value for reserved[65], expected 61, is "
       << last_msg_->reserved[65];
-  EXPECT_EQ(last_msg_->reserved[66], 61)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[66])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[66])),
+            61)
       << "incorrect value for reserved[66], expected 61, is "
       << last_msg_->reserved[66];
-  EXPECT_EQ(last_msg_->reserved[67], 201)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[67])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[67])),
+            201)
       << "incorrect value for reserved[67], expected 201, is "
       << last_msg_->reserved[67];
-  EXPECT_EQ(last_msg_->reserved[68], 220)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[68])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[68])),
+            220)
       << "incorrect value for reserved[68], expected 220, is "
       << last_msg_->reserved[68];
-  EXPECT_EQ(last_msg_->reserved[69], 31)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[69])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[69])),
+            31)
       << "incorrect value for reserved[69], expected 31, is "
       << last_msg_->reserved[69];
-  EXPECT_EQ(last_msg_->reserved[70], 78)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[70])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[70])),
+            78)
       << "incorrect value for reserved[70], expected 78, is "
       << last_msg_->reserved[70];
-  EXPECT_EQ(last_msg_->reserved[71], 34)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[71])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[71])),
+            34)
       << "incorrect value for reserved[71], expected 34, is "
       << last_msg_->reserved[71];
-  EXPECT_EQ(last_msg_->reserved[72], 57)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[72])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[72])),
+            57)
       << "incorrect value for reserved[72], expected 57, is "
       << last_msg_->reserved[72];
-  EXPECT_EQ(last_msg_->reserved[73], 82)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[73])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[73])),
+            82)
       << "incorrect value for reserved[73], expected 82, is "
       << last_msg_->reserved[73];
-  EXPECT_EQ(last_msg_->reserved[74], 59)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[74])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[74])),
+            59)
       << "incorrect value for reserved[74], expected 59, is "
       << last_msg_->reserved[74];
-  EXPECT_EQ(last_msg_->reserved[75], 104)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[75])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[75])),
+            104)
       << "incorrect value for reserved[75], expected 104, is "
       << last_msg_->reserved[75];
-  EXPECT_EQ(last_msg_->reserved[76], 65)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[76])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[76])),
+            65)
       << "incorrect value for reserved[76], expected 65, is "
       << last_msg_->reserved[76];
-  EXPECT_EQ(last_msg_->reserved[77], 221)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[77])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[77])),
+            221)
       << "incorrect value for reserved[77], expected 221, is "
       << last_msg_->reserved[77];
-  EXPECT_EQ(last_msg_->reserved[78], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[78])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[78])),
+            0)
       << "incorrect value for reserved[78], expected 0, is "
       << last_msg_->reserved[78];
-  EXPECT_EQ(last_msg_->reserved[79], 43)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[79])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[79])),
+            43)
       << "incorrect value for reserved[79], expected 43, is "
       << last_msg_->reserved[79];
-  EXPECT_EQ(last_msg_->reserved[80], 210)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[80])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[80])),
+            210)
       << "incorrect value for reserved[80], expected 210, is "
       << last_msg_->reserved[80];
-  EXPECT_EQ(last_msg_->reserved[81], 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[81])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[81])),
+            9)
       << "incorrect value for reserved[81], expected 9, is "
       << last_msg_->reserved[81];
-  EXPECT_EQ(last_msg_->reserved[82], 32)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[82])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[82])),
+            32)
       << "incorrect value for reserved[82], expected 32, is "
       << last_msg_->reserved[82];
-  EXPECT_EQ(last_msg_->reserved[83], 122)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[83])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[83])),
+            122)
       << "incorrect value for reserved[83], expected 122, is "
       << last_msg_->reserved[83];
-  EXPECT_EQ(last_msg_->reserved[84], 29)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[84])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[84])),
+            29)
       << "incorrect value for reserved[84], expected 29, is "
       << last_msg_->reserved[84];
-  EXPECT_EQ(last_msg_->reserved[85], 237)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[85])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[85])),
+            237)
       << "incorrect value for reserved[85], expected 237, is "
       << last_msg_->reserved[85];
-  EXPECT_EQ(last_msg_->reserved[86], 11)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[86])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[86])),
+            11)
       << "incorrect value for reserved[86], expected 11, is "
       << last_msg_->reserved[86];
-  EXPECT_EQ(last_msg_->reserved[87], 151)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[87])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[87])),
+            151)
       << "incorrect value for reserved[87], expected 151, is "
       << last_msg_->reserved[87];
-  EXPECT_EQ(last_msg_->reserved[88], 223)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[88])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[88])),
+            223)
       << "incorrect value for reserved[88], expected 223, is "
       << last_msg_->reserved[88];
-  EXPECT_EQ(last_msg_->reserved[89], 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[89])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[89])),
+            18)
       << "incorrect value for reserved[89], expected 18, is "
       << last_msg_->reserved[89];
-  EXPECT_EQ(last_msg_->reserved[90], 81)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[90])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[90])),
+            81)
       << "incorrect value for reserved[90], expected 81, is "
       << last_msg_->reserved[90];
-  EXPECT_EQ(last_msg_->reserved[91], 204)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[91])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[91])),
+            204)
       << "incorrect value for reserved[91], expected 204, is "
       << last_msg_->reserved[91];
-  EXPECT_EQ(last_msg_->reserved[92], 172)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[92])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[92])),
+            172)
       << "incorrect value for reserved[92], expected 172, is "
       << last_msg_->reserved[92];
-  EXPECT_EQ(last_msg_->reserved[93], 234)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[93])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[93])),
+            234)
       << "incorrect value for reserved[93], expected 234, is "
       << last_msg_->reserved[93];
-  EXPECT_EQ(last_msg_->reserved[94], 127)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[94])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[94])),
+            127)
       << "incorrect value for reserved[94], expected 127, is "
       << last_msg_->reserved[94];
-  EXPECT_EQ(last_msg_->reserved[95], 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[95])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[95])),
+            3)
       << "incorrect value for reserved[95], expected 3, is "
       << last_msg_->reserved[95];
-  EXPECT_EQ(last_msg_->reserved[96], 82)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[96])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[96])),
+            82)
       << "incorrect value for reserved[96], expected 82, is "
       << last_msg_->reserved[96];
-  EXPECT_EQ(last_msg_->reserved[97], 133)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[97])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[97])),
+            133)
       << "incorrect value for reserved[97], expected 133, is "
       << last_msg_->reserved[97];
-  EXPECT_EQ(last_msg_->reserved[98], 169)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[98])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[98])),
+            169)
       << "incorrect value for reserved[98], expected 169, is "
       << last_msg_->reserved[98];
-  EXPECT_EQ(last_msg_->reserved[99], 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[99])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[99])),
+            12)
       << "incorrect value for reserved[99], expected 12, is "
       << last_msg_->reserved[99];
-  EXPECT_EQ(last_msg_->reserved[100], 176)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[100])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[100])),
+            176)
       << "incorrect value for reserved[100], expected 176, is "
       << last_msg_->reserved[100];
-  EXPECT_EQ(last_msg_->reserved[101], 193)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[101])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[101])),
+            193)
       << "incorrect value for reserved[101], expected 193, is "
       << last_msg_->reserved[101];
-  EXPECT_EQ(last_msg_->reserved[102], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[102])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[102])),
+            0)
       << "incorrect value for reserved[102], expected 0, is "
       << last_msg_->reserved[102];
-  EXPECT_EQ(last_msg_->reserved[103], 24)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[103])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[103])),
+            24)
       << "incorrect value for reserved[103], expected 24, is "
       << last_msg_->reserved[103];
-  EXPECT_EQ(last_msg_->reserved[104], 121)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[104])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[104])),
+            121)
       << "incorrect value for reserved[104], expected 121, is "
       << last_msg_->reserved[104];
-  EXPECT_EQ(last_msg_->reserved[105], 85)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[105])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[105])),
+            85)
       << "incorrect value for reserved[105], expected 85, is "
       << last_msg_->reserved[105];
-  EXPECT_EQ(last_msg_->reserved[106], 55)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[106])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[106])),
+            55)
       << "incorrect value for reserved[106], expected 55, is "
       << last_msg_->reserved[106];
-  EXPECT_EQ(last_msg_->reserved[107], 214)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[107])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[107])),
+            214)
       << "incorrect value for reserved[107], expected 214, is "
       << last_msg_->reserved[107];
-  EXPECT_EQ(last_msg_->reserved[108], 198)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[108])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[108])),
+            198)
       << "incorrect value for reserved[108], expected 198, is "
       << last_msg_->reserved[108];
-  EXPECT_EQ(last_msg_->reserved[109], 75)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[109])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[109])),
+            75)
       << "incorrect value for reserved[109], expected 75, is "
       << last_msg_->reserved[109];
-  EXPECT_EQ(last_msg_->reserved[110], 234)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[110])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[110])),
+            234)
       << "incorrect value for reserved[110], expected 234, is "
       << last_msg_->reserved[110];
-  EXPECT_EQ(last_msg_->reserved[111], 179)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[111])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[111])),
+            179)
       << "incorrect value for reserved[111], expected 179, is "
       << last_msg_->reserved[111];
-  EXPECT_EQ(last_msg_->reserved[112], 214)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[112])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[112])),
+            214)
       << "incorrect value for reserved[112], expected 214, is "
       << last_msg_->reserved[112];
-  EXPECT_EQ(last_msg_->reserved[113], 85)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[113])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[113])),
+            85)
       << "incorrect value for reserved[113], expected 85, is "
       << last_msg_->reserved[113];
-  EXPECT_EQ(last_msg_->reserved[114], 94)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[114])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[114])),
+            94)
       << "incorrect value for reserved[114], expected 94, is "
       << last_msg_->reserved[114];
-  EXPECT_EQ(last_msg_->reserved[115], 115)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[115])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[115])),
+            115)
       << "incorrect value for reserved[115], expected 115, is "
       << last_msg_->reserved[115];
-  EXPECT_EQ(last_msg_->reserved[116], 21)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[116])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[116])),
+            21)
       << "incorrect value for reserved[116], expected 21, is "
       << last_msg_->reserved[116];
-  EXPECT_EQ(last_msg_->reserved[117], 73)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[117])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[117])),
+            73)
       << "incorrect value for reserved[117], expected 73, is "
       << last_msg_->reserved[117];
-  EXPECT_EQ(last_msg_->reserved[118], 121)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[118])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[118])),
+            121)
       << "incorrect value for reserved[118], expected 121, is "
       << last_msg_->reserved[118];
-  EXPECT_EQ(last_msg_->reserved[119], 75)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[119])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[119])),
+            75)
       << "incorrect value for reserved[119], expected 75, is "
       << last_msg_->reserved[119];
-  EXPECT_EQ(last_msg_->reserved[120], 46)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[120])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[120])),
+            46)
       << "incorrect value for reserved[120], expected 46, is "
       << last_msg_->reserved[120];
-  EXPECT_EQ(last_msg_->reserved[121], 158)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[121])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[121])),
+            158)
       << "incorrect value for reserved[121], expected 158, is "
       << last_msg_->reserved[121];
-  EXPECT_EQ(last_msg_->reserved[122], 63)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[122])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[122])),
+            63)
       << "incorrect value for reserved[122], expected 63, is "
       << last_msg_->reserved[122];
-  EXPECT_EQ(last_msg_->reserved[123], 100)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[123])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[123])),
+            100)
       << "incorrect value for reserved[123], expected 100, is "
       << last_msg_->reserved[123];
-  EXPECT_EQ(last_msg_->reserved[124], 122)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[124])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[124])),
+            122)
       << "incorrect value for reserved[124], expected 122, is "
       << last_msg_->reserved[124];
-  EXPECT_EQ(last_msg_->reserved[125], 213)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[125])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[125])),
+            213)
       << "incorrect value for reserved[125], expected 213, is "
       << last_msg_->reserved[125];
-  EXPECT_EQ(last_msg_->reserved[126], 20)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[126])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[126])),
+            20)
       << "incorrect value for reserved[126], expected 20, is "
       << last_msg_->reserved[126];
-  EXPECT_EQ(last_msg_->reserved[127], 85)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[127])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[127])),
+            85)
       << "incorrect value for reserved[127], expected 85, is "
       << last_msg_->reserved[127];
-  EXPECT_EQ(last_msg_->reserved[128], 212)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[128])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[128])),
+            212)
       << "incorrect value for reserved[128], expected 212, is "
       << last_msg_->reserved[128];
-  EXPECT_EQ(last_msg_->reserved[129], 131)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[129])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[129])),
+            131)
       << "incorrect value for reserved[129], expected 131, is "
       << last_msg_->reserved[129];
-  EXPECT_EQ(last_msg_->reserved[130], 50)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[130])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[130])),
+            50)
       << "incorrect value for reserved[130], expected 50, is "
       << last_msg_->reserved[130];
-  EXPECT_EQ(last_msg_->reserved[131], 224)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[131])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[131])),
+            224)
       << "incorrect value for reserved[131], expected 224, is "
       << last_msg_->reserved[131];
-  EXPECT_EQ(last_msg_->reserved[132], 218)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[132])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[132])),
+            218)
       << "incorrect value for reserved[132], expected 218, is "
       << last_msg_->reserved[132];
-  EXPECT_EQ(last_msg_->reserved[133], 215)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[133])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[133])),
+            215)
       << "incorrect value for reserved[133], expected 215, is "
       << last_msg_->reserved[133];
-  EXPECT_EQ(last_msg_->reserved[134], 215)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[134])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[134])),
+            215)
       << "incorrect value for reserved[134], expected 215, is "
       << last_msg_->reserved[134];
-  EXPECT_EQ(last_msg_->reserved[135], 149)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[135])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[135])),
+            149)
       << "incorrect value for reserved[135], expected 149, is "
       << last_msg_->reserved[135];
-  EXPECT_EQ(last_msg_->reserved[136], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[136])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[136])),
+            2)
       << "incorrect value for reserved[136], expected 2, is "
       << last_msg_->reserved[136];
-  EXPECT_EQ(last_msg_->reserved[137], 19)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[137])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[137])),
+            19)
       << "incorrect value for reserved[137], expected 19, is "
       << last_msg_->reserved[137];
-  EXPECT_EQ(last_msg_->reserved[138], 129)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[138])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[138])),
+            129)
       << "incorrect value for reserved[138], expected 129, is "
       << last_msg_->reserved[138];
-  EXPECT_EQ(last_msg_->reserved[139], 39)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[139])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[139])),
+            39)
       << "incorrect value for reserved[139], expected 39, is "
       << last_msg_->reserved[139];
-  EXPECT_EQ(last_msg_->reserved[140], 164)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[140])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[140])),
+            164)
       << "incorrect value for reserved[140], expected 164, is "
       << last_msg_->reserved[140];
-  EXPECT_EQ(last_msg_->reserved[141], 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[141])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[141])),
+            5)
       << "incorrect value for reserved[141], expected 5, is "
       << last_msg_->reserved[141];
-  EXPECT_EQ(last_msg_->reserved[142], 175)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[142])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[142])),
+            175)
       << "incorrect value for reserved[142], expected 175, is "
       << last_msg_->reserved[142];
-  EXPECT_EQ(last_msg_->reserved[143], 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[143])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[143])),
+            6)
       << "incorrect value for reserved[143], expected 6, is "
       << last_msg_->reserved[143];
-  EXPECT_EQ(last_msg_->reserved[144], 62)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[144])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[144])),
+            62)
       << "incorrect value for reserved[144], expected 62, is "
       << last_msg_->reserved[144];
-  EXPECT_EQ(last_msg_->reserved[145], 51)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[145])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[145])),
+            51)
       << "incorrect value for reserved[145], expected 51, is "
       << last_msg_->reserved[145];
-  EXPECT_EQ(last_msg_->reserved[146], 78)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[146])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[146])),
+            78)
       << "incorrect value for reserved[146], expected 78, is "
       << last_msg_->reserved[146];
-  EXPECT_EQ(last_msg_->reserved[147], 66)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[147])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[147])),
+            66)
       << "incorrect value for reserved[147], expected 66, is "
       << last_msg_->reserved[147];
-  EXPECT_EQ(last_msg_->reserved[148], 248)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[148])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[148])),
+            248)
       << "incorrect value for reserved[148], expected 248, is "
       << last_msg_->reserved[148];
-  EXPECT_EQ(last_msg_->reserved[149], 116)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[149])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[149])),
+            116)
       << "incorrect value for reserved[149], expected 116, is "
       << last_msg_->reserved[149];
-  EXPECT_EQ(last_msg_->reserved[150], 88)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[150])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[150])),
+            88)
       << "incorrect value for reserved[150], expected 88, is "
       << last_msg_->reserved[150];
-  EXPECT_EQ(last_msg_->reserved[151], 90)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[151])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[151])),
+            90)
       << "incorrect value for reserved[151], expected 90, is "
       << last_msg_->reserved[151];
-  EXPECT_EQ(last_msg_->reserved[152], 128)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[152])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[152])),
+            128)
       << "incorrect value for reserved[152], expected 128, is "
       << last_msg_->reserved[152];
-  EXPECT_EQ(last_msg_->reserved[153], 226)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[153])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[153])),
+            226)
       << "incorrect value for reserved[153], expected 226, is "
       << last_msg_->reserved[153];
-  EXPECT_EQ(last_msg_->reserved[154], 177)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[154])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[154])),
+            177)
       << "incorrect value for reserved[154], expected 177, is "
       << last_msg_->reserved[154];
-  EXPECT_EQ(last_msg_->reserved[155], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[155])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[155])),
+            0)
       << "incorrect value for reserved[155], expected 0, is "
       << last_msg_->reserved[155];
-  EXPECT_EQ(last_msg_->reserved[156], 47)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[156])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[156])),
+            47)
       << "incorrect value for reserved[156], expected 47, is "
       << last_msg_->reserved[156];
-  EXPECT_EQ(last_msg_->reserved[157], 140)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[157])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[157])),
+            140)
       << "incorrect value for reserved[157], expected 140, is "
       << last_msg_->reserved[157];
-  EXPECT_EQ(last_msg_->reserved[158], 33)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[158])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[158])),
+            33)
       << "incorrect value for reserved[158], expected 33, is "
       << last_msg_->reserved[158];
-  EXPECT_EQ(last_msg_->reserved[159], 126)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[159])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[159])),
+            126)
       << "incorrect value for reserved[159], expected 126, is "
       << last_msg_->reserved[159];
-  EXPECT_EQ(last_msg_->reserved[160], 221)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[160])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[160])),
+            221)
       << "incorrect value for reserved[160], expected 221, is "
       << last_msg_->reserved[160];
-  EXPECT_EQ(last_msg_->reserved[161], 110)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[161])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[161])),
+            110)
       << "incorrect value for reserved[161], expected 110, is "
       << last_msg_->reserved[161];
-  EXPECT_EQ(last_msg_->reserved[162], 144)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[162])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[162])),
+            144)
       << "incorrect value for reserved[162], expected 144, is "
       << last_msg_->reserved[162];
-  EXPECT_EQ(last_msg_->reserved[163], 97)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[163])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[163])),
+            97)
       << "incorrect value for reserved[163], expected 97, is "
       << last_msg_->reserved[163];
-  EXPECT_EQ(last_msg_->reserved[164], 74)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[164])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[164])),
+            74)
       << "incorrect value for reserved[164], expected 74, is "
       << last_msg_->reserved[164];
-  EXPECT_EQ(last_msg_->reserved[165], 250)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[165])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[165])),
+            250)
       << "incorrect value for reserved[165], expected 250, is "
       << last_msg_->reserved[165];
-  EXPECT_EQ(last_msg_->reserved[166], 181)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[166])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[166])),
+            181)
       << "incorrect value for reserved[166], expected 181, is "
       << last_msg_->reserved[166];
-  EXPECT_EQ(last_msg_->reserved[167], 199)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[167])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[167])),
+            199)
       << "incorrect value for reserved[167], expected 199, is "
       << last_msg_->reserved[167];
-  EXPECT_EQ(last_msg_->reserved[168], 27)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[168])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[168])),
+            27)
       << "incorrect value for reserved[168], expected 27, is "
       << last_msg_->reserved[168];
-  EXPECT_EQ(last_msg_->reserved[169], 176)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[169])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[169])),
+            176)
       << "incorrect value for reserved[169], expected 176, is "
       << last_msg_->reserved[169];
-  EXPECT_EQ(last_msg_->reserved[170], 65)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[170])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[170])),
+            65)
       << "incorrect value for reserved[170], expected 65, is "
       << last_msg_->reserved[170];
-  EXPECT_EQ(last_msg_->reserved[171], 185)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[171])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[171])),
+            185)
       << "incorrect value for reserved[171], expected 185, is "
       << last_msg_->reserved[171];
-  EXPECT_EQ(last_msg_->reserved[172], 110)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[172])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[172])),
+            110)
       << "incorrect value for reserved[172], expected 110, is "
       << last_msg_->reserved[172];
-  EXPECT_EQ(last_msg_->reserved[173], 92)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[173])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[173])),
+            92)
       << "incorrect value for reserved[173], expected 92, is "
       << last_msg_->reserved[173];
-  EXPECT_EQ(last_msg_->reserved[174], 34)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[174])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[174])),
+            34)
       << "incorrect value for reserved[174], expected 34, is "
       << last_msg_->reserved[174];
-  EXPECT_EQ(last_msg_->reserved[175], 44)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[175])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[175])),
+            44)
       << "incorrect value for reserved[175], expected 44, is "
       << last_msg_->reserved[175];
-  EXPECT_EQ(last_msg_->reserved[176], 131)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[176])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[176])),
+            131)
       << "incorrect value for reserved[176], expected 131, is "
       << last_msg_->reserved[176];
-  EXPECT_EQ(last_msg_->reserved[177], 96)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[177])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[177])),
+            96)
       << "incorrect value for reserved[177], expected 96, is "
       << last_msg_->reserved[177];
-  EXPECT_EQ(last_msg_->reserved[178], 178)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[178])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[178])),
+            178)
       << "incorrect value for reserved[178], expected 178, is "
       << last_msg_->reserved[178];
-  EXPECT_EQ(last_msg_->reserved[179], 40)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[179])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[179])),
+            40)
       << "incorrect value for reserved[179], expected 40, is "
       << last_msg_->reserved[179];
-  EXPECT_EQ(last_msg_->reserved[180], 176)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[180])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[180])),
+            176)
       << "incorrect value for reserved[180], expected 176, is "
       << last_msg_->reserved[180];
-  EXPECT_EQ(last_msg_->reserved[181], 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[181])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[181])),
+            4)
       << "incorrect value for reserved[181], expected 4, is "
       << last_msg_->reserved[181];
-  EXPECT_EQ(last_msg_->reserved[182], 90)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[182])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[182])),
+            90)
       << "incorrect value for reserved[182], expected 90, is "
       << last_msg_->reserved[182];
-  EXPECT_EQ(last_msg_->reserved[183], 36)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[183])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[183])),
+            36)
       << "incorrect value for reserved[183], expected 36, is "
       << last_msg_->reserved[183];
-  EXPECT_EQ(last_msg_->reserved[184], 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[184])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[184])),
+            7)
       << "incorrect value for reserved[184], expected 7, is "
       << last_msg_->reserved[184];
-  EXPECT_EQ(last_msg_->reserved[185], 180)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[185])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[185])),
+            180)
       << "incorrect value for reserved[185], expected 180, is "
       << last_msg_->reserved[185];
-  EXPECT_EQ(last_msg_->reserved[186], 244)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[186])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[186])),
+            244)
       << "incorrect value for reserved[186], expected 244, is "
       << last_msg_->reserved[186];
-  EXPECT_EQ(last_msg_->reserved[187], 244)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[187])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[187])),
+            244)
       << "incorrect value for reserved[187], expected 244, is "
       << last_msg_->reserved[187];
-  EXPECT_EQ(last_msg_->reserved[188], 23)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[188])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[188])),
+            23)
       << "incorrect value for reserved[188], expected 23, is "
       << last_msg_->reserved[188];
-  EXPECT_EQ(last_msg_->reserved[189], 108)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[189])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[189])),
+            108)
       << "incorrect value for reserved[189], expected 108, is "
       << last_msg_->reserved[189];
-  EXPECT_EQ(last_msg_->reserved[190], 171)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[190])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[190])),
+            171)
       << "incorrect value for reserved[190], expected 171, is "
       << last_msg_->reserved[190];
-  EXPECT_EQ(last_msg_->reserved[191], 204)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[191])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[191])),
+            204)
       << "incorrect value for reserved[191], expected 204, is "
       << last_msg_->reserved[191];
-  EXPECT_EQ(last_msg_->reserved[192], 196)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[192])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[192])),
+            196)
       << "incorrect value for reserved[192], expected 196, is "
       << last_msg_->reserved[192];
-  EXPECT_EQ(last_msg_->reserved[193], 61)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[193])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[193])),
+            61)
       << "incorrect value for reserved[193], expected 61, is "
       << last_msg_->reserved[193];
-  EXPECT_EQ(last_msg_->reserved[194], 51)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[194])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[194])),
+            51)
       << "incorrect value for reserved[194], expected 51, is "
       << last_msg_->reserved[194];
-  EXPECT_EQ(last_msg_->reserved[195], 179)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[195])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[195])),
+            179)
       << "incorrect value for reserved[195], expected 179, is "
       << last_msg_->reserved[195];
-  EXPECT_EQ(last_msg_->reserved[196], 242)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[196])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[196])),
+            242)
       << "incorrect value for reserved[196], expected 242, is "
       << last_msg_->reserved[196];
-  EXPECT_EQ(last_msg_->reserved[197], 156)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[197])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[197])),
+            156)
       << "incorrect value for reserved[197], expected 156, is "
       << last_msg_->reserved[197];
-  EXPECT_EQ(last_msg_->reserved[198], 81)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[198])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[198])),
+            81)
       << "incorrect value for reserved[198], expected 81, is "
       << last_msg_->reserved[198];
-  EXPECT_EQ(last_msg_->reserved[199], 83)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[199])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[199])),
+            83)
       << "incorrect value for reserved[199], expected 83, is "
       << last_msg_->reserved[199];
-  EXPECT_EQ(last_msg_->reserved[200], 16)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[200])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[200])),
+            16)
       << "incorrect value for reserved[200], expected 16, is "
       << last_msg_->reserved[200];
-  EXPECT_EQ(last_msg_->reserved[201], 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[201])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[201])),
+            15)
       << "incorrect value for reserved[201], expected 15, is "
       << last_msg_->reserved[201];
-  EXPECT_EQ(last_msg_->reserved[202], 134)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[202])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[202])),
+            134)
       << "incorrect value for reserved[202], expected 134, is "
       << last_msg_->reserved[202];
-  EXPECT_EQ(last_msg_->reserved[203], 40)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[203])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[203])),
+            40)
       << "incorrect value for reserved[203], expected 40, is "
       << last_msg_->reserved[203];
-  EXPECT_EQ(last_msg_->reserved[204], 245)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[204])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[204])),
+            245)
       << "incorrect value for reserved[204], expected 245, is "
       << last_msg_->reserved[204];
-  EXPECT_EQ(last_msg_->reserved[205], 253)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[205])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[205])),
+            253)
       << "incorrect value for reserved[205], expected 253, is "
       << last_msg_->reserved[205];
-  EXPECT_EQ(last_msg_->reserved[206], 150)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[206])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[206])),
+            150)
       << "incorrect value for reserved[206], expected 150, is "
       << last_msg_->reserved[206];
-  EXPECT_EQ(last_msg_->reserved[207], 94)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[207])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[207])),
+            94)
       << "incorrect value for reserved[207], expected 94, is "
       << last_msg_->reserved[207];
-  EXPECT_EQ(last_msg_->reserved[208], 150)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[208])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[208])),
+            150)
       << "incorrect value for reserved[208], expected 150, is "
       << last_msg_->reserved[208];
-  EXPECT_EQ(last_msg_->reserved[209], 144)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[209])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[209])),
+            144)
       << "incorrect value for reserved[209], expected 144, is "
       << last_msg_->reserved[209];
-  EXPECT_EQ(last_msg_->reserved[210], 197)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[210])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[210])),
+            197)
       << "incorrect value for reserved[210], expected 197, is "
       << last_msg_->reserved[210];
-  EXPECT_EQ(last_msg_->reserved[211], 113)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[211])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[211])),
+            113)
       << "incorrect value for reserved[211], expected 113, is "
       << last_msg_->reserved[211];
-  EXPECT_EQ(last_msg_->reserved[212], 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[212])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[212])),
+            5)
       << "incorrect value for reserved[212], expected 5, is "
       << last_msg_->reserved[212];
-  EXPECT_EQ(last_msg_->reserved[213], 141)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[213])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[213])),
+            141)
       << "incorrect value for reserved[213], expected 141, is "
       << last_msg_->reserved[213];
-  EXPECT_EQ(last_msg_->reserved[214], 232)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[214])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[214])),
+            232)
       << "incorrect value for reserved[214], expected 232, is "
       << last_msg_->reserved[214];
-  EXPECT_EQ(last_msg_->reserved[215], 33)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[215])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[215])),
+            33)
       << "incorrect value for reserved[215], expected 33, is "
       << last_msg_->reserved[215];
-  EXPECT_EQ(last_msg_->reserved[216], 101)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[216])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[216])),
+            101)
       << "incorrect value for reserved[216], expected 101, is "
       << last_msg_->reserved[216];
-  EXPECT_EQ(last_msg_->reserved[217], 231)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[217])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[217])),
+            231)
       << "incorrect value for reserved[217], expected 231, is "
       << last_msg_->reserved[217];
-  EXPECT_EQ(last_msg_->reserved[218], 38)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[218])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[218])),
+            38)
       << "incorrect value for reserved[218], expected 38, is "
       << last_msg_->reserved[218];
-  EXPECT_EQ(last_msg_->reserved[219], 75)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[219])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[219])),
+            75)
       << "incorrect value for reserved[219], expected 75, is "
       << last_msg_->reserved[219];
-  EXPECT_EQ(last_msg_->reserved[220], 178)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[220])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[220])),
+            178)
       << "incorrect value for reserved[220], expected 178, is "
       << last_msg_->reserved[220];
-  EXPECT_EQ(last_msg_->reserved[221], 243)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[221])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[221])),
+            243)
       << "incorrect value for reserved[221], expected 243, is "
       << last_msg_->reserved[221];
-  EXPECT_EQ(last_msg_->reserved[222], 119)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[222])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[222])),
+            119)
       << "incorrect value for reserved[222], expected 119, is "
       << last_msg_->reserved[222];
-  EXPECT_EQ(last_msg_->reserved[223], 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[223])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[223])),
+            1)
       << "incorrect value for reserved[223], expected 1, is "
       << last_msg_->reserved[223];
-  EXPECT_EQ(last_msg_->reserved[224], 248)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[224])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[224])),
+            248)
       << "incorrect value for reserved[224], expected 248, is "
       << last_msg_->reserved[224];
-  EXPECT_EQ(last_msg_->reserved[225], 218)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[225])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[225])),
+            218)
       << "incorrect value for reserved[225], expected 218, is "
       << last_msg_->reserved[225];
-  EXPECT_EQ(last_msg_->reserved[226], 86)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[226])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[226])),
+            86)
       << "incorrect value for reserved[226], expected 86, is "
       << last_msg_->reserved[226];
-  EXPECT_EQ(last_msg_->reserved[227], 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[227])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[227])),
+            7)
       << "incorrect value for reserved[227], expected 7, is "
       << last_msg_->reserved[227];
-  EXPECT_EQ(last_msg_->reserved[228], 88)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[228])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[228])),
+            88)
       << "incorrect value for reserved[228], expected 88, is "
       << last_msg_->reserved[228];
-  EXPECT_EQ(last_msg_->reserved[229], 197)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[229])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[229])),
+            197)
       << "incorrect value for reserved[229], expected 197, is "
       << last_msg_->reserved[229];
-  EXPECT_EQ(last_msg_->reserved[230], 148)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[230])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[230])),
+            148)
       << "incorrect value for reserved[230], expected 148, is "
       << last_msg_->reserved[230];
-  EXPECT_EQ(last_msg_->reserved[231], 240)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[231])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[231])),
+            240)
       << "incorrect value for reserved[231], expected 240, is "
       << last_msg_->reserved[231];
-  EXPECT_EQ(last_msg_->reserved[232], 227)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[232])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[232])),
+            227)
       << "incorrect value for reserved[232], expected 227, is "
       << last_msg_->reserved[232];
-  EXPECT_EQ(last_msg_->reserved[233], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[233])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[233])),
+            2)
       << "incorrect value for reserved[233], expected 2, is "
       << last_msg_->reserved[233];
-  EXPECT_EQ(last_msg_->reserved[234], 65)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[234])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[234])),
+            65)
       << "incorrect value for reserved[234], expected 65, is "
       << last_msg_->reserved[234];
-  EXPECT_EQ(last_msg_->reserved[235], 173)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[235])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[235])),
+            173)
       << "incorrect value for reserved[235], expected 173, is "
       << last_msg_->reserved[235];
-  EXPECT_EQ(last_msg_->reserved[236], 122)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[236])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[236])),
+            122)
       << "incorrect value for reserved[236], expected 122, is "
       << last_msg_->reserved[236];
-  EXPECT_EQ(last_msg_->reserved[237], 143)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[237])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[237])),
+            143)
       << "incorrect value for reserved[237], expected 143, is "
       << last_msg_->reserved[237];
-  EXPECT_EQ(last_msg_->reserved[238], 251)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[238])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[238])),
+            251)
       << "incorrect value for reserved[238], expected 251, is "
       << last_msg_->reserved[238];
-  EXPECT_EQ(last_msg_->reserved[239], 156)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[239])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[239])),
+            156)
       << "incorrect value for reserved[239], expected 156, is "
       << last_msg_->reserved[239];
-  EXPECT_EQ(last_msg_->reserved[240], 217)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[240])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[240])),
+            217)
       << "incorrect value for reserved[240], expected 217, is "
       << last_msg_->reserved[240];
-  EXPECT_EQ(last_msg_->reserved[241], 67)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[241])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[241])),
+            67)
       << "incorrect value for reserved[241], expected 67, is "
       << last_msg_->reserved[241];
-  EXPECT_EQ(last_msg_->reserved[242], 239)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[242])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[242])),
+            239)
       << "incorrect value for reserved[242], expected 239, is "
       << last_msg_->reserved[242];
-  EXPECT_EQ(last_msg_->reserved[243], 219)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[243])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[243])),
+            219)
       << "incorrect value for reserved[243], expected 219, is "
       << last_msg_->reserved[243];
-  EXPECT_EQ(last_msg_->reserved[244], 31)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[244])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[244])),
+            31)
       << "incorrect value for reserved[244], expected 31, is "
       << last_msg_->reserved[244];
-  EXPECT_EQ(last_msg_->reserved[245], 224)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[245])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[245])),
+            224)
       << "incorrect value for reserved[245], expected 224, is "
       << last_msg_->reserved[245];
-  EXPECT_EQ(last_msg_->reserved[246], 176)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[246])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[246])),
+            176)
       << "incorrect value for reserved[246], expected 176, is "
       << last_msg_->reserved[246];
-  EXPECT_EQ(last_msg_->reserved[247], 129)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[247])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[247])),
+            129)
       << "incorrect value for reserved[247], expected 129, is "
       << last_msg_->reserved[247];
-  EXPECT_EQ(last_msg_->reserved[248], 81)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[248])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[248])),
+            81)
       << "incorrect value for reserved[248], expected 81, is "
       << last_msg_->reserved[248];
-  EXPECT_EQ(last_msg_->reserved[249], 80)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved[249])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved[249])),
+            80)
       << "incorrect value for reserved[249], expected 80, is "
       << last_msg_->reserved[249];
   EXPECT_LT((last_msg_->signal_error_rate * 100 - 8588.20019531 * 100), 0.05)
       << "incorrect value for signal_error_rate, expected 8588.20019531, is "
       << last_msg_->signal_error_rate;
-  EXPECT_EQ(last_msg_->signal_strength, 103)
+  EXPECT_EQ(get_as<decltype(last_msg_->signal_strength)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signal_strength)),
+            103)
       << "incorrect value for signal_strength, expected 103, is "
       << last_msg_->signal_strength;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_piksi_MsgCommandOutput.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_piksi_MsgCommandOutput.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/piksi.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_piksi_MsgCommandOutput0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -130,7 +137,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgCommandOutput0, Test) {
         << "incorrect value for last_msg_->line, expected string '"
         << check_string << "', is '" << last_msg_->line << "'";
   }
-  EXPECT_EQ(last_msg_->sequence, 2507449470)
+  EXPECT_EQ(get_as<decltype(last_msg_->sequence)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sequence)),
+            2507449470)
       << "incorrect value for sequence, expected 2507449470, is "
       << last_msg_->sequence;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_piksi_MsgCommandReq.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_piksi_MsgCommandReq.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/piksi.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_piksi_MsgCommandReq0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -135,7 +142,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgCommandReq0, Test) {
         << "incorrect value for last_msg_->command, expected string '"
         << check_string << "', is '" << last_msg_->command << "'";
   }
-  EXPECT_EQ(last_msg_->sequence, 1755532595)
+  EXPECT_EQ(get_as<decltype(last_msg_->sequence)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sequence)),
+            1755532595)
       << "incorrect value for sequence, expected 1755532595, is "
       << last_msg_->sequence;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_piksi_MsgCommandResp.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_piksi_MsgCommandResp.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/piksi.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_piksi_MsgCommandResp0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -111,10 +118,14 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgCommandResp0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 52793);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->code, 1737912018)
+  EXPECT_EQ(get_as<decltype(last_msg_->code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->code)),
+            1737912018)
       << "incorrect value for code, expected 1737912018, is "
       << last_msg_->code;
-  EXPECT_EQ(last_msg_->sequence, 2692994934)
+  EXPECT_EQ(get_as<decltype(last_msg_->sequence)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sequence)),
+            2692994934)
       << "incorrect value for sequence, expected 2692994934, is "
       << last_msg_->sequence;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_piksi_MsgCwResults.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_piksi_MsgCwResults.cc
@@ -29,3 +29,10 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/piksi.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}

--- a/c/test/legacy/cpp/auto_check_sbp_piksi_MsgCwStart.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_piksi_MsgCwStart.cc
@@ -29,3 +29,10 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/piksi.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}

--- a/c/test/legacy/cpp/auto_check_sbp_piksi_MsgDeviceMonitor.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_piksi_MsgDeviceMonitor.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/piksi.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_piksi_MsgDeviceMonitor0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -115,19 +122,29 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgDeviceMonitor0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 16991);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->cpu_temperature, 6165)
+  EXPECT_EQ(get_as<decltype(last_msg_->cpu_temperature)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cpu_temperature)),
+            6165)
       << "incorrect value for cpu_temperature, expected 6165, is "
       << last_msg_->cpu_temperature;
-  EXPECT_EQ(last_msg_->cpu_vaux, 1789)
+  EXPECT_EQ(get_as<decltype(last_msg_->cpu_vaux)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cpu_vaux)),
+            1789)
       << "incorrect value for cpu_vaux, expected 1789, is "
       << last_msg_->cpu_vaux;
-  EXPECT_EQ(last_msg_->cpu_vint, 987)
+  EXPECT_EQ(get_as<decltype(last_msg_->cpu_vint)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cpu_vint)),
+            987)
       << "incorrect value for cpu_vint, expected 987, is "
       << last_msg_->cpu_vint;
-  EXPECT_EQ(last_msg_->dev_vin, -9999)
+  EXPECT_EQ(get_as<decltype(last_msg_->dev_vin)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->dev_vin)),
+            -9999)
       << "incorrect value for dev_vin, expected -9999, is "
       << last_msg_->dev_vin;
-  EXPECT_EQ(last_msg_->fe_temperature, 4776)
+  EXPECT_EQ(get_as<decltype(last_msg_->fe_temperature)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fe_temperature)),
+            4776)
       << "incorrect value for fe_temperature, expected 4776, is "
       << last_msg_->fe_temperature;
 }
@@ -217,19 +234,29 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgDeviceMonitor1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 16991);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->cpu_temperature, 6168)
+  EXPECT_EQ(get_as<decltype(last_msg_->cpu_temperature)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cpu_temperature)),
+            6168)
       << "incorrect value for cpu_temperature, expected 6168, is "
       << last_msg_->cpu_temperature;
-  EXPECT_EQ(last_msg_->cpu_vaux, 1790)
+  EXPECT_EQ(get_as<decltype(last_msg_->cpu_vaux)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cpu_vaux)),
+            1790)
       << "incorrect value for cpu_vaux, expected 1790, is "
       << last_msg_->cpu_vaux;
-  EXPECT_EQ(last_msg_->cpu_vint, 987)
+  EXPECT_EQ(get_as<decltype(last_msg_->cpu_vint)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cpu_vint)),
+            987)
       << "incorrect value for cpu_vint, expected 987, is "
       << last_msg_->cpu_vint;
-  EXPECT_EQ(last_msg_->dev_vin, -9999)
+  EXPECT_EQ(get_as<decltype(last_msg_->dev_vin)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->dev_vin)),
+            -9999)
       << "incorrect value for dev_vin, expected -9999, is "
       << last_msg_->dev_vin;
-  EXPECT_EQ(last_msg_->fe_temperature, 4776)
+  EXPECT_EQ(get_as<decltype(last_msg_->fe_temperature)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fe_temperature)),
+            4776)
       << "incorrect value for fe_temperature, expected 4776, is "
       << last_msg_->fe_temperature;
 }
@@ -319,19 +346,29 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgDeviceMonitor2, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 16991);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->cpu_temperature, 6166)
+  EXPECT_EQ(get_as<decltype(last_msg_->cpu_temperature)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cpu_temperature)),
+            6166)
       << "incorrect value for cpu_temperature, expected 6166, is "
       << last_msg_->cpu_temperature;
-  EXPECT_EQ(last_msg_->cpu_vaux, 1789)
+  EXPECT_EQ(get_as<decltype(last_msg_->cpu_vaux)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cpu_vaux)),
+            1789)
       << "incorrect value for cpu_vaux, expected 1789, is "
       << last_msg_->cpu_vaux;
-  EXPECT_EQ(last_msg_->cpu_vint, 987)
+  EXPECT_EQ(get_as<decltype(last_msg_->cpu_vint)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cpu_vint)),
+            987)
       << "incorrect value for cpu_vint, expected 987, is "
       << last_msg_->cpu_vint;
-  EXPECT_EQ(last_msg_->dev_vin, -9999)
+  EXPECT_EQ(get_as<decltype(last_msg_->dev_vin)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->dev_vin)),
+            -9999)
       << "incorrect value for dev_vin, expected -9999, is "
       << last_msg_->dev_vin;
-  EXPECT_EQ(last_msg_->fe_temperature, 4776)
+  EXPECT_EQ(get_as<decltype(last_msg_->fe_temperature)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fe_temperature)),
+            4776)
       << "incorrect value for fe_temperature, expected 4776, is "
       << last_msg_->fe_temperature;
 }
@@ -421,19 +458,29 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgDeviceMonitor3, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 16991);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->cpu_temperature, 6150)
+  EXPECT_EQ(get_as<decltype(last_msg_->cpu_temperature)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cpu_temperature)),
+            6150)
       << "incorrect value for cpu_temperature, expected 6150, is "
       << last_msg_->cpu_temperature;
-  EXPECT_EQ(last_msg_->cpu_vaux, 1788)
+  EXPECT_EQ(get_as<decltype(last_msg_->cpu_vaux)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cpu_vaux)),
+            1788)
       << "incorrect value for cpu_vaux, expected 1788, is "
       << last_msg_->cpu_vaux;
-  EXPECT_EQ(last_msg_->cpu_vint, 986)
+  EXPECT_EQ(get_as<decltype(last_msg_->cpu_vint)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cpu_vint)),
+            986)
       << "incorrect value for cpu_vint, expected 986, is "
       << last_msg_->cpu_vint;
-  EXPECT_EQ(last_msg_->dev_vin, -9999)
+  EXPECT_EQ(get_as<decltype(last_msg_->dev_vin)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->dev_vin)),
+            -9999)
       << "incorrect value for dev_vin, expected -9999, is "
       << last_msg_->dev_vin;
-  EXPECT_EQ(last_msg_->fe_temperature, 4776)
+  EXPECT_EQ(get_as<decltype(last_msg_->fe_temperature)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fe_temperature)),
+            4776)
       << "incorrect value for fe_temperature, expected 4776, is "
       << last_msg_->fe_temperature;
 }
@@ -523,19 +570,29 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgDeviceMonitor4, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 16991);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->cpu_temperature, 6123)
+  EXPECT_EQ(get_as<decltype(last_msg_->cpu_temperature)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cpu_temperature)),
+            6123)
       << "incorrect value for cpu_temperature, expected 6123, is "
       << last_msg_->cpu_temperature;
-  EXPECT_EQ(last_msg_->cpu_vaux, 1789)
+  EXPECT_EQ(get_as<decltype(last_msg_->cpu_vaux)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cpu_vaux)),
+            1789)
       << "incorrect value for cpu_vaux, expected 1789, is "
       << last_msg_->cpu_vaux;
-  EXPECT_EQ(last_msg_->cpu_vint, 988)
+  EXPECT_EQ(get_as<decltype(last_msg_->cpu_vint)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cpu_vint)),
+            988)
       << "incorrect value for cpu_vint, expected 988, is "
       << last_msg_->cpu_vint;
-  EXPECT_EQ(last_msg_->dev_vin, -9999)
+  EXPECT_EQ(get_as<decltype(last_msg_->dev_vin)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->dev_vin)),
+            -9999)
       << "incorrect value for dev_vin, expected -9999, is "
       << last_msg_->dev_vin;
-  EXPECT_EQ(last_msg_->fe_temperature, 4776)
+  EXPECT_EQ(get_as<decltype(last_msg_->fe_temperature)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fe_temperature)),
+            4776)
       << "incorrect value for fe_temperature, expected 4776, is "
       << last_msg_->fe_temperature;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_piksi_MsgFrontEndGain.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_piksi_MsgFrontEndGain.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/piksi.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_piksi_MsgFrontEndGain0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -190,52 +197,84 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgFrontEndGain0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 62895);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->if_gain[0], -10)
+  EXPECT_EQ(get_as<decltype(last_msg_->if_gain[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->if_gain[0])),
+            -10)
       << "incorrect value for if_gain[0], expected -10, is "
       << last_msg_->if_gain[0];
-  EXPECT_EQ(last_msg_->if_gain[1], -23)
+  EXPECT_EQ(get_as<decltype(last_msg_->if_gain[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->if_gain[1])),
+            -23)
       << "incorrect value for if_gain[1], expected -23, is "
       << last_msg_->if_gain[1];
-  EXPECT_EQ(last_msg_->if_gain[2], -40)
+  EXPECT_EQ(get_as<decltype(last_msg_->if_gain[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->if_gain[2])),
+            -40)
       << "incorrect value for if_gain[2], expected -40, is "
       << last_msg_->if_gain[2];
-  EXPECT_EQ(last_msg_->if_gain[3], 80)
+  EXPECT_EQ(get_as<decltype(last_msg_->if_gain[3])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->if_gain[3])),
+            80)
       << "incorrect value for if_gain[3], expected 80, is "
       << last_msg_->if_gain[3];
-  EXPECT_EQ(last_msg_->if_gain[4], -69)
+  EXPECT_EQ(get_as<decltype(last_msg_->if_gain[4])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->if_gain[4])),
+            -69)
       << "incorrect value for if_gain[4], expected -69, is "
       << last_msg_->if_gain[4];
-  EXPECT_EQ(last_msg_->if_gain[5], -43)
+  EXPECT_EQ(get_as<decltype(last_msg_->if_gain[5])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->if_gain[5])),
+            -43)
       << "incorrect value for if_gain[5], expected -43, is "
       << last_msg_->if_gain[5];
-  EXPECT_EQ(last_msg_->if_gain[6], 85)
+  EXPECT_EQ(get_as<decltype(last_msg_->if_gain[6])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->if_gain[6])),
+            85)
       << "incorrect value for if_gain[6], expected 85, is "
       << last_msg_->if_gain[6];
-  EXPECT_EQ(last_msg_->if_gain[7], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->if_gain[7])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->if_gain[7])),
+            2)
       << "incorrect value for if_gain[7], expected 2, is "
       << last_msg_->if_gain[7];
-  EXPECT_EQ(last_msg_->rf_gain[0], 41)
+  EXPECT_EQ(get_as<decltype(last_msg_->rf_gain[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rf_gain[0])),
+            41)
       << "incorrect value for rf_gain[0], expected 41, is "
       << last_msg_->rf_gain[0];
-  EXPECT_EQ(last_msg_->rf_gain[1], -123)
+  EXPECT_EQ(get_as<decltype(last_msg_->rf_gain[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rf_gain[1])),
+            -123)
       << "incorrect value for rf_gain[1], expected -123, is "
       << last_msg_->rf_gain[1];
-  EXPECT_EQ(last_msg_->rf_gain[2], -122)
+  EXPECT_EQ(get_as<decltype(last_msg_->rf_gain[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rf_gain[2])),
+            -122)
       << "incorrect value for rf_gain[2], expected -122, is "
       << last_msg_->rf_gain[2];
-  EXPECT_EQ(last_msg_->rf_gain[3], 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->rf_gain[3])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rf_gain[3])),
+            10)
       << "incorrect value for rf_gain[3], expected 10, is "
       << last_msg_->rf_gain[3];
-  EXPECT_EQ(last_msg_->rf_gain[4], 105)
+  EXPECT_EQ(get_as<decltype(last_msg_->rf_gain[4])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rf_gain[4])),
+            105)
       << "incorrect value for rf_gain[4], expected 105, is "
       << last_msg_->rf_gain[4];
-  EXPECT_EQ(last_msg_->rf_gain[5], 20)
+  EXPECT_EQ(get_as<decltype(last_msg_->rf_gain[5])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rf_gain[5])),
+            20)
       << "incorrect value for rf_gain[5], expected 20, is "
       << last_msg_->rf_gain[5];
-  EXPECT_EQ(last_msg_->rf_gain[6], 38)
+  EXPECT_EQ(get_as<decltype(last_msg_->rf_gain[6])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rf_gain[6])),
+            38)
       << "incorrect value for rf_gain[6], expected 38, is "
       << last_msg_->rf_gain[6];
-  EXPECT_EQ(last_msg_->rf_gain[7], 38)
+  EXPECT_EQ(get_as<decltype(last_msg_->rf_gain[7])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rf_gain[7])),
+            38)
       << "incorrect value for rf_gain[7], expected 38, is "
       << last_msg_->rf_gain[7];
 }

--- a/c/test/legacy/cpp/auto_check_sbp_piksi_MsgIarState.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_piksi_MsgIarState.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/piksi.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_piksi_MsgIarState0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -110,7 +117,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgIarState0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->num_hyps, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->num_hyps)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->num_hyps)),
+            1)
       << "incorrect value for num_hyps, expected 1, is " << last_msg_->num_hyps;
 }
 class Test_legacy_auto_check_sbp_piksi_MsgIarState1
@@ -194,7 +203,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgIarState1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->num_hyps, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->num_hyps)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->num_hyps)),
+            0)
       << "incorrect value for num_hyps, expected 0, is " << last_msg_->num_hyps;
 }
 class Test_legacy_auto_check_sbp_piksi_MsgIarState2
@@ -278,7 +289,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgIarState2, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->num_hyps, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->num_hyps)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->num_hyps)),
+            1)
       << "incorrect value for num_hyps, expected 1, is " << last_msg_->num_hyps;
 }
 class Test_legacy_auto_check_sbp_piksi_MsgIarState3
@@ -362,7 +375,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgIarState3, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->num_hyps, 729)
+  EXPECT_EQ(get_as<decltype(last_msg_->num_hyps)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->num_hyps)),
+            729)
       << "incorrect value for num_hyps, expected 729, is "
       << last_msg_->num_hyps;
 }
@@ -447,7 +462,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgIarState4, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->num_hyps, 728)
+  EXPECT_EQ(get_as<decltype(last_msg_->num_hyps)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->num_hyps)),
+            728)
       << "incorrect value for num_hyps, expected 728, is "
       << last_msg_->num_hyps;
 }
@@ -532,7 +549,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgIarState5, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->num_hyps, 727)
+  EXPECT_EQ(get_as<decltype(last_msg_->num_hyps)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->num_hyps)),
+            727)
       << "incorrect value for num_hyps, expected 727, is "
       << last_msg_->num_hyps;
 }
@@ -617,7 +636,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgIarState6, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->num_hyps, 723)
+  EXPECT_EQ(get_as<decltype(last_msg_->num_hyps)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->num_hyps)),
+            723)
       << "incorrect value for num_hyps, expected 723, is "
       << last_msg_->num_hyps;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_piksi_MsgInitBaseDep.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_piksi_MsgInitBaseDep.cc
@@ -29,3 +29,10 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/piksi.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}

--- a/c/test/legacy/cpp/auto_check_sbp_piksi_MsgMaskSatellite.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_piksi_MsgMaskSatellite.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/piksi.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_piksi_MsgMaskSatellite0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -112,11 +119,17 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgMaskSatellite0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 38829);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->mask, 183)
+  EXPECT_EQ(get_as<decltype(last_msg_->mask)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->mask)),
+            183)
       << "incorrect value for mask, expected 183, is " << last_msg_->mask;
-  EXPECT_EQ(last_msg_->sid.code, 57)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.code)),
+            57)
       << "incorrect value for sid.code, expected 57, is "
       << last_msg_->sid.code;
-  EXPECT_EQ(last_msg_->sid.sat, 87)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.sat)),
+            87)
       << "incorrect value for sid.sat, expected 87, is " << last_msg_->sid.sat;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_piksi_MsgMaskSatelliteDep.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_piksi_MsgMaskSatelliteDep.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/piksi.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_piksi_MsgMaskSatelliteDep0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -115,15 +122,23 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgMaskSatelliteDep0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 34491);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->mask, 33)
+  EXPECT_EQ(get_as<decltype(last_msg_->mask)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->mask)),
+            33)
       << "incorrect value for mask, expected 33, is " << last_msg_->mask;
-  EXPECT_EQ(last_msg_->sid.code, 95)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.code)),
+            95)
       << "incorrect value for sid.code, expected 95, is "
       << last_msg_->sid.code;
-  EXPECT_EQ(last_msg_->sid.reserved, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.reserved)),
+            4)
       << "incorrect value for sid.reserved, expected 4, is "
       << last_msg_->sid.reserved;
-  EXPECT_EQ(last_msg_->sid.sat, 39170)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.sat)),
+            39170)
       << "incorrect value for sid.sat, expected 39170, is "
       << last_msg_->sid.sat;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_piksi_MsgNetworkBandwidthUsage.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_piksi_MsgNetworkBandwidthUsage.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/piksi.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_piksi_MsgNetworkBandwidthUsage0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -219,7 +226,10 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgNetworkBandwidthUsage0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 31183);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->interfaces[0].duration, 2159176030)
+  EXPECT_EQ(get_as<decltype(last_msg_->interfaces[0].duration)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->interfaces[0].duration)),
+            2159176030)
       << "incorrect value for interfaces[0].duration, expected 2159176030, is "
       << last_msg_->interfaces[0].duration;
   {
@@ -235,16 +245,28 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgNetworkBandwidthUsage0, Test) {
         << check_string << "', is '" << last_msg_->interfaces[0].interface_name
         << "'";
   }
-  EXPECT_EQ(last_msg_->interfaces[0].rx_bytes, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->interfaces[0].rx_bytes)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->interfaces[0].rx_bytes)),
+            0)
       << "incorrect value for interfaces[0].rx_bytes, expected 0, is "
       << last_msg_->interfaces[0].rx_bytes;
-  EXPECT_EQ(last_msg_->interfaces[0].total_bytes, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->interfaces[0].total_bytes)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->interfaces[0].total_bytes)),
+            0)
       << "incorrect value for interfaces[0].total_bytes, expected 0, is "
       << last_msg_->interfaces[0].total_bytes;
-  EXPECT_EQ(last_msg_->interfaces[0].tx_bytes, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->interfaces[0].tx_bytes)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->interfaces[0].tx_bytes)),
+            0)
       << "incorrect value for interfaces[0].tx_bytes, expected 0, is "
       << last_msg_->interfaces[0].tx_bytes;
-  EXPECT_EQ(last_msg_->interfaces[1].duration, 2159176030)
+  EXPECT_EQ(get_as<decltype(last_msg_->interfaces[1].duration)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->interfaces[1].duration)),
+            2159176030)
       << "incorrect value for interfaces[1].duration, expected 2159176030, is "
       << last_msg_->interfaces[1].duration;
   {
@@ -260,16 +282,28 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgNetworkBandwidthUsage0, Test) {
         << check_string << "', is '" << last_msg_->interfaces[1].interface_name
         << "'";
   }
-  EXPECT_EQ(last_msg_->interfaces[1].rx_bytes, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->interfaces[1].rx_bytes)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->interfaces[1].rx_bytes)),
+            0)
       << "incorrect value for interfaces[1].rx_bytes, expected 0, is "
       << last_msg_->interfaces[1].rx_bytes;
-  EXPECT_EQ(last_msg_->interfaces[1].total_bytes, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->interfaces[1].total_bytes)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->interfaces[1].total_bytes)),
+            0)
       << "incorrect value for interfaces[1].total_bytes, expected 0, is "
       << last_msg_->interfaces[1].total_bytes;
-  EXPECT_EQ(last_msg_->interfaces[1].tx_bytes, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->interfaces[1].tx_bytes)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->interfaces[1].tx_bytes)),
+            0)
       << "incorrect value for interfaces[1].tx_bytes, expected 0, is "
       << last_msg_->interfaces[1].tx_bytes;
-  EXPECT_EQ(last_msg_->interfaces[2].duration, 2159176030)
+  EXPECT_EQ(get_as<decltype(last_msg_->interfaces[2].duration)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->interfaces[2].duration)),
+            2159176030)
       << "incorrect value for interfaces[2].duration, expected 2159176030, is "
       << last_msg_->interfaces[2].duration;
   {
@@ -285,17 +319,29 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgNetworkBandwidthUsage0, Test) {
         << check_string << "', is '" << last_msg_->interfaces[2].interface_name
         << "'";
   }
-  EXPECT_EQ(last_msg_->interfaces[2].rx_bytes, 4036234989)
+  EXPECT_EQ(get_as<decltype(last_msg_->interfaces[2].rx_bytes)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->interfaces[2].rx_bytes)),
+            4036234989)
       << "incorrect value for interfaces[2].rx_bytes, expected 4036234989, is "
       << last_msg_->interfaces[2].rx_bytes;
-  EXPECT_EQ(last_msg_->interfaces[2].total_bytes, 3411995557)
+  EXPECT_EQ(get_as<decltype(last_msg_->interfaces[2].total_bytes)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->interfaces[2].total_bytes)),
+            3411995557)
       << "incorrect value for interfaces[2].total_bytes, expected 3411995557, "
          "is "
       << last_msg_->interfaces[2].total_bytes;
-  EXPECT_EQ(last_msg_->interfaces[2].tx_bytes, 3670727864)
+  EXPECT_EQ(get_as<decltype(last_msg_->interfaces[2].tx_bytes)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->interfaces[2].tx_bytes)),
+            3670727864)
       << "incorrect value for interfaces[2].tx_bytes, expected 3670727864, is "
       << last_msg_->interfaces[2].tx_bytes;
-  EXPECT_EQ(last_msg_->interfaces[3].duration, 2159176030)
+  EXPECT_EQ(get_as<decltype(last_msg_->interfaces[3].duration)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->interfaces[3].duration)),
+            2159176030)
       << "incorrect value for interfaces[3].duration, expected 2159176030, is "
       << last_msg_->interfaces[3].duration;
   {
@@ -311,16 +357,28 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgNetworkBandwidthUsage0, Test) {
         << check_string << "', is '" << last_msg_->interfaces[3].interface_name
         << "'";
   }
-  EXPECT_EQ(last_msg_->interfaces[3].rx_bytes, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->interfaces[3].rx_bytes)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->interfaces[3].rx_bytes)),
+            0)
       << "incorrect value for interfaces[3].rx_bytes, expected 0, is "
       << last_msg_->interfaces[3].rx_bytes;
-  EXPECT_EQ(last_msg_->interfaces[3].total_bytes, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->interfaces[3].total_bytes)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->interfaces[3].total_bytes)),
+            0)
       << "incorrect value for interfaces[3].total_bytes, expected 0, is "
       << last_msg_->interfaces[3].total_bytes;
-  EXPECT_EQ(last_msg_->interfaces[3].tx_bytes, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->interfaces[3].tx_bytes)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->interfaces[3].tx_bytes)),
+            0)
       << "incorrect value for interfaces[3].tx_bytes, expected 0, is "
       << last_msg_->interfaces[3].tx_bytes;
-  EXPECT_EQ(last_msg_->interfaces[4].duration, 2159176030)
+  EXPECT_EQ(get_as<decltype(last_msg_->interfaces[4].duration)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->interfaces[4].duration)),
+            2159176030)
       << "incorrect value for interfaces[4].duration, expected 2159176030, is "
       << last_msg_->interfaces[4].duration;
   {
@@ -336,13 +394,22 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgNetworkBandwidthUsage0, Test) {
         << check_string << "', is '" << last_msg_->interfaces[4].interface_name
         << "'";
   }
-  EXPECT_EQ(last_msg_->interfaces[4].rx_bytes, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->interfaces[4].rx_bytes)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->interfaces[4].rx_bytes)),
+            0)
       << "incorrect value for interfaces[4].rx_bytes, expected 0, is "
       << last_msg_->interfaces[4].rx_bytes;
-  EXPECT_EQ(last_msg_->interfaces[4].total_bytes, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->interfaces[4].total_bytes)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->interfaces[4].total_bytes)),
+            0)
       << "incorrect value for interfaces[4].total_bytes, expected 0, is "
       << last_msg_->interfaces[4].total_bytes;
-  EXPECT_EQ(last_msg_->interfaces[4].tx_bytes, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->interfaces[4].tx_bytes)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->interfaces[4].tx_bytes)),
+            0)
       << "incorrect value for interfaces[4].tx_bytes, expected 0, is "
       << last_msg_->interfaces[4].tx_bytes;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_piksi_MsgNetworkStateReq.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_piksi_MsgNetworkStateReq.cc
@@ -29,3 +29,10 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/piksi.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}

--- a/c/test/legacy/cpp/auto_check_sbp_piksi_MsgNetworkStateResp.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_piksi_MsgNetworkStateResp.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/piksi.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_piksi_MsgNetworkStateResp0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -229,7 +236,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgNetworkStateResp0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 3880);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 2471552451)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            2471552451)
       << "incorrect value for flags, expected 2471552451, is "
       << last_msg_->flags;
   {
@@ -243,76 +252,130 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgNetworkStateResp0, Test) {
         << "incorrect value for last_msg_->interface_name, expected string '"
         << check_string << "', is '" << last_msg_->interface_name << "'";
   }
-  EXPECT_EQ(last_msg_->ipv4_address[0], 143)
+  EXPECT_EQ(get_as<decltype(last_msg_->ipv4_address[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ipv4_address[0])),
+            143)
       << "incorrect value for ipv4_address[0], expected 143, is "
       << last_msg_->ipv4_address[0];
-  EXPECT_EQ(last_msg_->ipv4_address[1], 241)
+  EXPECT_EQ(get_as<decltype(last_msg_->ipv4_address[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ipv4_address[1])),
+            241)
       << "incorrect value for ipv4_address[1], expected 241, is "
       << last_msg_->ipv4_address[1];
-  EXPECT_EQ(last_msg_->ipv4_address[2], 84)
+  EXPECT_EQ(get_as<decltype(last_msg_->ipv4_address[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ipv4_address[2])),
+            84)
       << "incorrect value for ipv4_address[2], expected 84, is "
       << last_msg_->ipv4_address[2];
-  EXPECT_EQ(last_msg_->ipv4_address[3], 180)
+  EXPECT_EQ(get_as<decltype(last_msg_->ipv4_address[3])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ipv4_address[3])),
+            180)
       << "incorrect value for ipv4_address[3], expected 180, is "
       << last_msg_->ipv4_address[3];
-  EXPECT_EQ(last_msg_->ipv4_mask_size, 152)
+  EXPECT_EQ(get_as<decltype(last_msg_->ipv4_mask_size)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ipv4_mask_size)),
+            152)
       << "incorrect value for ipv4_mask_size, expected 152, is "
       << last_msg_->ipv4_mask_size;
-  EXPECT_EQ(last_msg_->ipv6_address[0], 194)
+  EXPECT_EQ(get_as<decltype(last_msg_->ipv6_address[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ipv6_address[0])),
+            194)
       << "incorrect value for ipv6_address[0], expected 194, is "
       << last_msg_->ipv6_address[0];
-  EXPECT_EQ(last_msg_->ipv6_address[1], 137)
+  EXPECT_EQ(get_as<decltype(last_msg_->ipv6_address[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ipv6_address[1])),
+            137)
       << "incorrect value for ipv6_address[1], expected 137, is "
       << last_msg_->ipv6_address[1];
-  EXPECT_EQ(last_msg_->ipv6_address[2], 32)
+  EXPECT_EQ(get_as<decltype(last_msg_->ipv6_address[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ipv6_address[2])),
+            32)
       << "incorrect value for ipv6_address[2], expected 32, is "
       << last_msg_->ipv6_address[2];
-  EXPECT_EQ(last_msg_->ipv6_address[3], 44)
+  EXPECT_EQ(get_as<decltype(last_msg_->ipv6_address[3])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ipv6_address[3])),
+            44)
       << "incorrect value for ipv6_address[3], expected 44, is "
       << last_msg_->ipv6_address[3];
-  EXPECT_EQ(last_msg_->ipv6_address[4], 114)
+  EXPECT_EQ(get_as<decltype(last_msg_->ipv6_address[4])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ipv6_address[4])),
+            114)
       << "incorrect value for ipv6_address[4], expected 114, is "
       << last_msg_->ipv6_address[4];
-  EXPECT_EQ(last_msg_->ipv6_address[5], 147)
+  EXPECT_EQ(get_as<decltype(last_msg_->ipv6_address[5])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ipv6_address[5])),
+            147)
       << "incorrect value for ipv6_address[5], expected 147, is "
       << last_msg_->ipv6_address[5];
-  EXPECT_EQ(last_msg_->ipv6_address[6], 68)
+  EXPECT_EQ(get_as<decltype(last_msg_->ipv6_address[6])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ipv6_address[6])),
+            68)
       << "incorrect value for ipv6_address[6], expected 68, is "
       << last_msg_->ipv6_address[6];
-  EXPECT_EQ(last_msg_->ipv6_address[7], 222)
+  EXPECT_EQ(get_as<decltype(last_msg_->ipv6_address[7])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ipv6_address[7])),
+            222)
       << "incorrect value for ipv6_address[7], expected 222, is "
       << last_msg_->ipv6_address[7];
-  EXPECT_EQ(last_msg_->ipv6_address[8], 92)
+  EXPECT_EQ(get_as<decltype(last_msg_->ipv6_address[8])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ipv6_address[8])),
+            92)
       << "incorrect value for ipv6_address[8], expected 92, is "
       << last_msg_->ipv6_address[8];
-  EXPECT_EQ(last_msg_->ipv6_address[9], 192)
+  EXPECT_EQ(get_as<decltype(last_msg_->ipv6_address[9])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ipv6_address[9])),
+            192)
       << "incorrect value for ipv6_address[9], expected 192, is "
       << last_msg_->ipv6_address[9];
-  EXPECT_EQ(last_msg_->ipv6_address[10], 78)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->ipv6_address[10])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->ipv6_address[10])),
+      78)
       << "incorrect value for ipv6_address[10], expected 78, is "
       << last_msg_->ipv6_address[10];
-  EXPECT_EQ(last_msg_->ipv6_address[11], 235)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->ipv6_address[11])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->ipv6_address[11])),
+      235)
       << "incorrect value for ipv6_address[11], expected 235, is "
       << last_msg_->ipv6_address[11];
-  EXPECT_EQ(last_msg_->ipv6_address[12], 63)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->ipv6_address[12])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->ipv6_address[12])),
+      63)
       << "incorrect value for ipv6_address[12], expected 63, is "
       << last_msg_->ipv6_address[12];
-  EXPECT_EQ(last_msg_->ipv6_address[13], 208)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->ipv6_address[13])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->ipv6_address[13])),
+      208)
       << "incorrect value for ipv6_address[13], expected 208, is "
       << last_msg_->ipv6_address[13];
-  EXPECT_EQ(last_msg_->ipv6_address[14], 114)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->ipv6_address[14])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->ipv6_address[14])),
+      114)
       << "incorrect value for ipv6_address[14], expected 114, is "
       << last_msg_->ipv6_address[14];
-  EXPECT_EQ(last_msg_->ipv6_address[15], 53)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->ipv6_address[15])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->ipv6_address[15])),
+      53)
       << "incorrect value for ipv6_address[15], expected 53, is "
       << last_msg_->ipv6_address[15];
-  EXPECT_EQ(last_msg_->ipv6_mask_size, 183)
+  EXPECT_EQ(get_as<decltype(last_msg_->ipv6_mask_size)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ipv6_mask_size)),
+            183)
       << "incorrect value for ipv6_mask_size, expected 183, is "
       << last_msg_->ipv6_mask_size;
-  EXPECT_EQ(last_msg_->rx_bytes, 451408920)
+  EXPECT_EQ(get_as<decltype(last_msg_->rx_bytes)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rx_bytes)),
+            451408920)
       << "incorrect value for rx_bytes, expected 451408920, is "
       << last_msg_->rx_bytes;
-  EXPECT_EQ(last_msg_->tx_bytes, 59251049)
+  EXPECT_EQ(get_as<decltype(last_msg_->tx_bytes)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tx_bytes)),
+            59251049)
       << "incorrect value for tx_bytes, expected 59251049, is "
       << last_msg_->tx_bytes;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_piksi_MsgReset.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_piksi_MsgReset.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/piksi.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_piksi_MsgReset0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -110,7 +117,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgReset0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 53823);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 334428248)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            334428248)
       << "incorrect value for flags, expected 334428248, is "
       << last_msg_->flags;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_piksi_MsgResetDep.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_piksi_MsgResetDep.cc
@@ -29,3 +29,10 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/piksi.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}

--- a/c/test/legacy/cpp/auto_check_sbp_piksi_MsgResetFilters.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_piksi_MsgResetFilters.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/piksi.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_piksi_MsgResetFilters0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -110,6 +117,8 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgResetFilters0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 51281);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->filter, 100)
+  EXPECT_EQ(get_as<decltype(last_msg_->filter)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->filter)),
+            100)
       << "incorrect value for filter, expected 100, is " << last_msg_->filter;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_piksi_MsgSetTime.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_piksi_MsgSetTime.cc
@@ -29,3 +29,10 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/piksi.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}

--- a/c/test/legacy/cpp/auto_check_sbp_piksi_MsgSpecan.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_piksi_MsgSpecan.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/piksi.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_piksi_MsgSpecan0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -1502,688 +1509,1371 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgSpecan0, Test) {
   EXPECT_LT((last_msg_->amplitude_unit * 100 - 1329.19995117 * 100), 0.05)
       << "incorrect value for amplitude_unit, expected 1329.19995117, is "
       << last_msg_->amplitude_unit;
-  EXPECT_EQ(last_msg_->amplitude_value[0], 100)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[0])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[0])),
+      100)
       << "incorrect value for amplitude_value[0], expected 100, is "
       << last_msg_->amplitude_value[0];
-  EXPECT_EQ(last_msg_->amplitude_value[1], 179)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[1])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[1])),
+      179)
       << "incorrect value for amplitude_value[1], expected 179, is "
       << last_msg_->amplitude_value[1];
-  EXPECT_EQ(last_msg_->amplitude_value[2], 185)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[2])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[2])),
+      185)
       << "incorrect value for amplitude_value[2], expected 185, is "
       << last_msg_->amplitude_value[2];
-  EXPECT_EQ(last_msg_->amplitude_value[3], 17)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[3])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[3])),
+      17)
       << "incorrect value for amplitude_value[3], expected 17, is "
       << last_msg_->amplitude_value[3];
-  EXPECT_EQ(last_msg_->amplitude_value[4], 175)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[4])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[4])),
+      175)
       << "incorrect value for amplitude_value[4], expected 175, is "
       << last_msg_->amplitude_value[4];
-  EXPECT_EQ(last_msg_->amplitude_value[5], 49)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[5])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[5])),
+      49)
       << "incorrect value for amplitude_value[5], expected 49, is "
       << last_msg_->amplitude_value[5];
-  EXPECT_EQ(last_msg_->amplitude_value[6], 193)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[6])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[6])),
+      193)
       << "incorrect value for amplitude_value[6], expected 193, is "
       << last_msg_->amplitude_value[6];
-  EXPECT_EQ(last_msg_->amplitude_value[7], 228)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[7])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[7])),
+      228)
       << "incorrect value for amplitude_value[7], expected 228, is "
       << last_msg_->amplitude_value[7];
-  EXPECT_EQ(last_msg_->amplitude_value[8], 228)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[8])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[8])),
+      228)
       << "incorrect value for amplitude_value[8], expected 228, is "
       << last_msg_->amplitude_value[8];
-  EXPECT_EQ(last_msg_->amplitude_value[9], 47)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[9])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[9])),
+      47)
       << "incorrect value for amplitude_value[9], expected 47, is "
       << last_msg_->amplitude_value[9];
-  EXPECT_EQ(last_msg_->amplitude_value[10], 33)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[10])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[10])),
+      33)
       << "incorrect value for amplitude_value[10], expected 33, is "
       << last_msg_->amplitude_value[10];
-  EXPECT_EQ(last_msg_->amplitude_value[11], 24)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[11])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[11])),
+      24)
       << "incorrect value for amplitude_value[11], expected 24, is "
       << last_msg_->amplitude_value[11];
-  EXPECT_EQ(last_msg_->amplitude_value[12], 141)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[12])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[12])),
+      141)
       << "incorrect value for amplitude_value[12], expected 141, is "
       << last_msg_->amplitude_value[12];
-  EXPECT_EQ(last_msg_->amplitude_value[13], 177)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[13])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[13])),
+      177)
       << "incorrect value for amplitude_value[13], expected 177, is "
       << last_msg_->amplitude_value[13];
-  EXPECT_EQ(last_msg_->amplitude_value[14], 18)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[14])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[14])),
+      18)
       << "incorrect value for amplitude_value[14], expected 18, is "
       << last_msg_->amplitude_value[14];
-  EXPECT_EQ(last_msg_->amplitude_value[15], 99)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[15])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[15])),
+      99)
       << "incorrect value for amplitude_value[15], expected 99, is "
       << last_msg_->amplitude_value[15];
-  EXPECT_EQ(last_msg_->amplitude_value[16], 246)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[16])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[16])),
+      246)
       << "incorrect value for amplitude_value[16], expected 246, is "
       << last_msg_->amplitude_value[16];
-  EXPECT_EQ(last_msg_->amplitude_value[17], 121)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[17])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[17])),
+      121)
       << "incorrect value for amplitude_value[17], expected 121, is "
       << last_msg_->amplitude_value[17];
-  EXPECT_EQ(last_msg_->amplitude_value[18], 61)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[18])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[18])),
+      61)
       << "incorrect value for amplitude_value[18], expected 61, is "
       << last_msg_->amplitude_value[18];
-  EXPECT_EQ(last_msg_->amplitude_value[19], 40)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[19])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[19])),
+      40)
       << "incorrect value for amplitude_value[19], expected 40, is "
       << last_msg_->amplitude_value[19];
-  EXPECT_EQ(last_msg_->amplitude_value[20], 91)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[20])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[20])),
+      91)
       << "incorrect value for amplitude_value[20], expected 91, is "
       << last_msg_->amplitude_value[20];
-  EXPECT_EQ(last_msg_->amplitude_value[21], 145)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[21])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[21])),
+      145)
       << "incorrect value for amplitude_value[21], expected 145, is "
       << last_msg_->amplitude_value[21];
-  EXPECT_EQ(last_msg_->amplitude_value[22], 223)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[22])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[22])),
+      223)
       << "incorrect value for amplitude_value[22], expected 223, is "
       << last_msg_->amplitude_value[22];
-  EXPECT_EQ(last_msg_->amplitude_value[23], 167)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[23])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[23])),
+      167)
       << "incorrect value for amplitude_value[23], expected 167, is "
       << last_msg_->amplitude_value[23];
-  EXPECT_EQ(last_msg_->amplitude_value[24], 174)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[24])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[24])),
+      174)
       << "incorrect value for amplitude_value[24], expected 174, is "
       << last_msg_->amplitude_value[24];
-  EXPECT_EQ(last_msg_->amplitude_value[25], 9)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[25])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[25])),
+      9)
       << "incorrect value for amplitude_value[25], expected 9, is "
       << last_msg_->amplitude_value[25];
-  EXPECT_EQ(last_msg_->amplitude_value[26], 116)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[26])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[26])),
+      116)
       << "incorrect value for amplitude_value[26], expected 116, is "
       << last_msg_->amplitude_value[26];
-  EXPECT_EQ(last_msg_->amplitude_value[27], 11)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[27])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[27])),
+      11)
       << "incorrect value for amplitude_value[27], expected 11, is "
       << last_msg_->amplitude_value[27];
-  EXPECT_EQ(last_msg_->amplitude_value[28], 247)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[28])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[28])),
+      247)
       << "incorrect value for amplitude_value[28], expected 247, is "
       << last_msg_->amplitude_value[28];
-  EXPECT_EQ(last_msg_->amplitude_value[29], 84)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[29])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[29])),
+      84)
       << "incorrect value for amplitude_value[29], expected 84, is "
       << last_msg_->amplitude_value[29];
-  EXPECT_EQ(last_msg_->amplitude_value[30], 49)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[30])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[30])),
+      49)
       << "incorrect value for amplitude_value[30], expected 49, is "
       << last_msg_->amplitude_value[30];
-  EXPECT_EQ(last_msg_->amplitude_value[31], 153)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[31])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[31])),
+      153)
       << "incorrect value for amplitude_value[31], expected 153, is "
       << last_msg_->amplitude_value[31];
-  EXPECT_EQ(last_msg_->amplitude_value[32], 205)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[32])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[32])),
+      205)
       << "incorrect value for amplitude_value[32], expected 205, is "
       << last_msg_->amplitude_value[32];
-  EXPECT_EQ(last_msg_->amplitude_value[33], 2)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[33])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[33])),
+      2)
       << "incorrect value for amplitude_value[33], expected 2, is "
       << last_msg_->amplitude_value[33];
-  EXPECT_EQ(last_msg_->amplitude_value[34], 230)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[34])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[34])),
+      230)
       << "incorrect value for amplitude_value[34], expected 230, is "
       << last_msg_->amplitude_value[34];
-  EXPECT_EQ(last_msg_->amplitude_value[35], 194)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[35])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[35])),
+      194)
       << "incorrect value for amplitude_value[35], expected 194, is "
       << last_msg_->amplitude_value[35];
-  EXPECT_EQ(last_msg_->amplitude_value[36], 218)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[36])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[36])),
+      218)
       << "incorrect value for amplitude_value[36], expected 218, is "
       << last_msg_->amplitude_value[36];
-  EXPECT_EQ(last_msg_->amplitude_value[37], 241)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[37])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[37])),
+      241)
       << "incorrect value for amplitude_value[37], expected 241, is "
       << last_msg_->amplitude_value[37];
-  EXPECT_EQ(last_msg_->amplitude_value[38], 101)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[38])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[38])),
+      101)
       << "incorrect value for amplitude_value[38], expected 101, is "
       << last_msg_->amplitude_value[38];
-  EXPECT_EQ(last_msg_->amplitude_value[39], 107)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[39])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[39])),
+      107)
       << "incorrect value for amplitude_value[39], expected 107, is "
       << last_msg_->amplitude_value[39];
-  EXPECT_EQ(last_msg_->amplitude_value[40], 45)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[40])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[40])),
+      45)
       << "incorrect value for amplitude_value[40], expected 45, is "
       << last_msg_->amplitude_value[40];
-  EXPECT_EQ(last_msg_->amplitude_value[41], 137)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[41])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[41])),
+      137)
       << "incorrect value for amplitude_value[41], expected 137, is "
       << last_msg_->amplitude_value[41];
-  EXPECT_EQ(last_msg_->amplitude_value[42], 93)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[42])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[42])),
+      93)
       << "incorrect value for amplitude_value[42], expected 93, is "
       << last_msg_->amplitude_value[42];
-  EXPECT_EQ(last_msg_->amplitude_value[43], 114)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[43])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[43])),
+      114)
       << "incorrect value for amplitude_value[43], expected 114, is "
       << last_msg_->amplitude_value[43];
-  EXPECT_EQ(last_msg_->amplitude_value[44], 230)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[44])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[44])),
+      230)
       << "incorrect value for amplitude_value[44], expected 230, is "
       << last_msg_->amplitude_value[44];
-  EXPECT_EQ(last_msg_->amplitude_value[45], 43)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[45])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[45])),
+      43)
       << "incorrect value for amplitude_value[45], expected 43, is "
       << last_msg_->amplitude_value[45];
-  EXPECT_EQ(last_msg_->amplitude_value[46], 224)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[46])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[46])),
+      224)
       << "incorrect value for amplitude_value[46], expected 224, is "
       << last_msg_->amplitude_value[46];
-  EXPECT_EQ(last_msg_->amplitude_value[47], 23)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[47])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[47])),
+      23)
       << "incorrect value for amplitude_value[47], expected 23, is "
       << last_msg_->amplitude_value[47];
-  EXPECT_EQ(last_msg_->amplitude_value[48], 74)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[48])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[48])),
+      74)
       << "incorrect value for amplitude_value[48], expected 74, is "
       << last_msg_->amplitude_value[48];
-  EXPECT_EQ(last_msg_->amplitude_value[49], 209)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[49])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[49])),
+      209)
       << "incorrect value for amplitude_value[49], expected 209, is "
       << last_msg_->amplitude_value[49];
-  EXPECT_EQ(last_msg_->amplitude_value[50], 199)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[50])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[50])),
+      199)
       << "incorrect value for amplitude_value[50], expected 199, is "
       << last_msg_->amplitude_value[50];
-  EXPECT_EQ(last_msg_->amplitude_value[51], 211)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[51])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[51])),
+      211)
       << "incorrect value for amplitude_value[51], expected 211, is "
       << last_msg_->amplitude_value[51];
-  EXPECT_EQ(last_msg_->amplitude_value[52], 130)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[52])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[52])),
+      130)
       << "incorrect value for amplitude_value[52], expected 130, is "
       << last_msg_->amplitude_value[52];
-  EXPECT_EQ(last_msg_->amplitude_value[53], 89)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[53])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[53])),
+      89)
       << "incorrect value for amplitude_value[53], expected 89, is "
       << last_msg_->amplitude_value[53];
-  EXPECT_EQ(last_msg_->amplitude_value[54], 220)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[54])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[54])),
+      220)
       << "incorrect value for amplitude_value[54], expected 220, is "
       << last_msg_->amplitude_value[54];
-  EXPECT_EQ(last_msg_->amplitude_value[55], 163)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[55])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[55])),
+      163)
       << "incorrect value for amplitude_value[55], expected 163, is "
       << last_msg_->amplitude_value[55];
-  EXPECT_EQ(last_msg_->amplitude_value[56], 68)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[56])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[56])),
+      68)
       << "incorrect value for amplitude_value[56], expected 68, is "
       << last_msg_->amplitude_value[56];
-  EXPECT_EQ(last_msg_->amplitude_value[57], 20)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[57])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[57])),
+      20)
       << "incorrect value for amplitude_value[57], expected 20, is "
       << last_msg_->amplitude_value[57];
-  EXPECT_EQ(last_msg_->amplitude_value[58], 253)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[58])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[58])),
+      253)
       << "incorrect value for amplitude_value[58], expected 253, is "
       << last_msg_->amplitude_value[58];
-  EXPECT_EQ(last_msg_->amplitude_value[59], 7)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[59])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[59])),
+      7)
       << "incorrect value for amplitude_value[59], expected 7, is "
       << last_msg_->amplitude_value[59];
-  EXPECT_EQ(last_msg_->amplitude_value[60], 206)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[60])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[60])),
+      206)
       << "incorrect value for amplitude_value[60], expected 206, is "
       << last_msg_->amplitude_value[60];
-  EXPECT_EQ(last_msg_->amplitude_value[61], 50)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[61])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[61])),
+      50)
       << "incorrect value for amplitude_value[61], expected 50, is "
       << last_msg_->amplitude_value[61];
-  EXPECT_EQ(last_msg_->amplitude_value[62], 129)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[62])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[62])),
+      129)
       << "incorrect value for amplitude_value[62], expected 129, is "
       << last_msg_->amplitude_value[62];
-  EXPECT_EQ(last_msg_->amplitude_value[63], 116)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[63])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[63])),
+      116)
       << "incorrect value for amplitude_value[63], expected 116, is "
       << last_msg_->amplitude_value[63];
-  EXPECT_EQ(last_msg_->amplitude_value[64], 194)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[64])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[64])),
+      194)
       << "incorrect value for amplitude_value[64], expected 194, is "
       << last_msg_->amplitude_value[64];
-  EXPECT_EQ(last_msg_->amplitude_value[65], 23)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[65])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[65])),
+      23)
       << "incorrect value for amplitude_value[65], expected 23, is "
       << last_msg_->amplitude_value[65];
-  EXPECT_EQ(last_msg_->amplitude_value[66], 31)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[66])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[66])),
+      31)
       << "incorrect value for amplitude_value[66], expected 31, is "
       << last_msg_->amplitude_value[66];
-  EXPECT_EQ(last_msg_->amplitude_value[67], 226)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[67])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[67])),
+      226)
       << "incorrect value for amplitude_value[67], expected 226, is "
       << last_msg_->amplitude_value[67];
-  EXPECT_EQ(last_msg_->amplitude_value[68], 217)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[68])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[68])),
+      217)
       << "incorrect value for amplitude_value[68], expected 217, is "
       << last_msg_->amplitude_value[68];
-  EXPECT_EQ(last_msg_->amplitude_value[69], 157)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[69])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[69])),
+      157)
       << "incorrect value for amplitude_value[69], expected 157, is "
       << last_msg_->amplitude_value[69];
-  EXPECT_EQ(last_msg_->amplitude_value[70], 205)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[70])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[70])),
+      205)
       << "incorrect value for amplitude_value[70], expected 205, is "
       << last_msg_->amplitude_value[70];
-  EXPECT_EQ(last_msg_->amplitude_value[71], 221)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[71])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[71])),
+      221)
       << "incorrect value for amplitude_value[71], expected 221, is "
       << last_msg_->amplitude_value[71];
-  EXPECT_EQ(last_msg_->amplitude_value[72], 5)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[72])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[72])),
+      5)
       << "incorrect value for amplitude_value[72], expected 5, is "
       << last_msg_->amplitude_value[72];
-  EXPECT_EQ(last_msg_->amplitude_value[73], 224)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[73])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[73])),
+      224)
       << "incorrect value for amplitude_value[73], expected 224, is "
       << last_msg_->amplitude_value[73];
-  EXPECT_EQ(last_msg_->amplitude_value[74], 92)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[74])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[74])),
+      92)
       << "incorrect value for amplitude_value[74], expected 92, is "
       << last_msg_->amplitude_value[74];
-  EXPECT_EQ(last_msg_->amplitude_value[75], 82)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[75])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[75])),
+      82)
       << "incorrect value for amplitude_value[75], expected 82, is "
       << last_msg_->amplitude_value[75];
-  EXPECT_EQ(last_msg_->amplitude_value[76], 109)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[76])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[76])),
+      109)
       << "incorrect value for amplitude_value[76], expected 109, is "
       << last_msg_->amplitude_value[76];
-  EXPECT_EQ(last_msg_->amplitude_value[77], 223)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[77])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[77])),
+      223)
       << "incorrect value for amplitude_value[77], expected 223, is "
       << last_msg_->amplitude_value[77];
-  EXPECT_EQ(last_msg_->amplitude_value[78], 195)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[78])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[78])),
+      195)
       << "incorrect value for amplitude_value[78], expected 195, is "
       << last_msg_->amplitude_value[78];
-  EXPECT_EQ(last_msg_->amplitude_value[79], 233)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[79])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[79])),
+      233)
       << "incorrect value for amplitude_value[79], expected 233, is "
       << last_msg_->amplitude_value[79];
-  EXPECT_EQ(last_msg_->amplitude_value[80], 165)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[80])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[80])),
+      165)
       << "incorrect value for amplitude_value[80], expected 165, is "
       << last_msg_->amplitude_value[80];
-  EXPECT_EQ(last_msg_->amplitude_value[81], 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[81])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[81])),
+      1)
       << "incorrect value for amplitude_value[81], expected 1, is "
       << last_msg_->amplitude_value[81];
-  EXPECT_EQ(last_msg_->amplitude_value[82], 82)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[82])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[82])),
+      82)
       << "incorrect value for amplitude_value[82], expected 82, is "
       << last_msg_->amplitude_value[82];
-  EXPECT_EQ(last_msg_->amplitude_value[83], 141)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[83])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[83])),
+      141)
       << "incorrect value for amplitude_value[83], expected 141, is "
       << last_msg_->amplitude_value[83];
-  EXPECT_EQ(last_msg_->amplitude_value[84], 157)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[84])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[84])),
+      157)
       << "incorrect value for amplitude_value[84], expected 157, is "
       << last_msg_->amplitude_value[84];
-  EXPECT_EQ(last_msg_->amplitude_value[85], 177)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[85])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[85])),
+      177)
       << "incorrect value for amplitude_value[85], expected 177, is "
       << last_msg_->amplitude_value[85];
-  EXPECT_EQ(last_msg_->amplitude_value[86], 169)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[86])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[86])),
+      169)
       << "incorrect value for amplitude_value[86], expected 169, is "
       << last_msg_->amplitude_value[86];
-  EXPECT_EQ(last_msg_->amplitude_value[87], 244)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[87])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[87])),
+      244)
       << "incorrect value for amplitude_value[87], expected 244, is "
       << last_msg_->amplitude_value[87];
-  EXPECT_EQ(last_msg_->amplitude_value[88], 131)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[88])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[88])),
+      131)
       << "incorrect value for amplitude_value[88], expected 131, is "
       << last_msg_->amplitude_value[88];
-  EXPECT_EQ(last_msg_->amplitude_value[89], 96)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[89])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[89])),
+      96)
       << "incorrect value for amplitude_value[89], expected 96, is "
       << last_msg_->amplitude_value[89];
-  EXPECT_EQ(last_msg_->amplitude_value[90], 109)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[90])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[90])),
+      109)
       << "incorrect value for amplitude_value[90], expected 109, is "
       << last_msg_->amplitude_value[90];
-  EXPECT_EQ(last_msg_->amplitude_value[91], 111)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[91])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[91])),
+      111)
       << "incorrect value for amplitude_value[91], expected 111, is "
       << last_msg_->amplitude_value[91];
-  EXPECT_EQ(last_msg_->amplitude_value[92], 253)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[92])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[92])),
+      253)
       << "incorrect value for amplitude_value[92], expected 253, is "
       << last_msg_->amplitude_value[92];
-  EXPECT_EQ(last_msg_->amplitude_value[93], 149)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[93])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[93])),
+      149)
       << "incorrect value for amplitude_value[93], expected 149, is "
       << last_msg_->amplitude_value[93];
-  EXPECT_EQ(last_msg_->amplitude_value[94], 28)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[94])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[94])),
+      28)
       << "incorrect value for amplitude_value[94], expected 28, is "
       << last_msg_->amplitude_value[94];
-  EXPECT_EQ(last_msg_->amplitude_value[95], 225)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[95])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[95])),
+      225)
       << "incorrect value for amplitude_value[95], expected 225, is "
       << last_msg_->amplitude_value[95];
-  EXPECT_EQ(last_msg_->amplitude_value[96], 225)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[96])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[96])),
+      225)
       << "incorrect value for amplitude_value[96], expected 225, is "
       << last_msg_->amplitude_value[96];
-  EXPECT_EQ(last_msg_->amplitude_value[97], 72)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[97])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[97])),
+      72)
       << "incorrect value for amplitude_value[97], expected 72, is "
       << last_msg_->amplitude_value[97];
-  EXPECT_EQ(last_msg_->amplitude_value[98], 158)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[98])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[98])),
+      158)
       << "incorrect value for amplitude_value[98], expected 158, is "
       << last_msg_->amplitude_value[98];
-  EXPECT_EQ(last_msg_->amplitude_value[99], 158)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[99])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[99])),
+      158)
       << "incorrect value for amplitude_value[99], expected 158, is "
       << last_msg_->amplitude_value[99];
-  EXPECT_EQ(last_msg_->amplitude_value[100], 210)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[100])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[100])),
+      210)
       << "incorrect value for amplitude_value[100], expected 210, is "
       << last_msg_->amplitude_value[100];
-  EXPECT_EQ(last_msg_->amplitude_value[101], 196)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[101])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[101])),
+      196)
       << "incorrect value for amplitude_value[101], expected 196, is "
       << last_msg_->amplitude_value[101];
-  EXPECT_EQ(last_msg_->amplitude_value[102], 206)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[102])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[102])),
+      206)
       << "incorrect value for amplitude_value[102], expected 206, is "
       << last_msg_->amplitude_value[102];
-  EXPECT_EQ(last_msg_->amplitude_value[103], 70)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[103])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[103])),
+      70)
       << "incorrect value for amplitude_value[103], expected 70, is "
       << last_msg_->amplitude_value[103];
-  EXPECT_EQ(last_msg_->amplitude_value[104], 63)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[104])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[104])),
+      63)
       << "incorrect value for amplitude_value[104], expected 63, is "
       << last_msg_->amplitude_value[104];
-  EXPECT_EQ(last_msg_->amplitude_value[105], 225)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[105])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[105])),
+      225)
       << "incorrect value for amplitude_value[105], expected 225, is "
       << last_msg_->amplitude_value[105];
-  EXPECT_EQ(last_msg_->amplitude_value[106], 184)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[106])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[106])),
+      184)
       << "incorrect value for amplitude_value[106], expected 184, is "
       << last_msg_->amplitude_value[106];
-  EXPECT_EQ(last_msg_->amplitude_value[107], 150)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[107])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[107])),
+      150)
       << "incorrect value for amplitude_value[107], expected 150, is "
       << last_msg_->amplitude_value[107];
-  EXPECT_EQ(last_msg_->amplitude_value[108], 174)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[108])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[108])),
+      174)
       << "incorrect value for amplitude_value[108], expected 174, is "
       << last_msg_->amplitude_value[108];
-  EXPECT_EQ(last_msg_->amplitude_value[109], 240)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[109])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[109])),
+      240)
       << "incorrect value for amplitude_value[109], expected 240, is "
       << last_msg_->amplitude_value[109];
-  EXPECT_EQ(last_msg_->amplitude_value[110], 45)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[110])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[110])),
+      45)
       << "incorrect value for amplitude_value[110], expected 45, is "
       << last_msg_->amplitude_value[110];
-  EXPECT_EQ(last_msg_->amplitude_value[111], 146)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[111])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[111])),
+      146)
       << "incorrect value for amplitude_value[111], expected 146, is "
       << last_msg_->amplitude_value[111];
-  EXPECT_EQ(last_msg_->amplitude_value[112], 59)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[112])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[112])),
+      59)
       << "incorrect value for amplitude_value[112], expected 59, is "
       << last_msg_->amplitude_value[112];
-  EXPECT_EQ(last_msg_->amplitude_value[113], 82)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[113])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[113])),
+      82)
       << "incorrect value for amplitude_value[113], expected 82, is "
       << last_msg_->amplitude_value[113];
-  EXPECT_EQ(last_msg_->amplitude_value[114], 194)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[114])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[114])),
+      194)
       << "incorrect value for amplitude_value[114], expected 194, is "
       << last_msg_->amplitude_value[114];
-  EXPECT_EQ(last_msg_->amplitude_value[115], 4)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[115])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[115])),
+      4)
       << "incorrect value for amplitude_value[115], expected 4, is "
       << last_msg_->amplitude_value[115];
-  EXPECT_EQ(last_msg_->amplitude_value[116], 179)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[116])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[116])),
+      179)
       << "incorrect value for amplitude_value[116], expected 179, is "
       << last_msg_->amplitude_value[116];
-  EXPECT_EQ(last_msg_->amplitude_value[117], 148)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[117])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[117])),
+      148)
       << "incorrect value for amplitude_value[117], expected 148, is "
       << last_msg_->amplitude_value[117];
-  EXPECT_EQ(last_msg_->amplitude_value[118], 66)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[118])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[118])),
+      66)
       << "incorrect value for amplitude_value[118], expected 66, is "
       << last_msg_->amplitude_value[118];
-  EXPECT_EQ(last_msg_->amplitude_value[119], 254)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[119])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[119])),
+      254)
       << "incorrect value for amplitude_value[119], expected 254, is "
       << last_msg_->amplitude_value[119];
-  EXPECT_EQ(last_msg_->amplitude_value[120], 115)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[120])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[120])),
+      115)
       << "incorrect value for amplitude_value[120], expected 115, is "
       << last_msg_->amplitude_value[120];
-  EXPECT_EQ(last_msg_->amplitude_value[121], 77)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[121])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[121])),
+      77)
       << "incorrect value for amplitude_value[121], expected 77, is "
       << last_msg_->amplitude_value[121];
-  EXPECT_EQ(last_msg_->amplitude_value[122], 30)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[122])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[122])),
+      30)
       << "incorrect value for amplitude_value[122], expected 30, is "
       << last_msg_->amplitude_value[122];
-  EXPECT_EQ(last_msg_->amplitude_value[123], 46)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[123])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[123])),
+      46)
       << "incorrect value for amplitude_value[123], expected 46, is "
       << last_msg_->amplitude_value[123];
-  EXPECT_EQ(last_msg_->amplitude_value[124], 4)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[124])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[124])),
+      4)
       << "incorrect value for amplitude_value[124], expected 4, is "
       << last_msg_->amplitude_value[124];
-  EXPECT_EQ(last_msg_->amplitude_value[125], 204)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[125])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[125])),
+      204)
       << "incorrect value for amplitude_value[125], expected 204, is "
       << last_msg_->amplitude_value[125];
-  EXPECT_EQ(last_msg_->amplitude_value[126], 37)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[126])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[126])),
+      37)
       << "incorrect value for amplitude_value[126], expected 37, is "
       << last_msg_->amplitude_value[126];
-  EXPECT_EQ(last_msg_->amplitude_value[127], 200)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[127])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[127])),
+      200)
       << "incorrect value for amplitude_value[127], expected 200, is "
       << last_msg_->amplitude_value[127];
-  EXPECT_EQ(last_msg_->amplitude_value[128], 121)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[128])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[128])),
+      121)
       << "incorrect value for amplitude_value[128], expected 121, is "
       << last_msg_->amplitude_value[128];
-  EXPECT_EQ(last_msg_->amplitude_value[129], 18)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[129])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[129])),
+      18)
       << "incorrect value for amplitude_value[129], expected 18, is "
       << last_msg_->amplitude_value[129];
-  EXPECT_EQ(last_msg_->amplitude_value[130], 17)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[130])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[130])),
+      17)
       << "incorrect value for amplitude_value[130], expected 17, is "
       << last_msg_->amplitude_value[130];
-  EXPECT_EQ(last_msg_->amplitude_value[131], 171)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[131])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[131])),
+      171)
       << "incorrect value for amplitude_value[131], expected 171, is "
       << last_msg_->amplitude_value[131];
-  EXPECT_EQ(last_msg_->amplitude_value[132], 102)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[132])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[132])),
+      102)
       << "incorrect value for amplitude_value[132], expected 102, is "
       << last_msg_->amplitude_value[132];
-  EXPECT_EQ(last_msg_->amplitude_value[133], 163)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[133])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[133])),
+      163)
       << "incorrect value for amplitude_value[133], expected 163, is "
       << last_msg_->amplitude_value[133];
-  EXPECT_EQ(last_msg_->amplitude_value[134], 175)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[134])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[134])),
+      175)
       << "incorrect value for amplitude_value[134], expected 175, is "
       << last_msg_->amplitude_value[134];
-  EXPECT_EQ(last_msg_->amplitude_value[135], 50)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[135])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[135])),
+      50)
       << "incorrect value for amplitude_value[135], expected 50, is "
       << last_msg_->amplitude_value[135];
-  EXPECT_EQ(last_msg_->amplitude_value[136], 66)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[136])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[136])),
+      66)
       << "incorrect value for amplitude_value[136], expected 66, is "
       << last_msg_->amplitude_value[136];
-  EXPECT_EQ(last_msg_->amplitude_value[137], 101)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[137])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[137])),
+      101)
       << "incorrect value for amplitude_value[137], expected 101, is "
       << last_msg_->amplitude_value[137];
-  EXPECT_EQ(last_msg_->amplitude_value[138], 69)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[138])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[138])),
+      69)
       << "incorrect value for amplitude_value[138], expected 69, is "
       << last_msg_->amplitude_value[138];
-  EXPECT_EQ(last_msg_->amplitude_value[139], 13)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[139])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[139])),
+      13)
       << "incorrect value for amplitude_value[139], expected 13, is "
       << last_msg_->amplitude_value[139];
-  EXPECT_EQ(last_msg_->amplitude_value[140], 223)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[140])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[140])),
+      223)
       << "incorrect value for amplitude_value[140], expected 223, is "
       << last_msg_->amplitude_value[140];
-  EXPECT_EQ(last_msg_->amplitude_value[141], 172)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[141])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[141])),
+      172)
       << "incorrect value for amplitude_value[141], expected 172, is "
       << last_msg_->amplitude_value[141];
-  EXPECT_EQ(last_msg_->amplitude_value[142], 160)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[142])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[142])),
+      160)
       << "incorrect value for amplitude_value[142], expected 160, is "
       << last_msg_->amplitude_value[142];
-  EXPECT_EQ(last_msg_->amplitude_value[143], 233)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[143])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[143])),
+      233)
       << "incorrect value for amplitude_value[143], expected 233, is "
       << last_msg_->amplitude_value[143];
-  EXPECT_EQ(last_msg_->amplitude_value[144], 220)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[144])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[144])),
+      220)
       << "incorrect value for amplitude_value[144], expected 220, is "
       << last_msg_->amplitude_value[144];
-  EXPECT_EQ(last_msg_->amplitude_value[145], 101)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[145])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[145])),
+      101)
       << "incorrect value for amplitude_value[145], expected 101, is "
       << last_msg_->amplitude_value[145];
-  EXPECT_EQ(last_msg_->amplitude_value[146], 237)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[146])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[146])),
+      237)
       << "incorrect value for amplitude_value[146], expected 237, is "
       << last_msg_->amplitude_value[146];
-  EXPECT_EQ(last_msg_->amplitude_value[147], 156)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[147])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[147])),
+      156)
       << "incorrect value for amplitude_value[147], expected 156, is "
       << last_msg_->amplitude_value[147];
-  EXPECT_EQ(last_msg_->amplitude_value[148], 62)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[148])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[148])),
+      62)
       << "incorrect value for amplitude_value[148], expected 62, is "
       << last_msg_->amplitude_value[148];
-  EXPECT_EQ(last_msg_->amplitude_value[149], 117)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[149])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[149])),
+      117)
       << "incorrect value for amplitude_value[149], expected 117, is "
       << last_msg_->amplitude_value[149];
-  EXPECT_EQ(last_msg_->amplitude_value[150], 47)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[150])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[150])),
+      47)
       << "incorrect value for amplitude_value[150], expected 47, is "
       << last_msg_->amplitude_value[150];
-  EXPECT_EQ(last_msg_->amplitude_value[151], 143)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[151])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[151])),
+      143)
       << "incorrect value for amplitude_value[151], expected 143, is "
       << last_msg_->amplitude_value[151];
-  EXPECT_EQ(last_msg_->amplitude_value[152], 94)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[152])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[152])),
+      94)
       << "incorrect value for amplitude_value[152], expected 94, is "
       << last_msg_->amplitude_value[152];
-  EXPECT_EQ(last_msg_->amplitude_value[153], 135)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[153])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[153])),
+      135)
       << "incorrect value for amplitude_value[153], expected 135, is "
       << last_msg_->amplitude_value[153];
-  EXPECT_EQ(last_msg_->amplitude_value[154], 22)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[154])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[154])),
+      22)
       << "incorrect value for amplitude_value[154], expected 22, is "
       << last_msg_->amplitude_value[154];
-  EXPECT_EQ(last_msg_->amplitude_value[155], 155)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[155])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[155])),
+      155)
       << "incorrect value for amplitude_value[155], expected 155, is "
       << last_msg_->amplitude_value[155];
-  EXPECT_EQ(last_msg_->amplitude_value[156], 113)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[156])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[156])),
+      113)
       << "incorrect value for amplitude_value[156], expected 113, is "
       << last_msg_->amplitude_value[156];
-  EXPECT_EQ(last_msg_->amplitude_value[157], 110)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[157])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[157])),
+      110)
       << "incorrect value for amplitude_value[157], expected 110, is "
       << last_msg_->amplitude_value[157];
-  EXPECT_EQ(last_msg_->amplitude_value[158], 15)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[158])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[158])),
+      15)
       << "incorrect value for amplitude_value[158], expected 15, is "
       << last_msg_->amplitude_value[158];
-  EXPECT_EQ(last_msg_->amplitude_value[159], 243)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[159])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[159])),
+      243)
       << "incorrect value for amplitude_value[159], expected 243, is "
       << last_msg_->amplitude_value[159];
-  EXPECT_EQ(last_msg_->amplitude_value[160], 141)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[160])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[160])),
+      141)
       << "incorrect value for amplitude_value[160], expected 141, is "
       << last_msg_->amplitude_value[160];
-  EXPECT_EQ(last_msg_->amplitude_value[161], 227)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[161])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[161])),
+      227)
       << "incorrect value for amplitude_value[161], expected 227, is "
       << last_msg_->amplitude_value[161];
-  EXPECT_EQ(last_msg_->amplitude_value[162], 46)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[162])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[162])),
+      46)
       << "incorrect value for amplitude_value[162], expected 46, is "
       << last_msg_->amplitude_value[162];
-  EXPECT_EQ(last_msg_->amplitude_value[163], 143)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[163])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[163])),
+      143)
       << "incorrect value for amplitude_value[163], expected 143, is "
       << last_msg_->amplitude_value[163];
-  EXPECT_EQ(last_msg_->amplitude_value[164], 227)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[164])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[164])),
+      227)
       << "incorrect value for amplitude_value[164], expected 227, is "
       << last_msg_->amplitude_value[164];
-  EXPECT_EQ(last_msg_->amplitude_value[165], 209)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[165])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[165])),
+      209)
       << "incorrect value for amplitude_value[165], expected 209, is "
       << last_msg_->amplitude_value[165];
-  EXPECT_EQ(last_msg_->amplitude_value[166], 249)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[166])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[166])),
+      249)
       << "incorrect value for amplitude_value[166], expected 249, is "
       << last_msg_->amplitude_value[166];
-  EXPECT_EQ(last_msg_->amplitude_value[167], 2)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[167])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[167])),
+      2)
       << "incorrect value for amplitude_value[167], expected 2, is "
       << last_msg_->amplitude_value[167];
-  EXPECT_EQ(last_msg_->amplitude_value[168], 153)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[168])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[168])),
+      153)
       << "incorrect value for amplitude_value[168], expected 153, is "
       << last_msg_->amplitude_value[168];
-  EXPECT_EQ(last_msg_->amplitude_value[169], 168)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[169])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[169])),
+      168)
       << "incorrect value for amplitude_value[169], expected 168, is "
       << last_msg_->amplitude_value[169];
-  EXPECT_EQ(last_msg_->amplitude_value[170], 131)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[170])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[170])),
+      131)
       << "incorrect value for amplitude_value[170], expected 131, is "
       << last_msg_->amplitude_value[170];
-  EXPECT_EQ(last_msg_->amplitude_value[171], 249)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[171])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[171])),
+      249)
       << "incorrect value for amplitude_value[171], expected 249, is "
       << last_msg_->amplitude_value[171];
-  EXPECT_EQ(last_msg_->amplitude_value[172], 160)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[172])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[172])),
+      160)
       << "incorrect value for amplitude_value[172], expected 160, is "
       << last_msg_->amplitude_value[172];
-  EXPECT_EQ(last_msg_->amplitude_value[173], 88)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[173])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[173])),
+      88)
       << "incorrect value for amplitude_value[173], expected 88, is "
       << last_msg_->amplitude_value[173];
-  EXPECT_EQ(last_msg_->amplitude_value[174], 38)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[174])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[174])),
+      38)
       << "incorrect value for amplitude_value[174], expected 38, is "
       << last_msg_->amplitude_value[174];
-  EXPECT_EQ(last_msg_->amplitude_value[175], 117)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[175])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[175])),
+      117)
       << "incorrect value for amplitude_value[175], expected 117, is "
       << last_msg_->amplitude_value[175];
-  EXPECT_EQ(last_msg_->amplitude_value[176], 129)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[176])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[176])),
+      129)
       << "incorrect value for amplitude_value[176], expected 129, is "
       << last_msg_->amplitude_value[176];
-  EXPECT_EQ(last_msg_->amplitude_value[177], 57)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[177])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[177])),
+      57)
       << "incorrect value for amplitude_value[177], expected 57, is "
       << last_msg_->amplitude_value[177];
-  EXPECT_EQ(last_msg_->amplitude_value[178], 40)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[178])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[178])),
+      40)
       << "incorrect value for amplitude_value[178], expected 40, is "
       << last_msg_->amplitude_value[178];
-  EXPECT_EQ(last_msg_->amplitude_value[179], 109)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[179])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[179])),
+      109)
       << "incorrect value for amplitude_value[179], expected 109, is "
       << last_msg_->amplitude_value[179];
-  EXPECT_EQ(last_msg_->amplitude_value[180], 209)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[180])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[180])),
+      209)
       << "incorrect value for amplitude_value[180], expected 209, is "
       << last_msg_->amplitude_value[180];
-  EXPECT_EQ(last_msg_->amplitude_value[181], 177)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[181])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[181])),
+      177)
       << "incorrect value for amplitude_value[181], expected 177, is "
       << last_msg_->amplitude_value[181];
-  EXPECT_EQ(last_msg_->amplitude_value[182], 38)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[182])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[182])),
+      38)
       << "incorrect value for amplitude_value[182], expected 38, is "
       << last_msg_->amplitude_value[182];
-  EXPECT_EQ(last_msg_->amplitude_value[183], 47)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[183])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[183])),
+      47)
       << "incorrect value for amplitude_value[183], expected 47, is "
       << last_msg_->amplitude_value[183];
-  EXPECT_EQ(last_msg_->amplitude_value[184], 12)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[184])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[184])),
+      12)
       << "incorrect value for amplitude_value[184], expected 12, is "
       << last_msg_->amplitude_value[184];
-  EXPECT_EQ(last_msg_->amplitude_value[185], 15)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[185])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[185])),
+      15)
       << "incorrect value for amplitude_value[185], expected 15, is "
       << last_msg_->amplitude_value[185];
-  EXPECT_EQ(last_msg_->amplitude_value[186], 16)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[186])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[186])),
+      16)
       << "incorrect value for amplitude_value[186], expected 16, is "
       << last_msg_->amplitude_value[186];
-  EXPECT_EQ(last_msg_->amplitude_value[187], 9)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[187])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[187])),
+      9)
       << "incorrect value for amplitude_value[187], expected 9, is "
       << last_msg_->amplitude_value[187];
-  EXPECT_EQ(last_msg_->amplitude_value[188], 175)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[188])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[188])),
+      175)
       << "incorrect value for amplitude_value[188], expected 175, is "
       << last_msg_->amplitude_value[188];
-  EXPECT_EQ(last_msg_->amplitude_value[189], 69)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[189])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[189])),
+      69)
       << "incorrect value for amplitude_value[189], expected 69, is "
       << last_msg_->amplitude_value[189];
-  EXPECT_EQ(last_msg_->amplitude_value[190], 70)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[190])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[190])),
+      70)
       << "incorrect value for amplitude_value[190], expected 70, is "
       << last_msg_->amplitude_value[190];
-  EXPECT_EQ(last_msg_->amplitude_value[191], 182)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[191])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[191])),
+      182)
       << "incorrect value for amplitude_value[191], expected 182, is "
       << last_msg_->amplitude_value[191];
-  EXPECT_EQ(last_msg_->amplitude_value[192], 239)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[192])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[192])),
+      239)
       << "incorrect value for amplitude_value[192], expected 239, is "
       << last_msg_->amplitude_value[192];
-  EXPECT_EQ(last_msg_->amplitude_value[193], 117)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[193])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[193])),
+      117)
       << "incorrect value for amplitude_value[193], expected 117, is "
       << last_msg_->amplitude_value[193];
-  EXPECT_EQ(last_msg_->amplitude_value[194], 135)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[194])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[194])),
+      135)
       << "incorrect value for amplitude_value[194], expected 135, is "
       << last_msg_->amplitude_value[194];
-  EXPECT_EQ(last_msg_->amplitude_value[195], 6)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[195])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[195])),
+      6)
       << "incorrect value for amplitude_value[195], expected 6, is "
       << last_msg_->amplitude_value[195];
-  EXPECT_EQ(last_msg_->amplitude_value[196], 71)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[196])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[196])),
+      71)
       << "incorrect value for amplitude_value[196], expected 71, is "
       << last_msg_->amplitude_value[196];
-  EXPECT_EQ(last_msg_->amplitude_value[197], 99)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[197])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[197])),
+      99)
       << "incorrect value for amplitude_value[197], expected 99, is "
       << last_msg_->amplitude_value[197];
-  EXPECT_EQ(last_msg_->amplitude_value[198], 230)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[198])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[198])),
+      230)
       << "incorrect value for amplitude_value[198], expected 230, is "
       << last_msg_->amplitude_value[198];
-  EXPECT_EQ(last_msg_->amplitude_value[199], 115)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[199])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[199])),
+      115)
       << "incorrect value for amplitude_value[199], expected 115, is "
       << last_msg_->amplitude_value[199];
-  EXPECT_EQ(last_msg_->amplitude_value[200], 2)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[200])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[200])),
+      2)
       << "incorrect value for amplitude_value[200], expected 2, is "
       << last_msg_->amplitude_value[200];
-  EXPECT_EQ(last_msg_->amplitude_value[201], 71)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[201])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[201])),
+      71)
       << "incorrect value for amplitude_value[201], expected 71, is "
       << last_msg_->amplitude_value[201];
-  EXPECT_EQ(last_msg_->amplitude_value[202], 165)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[202])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[202])),
+      165)
       << "incorrect value for amplitude_value[202], expected 165, is "
       << last_msg_->amplitude_value[202];
-  EXPECT_EQ(last_msg_->amplitude_value[203], 228)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[203])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[203])),
+      228)
       << "incorrect value for amplitude_value[203], expected 228, is "
       << last_msg_->amplitude_value[203];
-  EXPECT_EQ(last_msg_->amplitude_value[204], 123)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[204])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[204])),
+      123)
       << "incorrect value for amplitude_value[204], expected 123, is "
       << last_msg_->amplitude_value[204];
-  EXPECT_EQ(last_msg_->amplitude_value[205], 210)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[205])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[205])),
+      210)
       << "incorrect value for amplitude_value[205], expected 210, is "
       << last_msg_->amplitude_value[205];
-  EXPECT_EQ(last_msg_->amplitude_value[206], 168)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[206])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[206])),
+      168)
       << "incorrect value for amplitude_value[206], expected 168, is "
       << last_msg_->amplitude_value[206];
-  EXPECT_EQ(last_msg_->amplitude_value[207], 90)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[207])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[207])),
+      90)
       << "incorrect value for amplitude_value[207], expected 90, is "
       << last_msg_->amplitude_value[207];
-  EXPECT_EQ(last_msg_->amplitude_value[208], 124)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[208])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[208])),
+      124)
       << "incorrect value for amplitude_value[208], expected 124, is "
       << last_msg_->amplitude_value[208];
-  EXPECT_EQ(last_msg_->amplitude_value[209], 20)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[209])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[209])),
+      20)
       << "incorrect value for amplitude_value[209], expected 20, is "
       << last_msg_->amplitude_value[209];
-  EXPECT_EQ(last_msg_->amplitude_value[210], 7)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[210])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[210])),
+      7)
       << "incorrect value for amplitude_value[210], expected 7, is "
       << last_msg_->amplitude_value[210];
-  EXPECT_EQ(last_msg_->amplitude_value[211], 220)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[211])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[211])),
+      220)
       << "incorrect value for amplitude_value[211], expected 220, is "
       << last_msg_->amplitude_value[211];
-  EXPECT_EQ(last_msg_->amplitude_value[212], 144)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[212])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[212])),
+      144)
       << "incorrect value for amplitude_value[212], expected 144, is "
       << last_msg_->amplitude_value[212];
-  EXPECT_EQ(last_msg_->amplitude_value[213], 168)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[213])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[213])),
+      168)
       << "incorrect value for amplitude_value[213], expected 168, is "
       << last_msg_->amplitude_value[213];
-  EXPECT_EQ(last_msg_->amplitude_value[214], 69)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[214])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[214])),
+      69)
       << "incorrect value for amplitude_value[214], expected 69, is "
       << last_msg_->amplitude_value[214];
-  EXPECT_EQ(last_msg_->amplitude_value[215], 22)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[215])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[215])),
+      22)
       << "incorrect value for amplitude_value[215], expected 22, is "
       << last_msg_->amplitude_value[215];
-  EXPECT_EQ(last_msg_->amplitude_value[216], 72)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[216])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[216])),
+      72)
       << "incorrect value for amplitude_value[216], expected 72, is "
       << last_msg_->amplitude_value[216];
-  EXPECT_EQ(last_msg_->amplitude_value[217], 162)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[217])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[217])),
+      162)
       << "incorrect value for amplitude_value[217], expected 162, is "
       << last_msg_->amplitude_value[217];
-  EXPECT_EQ(last_msg_->amplitude_value[218], 69)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[218])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[218])),
+      69)
       << "incorrect value for amplitude_value[218], expected 69, is "
       << last_msg_->amplitude_value[218];
-  EXPECT_EQ(last_msg_->amplitude_value[219], 111)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[219])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[219])),
+      111)
       << "incorrect value for amplitude_value[219], expected 111, is "
       << last_msg_->amplitude_value[219];
-  EXPECT_EQ(last_msg_->amplitude_value[220], 91)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[220])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[220])),
+      91)
       << "incorrect value for amplitude_value[220], expected 91, is "
       << last_msg_->amplitude_value[220];
-  EXPECT_EQ(last_msg_->amplitude_value[221], 251)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[221])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[221])),
+      251)
       << "incorrect value for amplitude_value[221], expected 251, is "
       << last_msg_->amplitude_value[221];
-  EXPECT_EQ(last_msg_->amplitude_value[222], 72)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[222])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[222])),
+      72)
       << "incorrect value for amplitude_value[222], expected 72, is "
       << last_msg_->amplitude_value[222];
-  EXPECT_EQ(last_msg_->amplitude_value[223], 220)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[223])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[223])),
+      220)
       << "incorrect value for amplitude_value[223], expected 220, is "
       << last_msg_->amplitude_value[223];
-  EXPECT_EQ(last_msg_->amplitude_value[224], 28)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[224])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[224])),
+      28)
       << "incorrect value for amplitude_value[224], expected 28, is "
       << last_msg_->amplitude_value[224];
-  EXPECT_EQ(last_msg_->amplitude_value[225], 119)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[225])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[225])),
+      119)
       << "incorrect value for amplitude_value[225], expected 119, is "
       << last_msg_->amplitude_value[225];
-  EXPECT_EQ(last_msg_->amplitude_value[226], 150)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[226])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[226])),
+      150)
       << "incorrect value for amplitude_value[226], expected 150, is "
       << last_msg_->amplitude_value[226];
-  EXPECT_EQ(last_msg_->channel_tag, 35146)
+  EXPECT_EQ(get_as<decltype(last_msg_->channel_tag)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->channel_tag)),
+            35146)
       << "incorrect value for channel_tag, expected 35146, is "
       << last_msg_->channel_tag;
   EXPECT_LT((last_msg_->freq_ref * 100 - 7737.20019531 * 100), 0.05)
@@ -2192,12 +2882,18 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgSpecan0, Test) {
   EXPECT_LT((last_msg_->freq_step * 100 - 8226.20019531 * 100), 0.05)
       << "incorrect value for freq_step, expected 8226.20019531, is "
       << last_msg_->freq_step;
-  EXPECT_EQ(last_msg_->t.ns_residual, -1479025396)
+  EXPECT_EQ(get_as<decltype(last_msg_->t.ns_residual)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->t.ns_residual)),
+            -1479025396)
       << "incorrect value for t.ns_residual, expected -1479025396, is "
       << last_msg_->t.ns_residual;
-  EXPECT_EQ(last_msg_->t.tow, 1227027783)
+  EXPECT_EQ(get_as<decltype(last_msg_->t.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->t.tow)),
+            1227027783)
       << "incorrect value for t.tow, expected 1227027783, is "
       << last_msg_->t.tow;
-  EXPECT_EQ(last_msg_->t.wn, 5075)
+  EXPECT_EQ(get_as<decltype(last_msg_->t.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->t.wn)),
+            5075)
       << "incorrect value for t.wn, expected 5075, is " << last_msg_->t.wn;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_piksi_MsgSpecanDep.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_piksi_MsgSpecanDep.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/piksi.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_piksi_MsgSpecanDep0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -1525,700 +1532,1395 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgSpecanDep0, Test) {
   EXPECT_LT((last_msg_->amplitude_unit * 100 - 3485.19995117 * 100), 0.05)
       << "incorrect value for amplitude_unit, expected 3485.19995117, is "
       << last_msg_->amplitude_unit;
-  EXPECT_EQ(last_msg_->amplitude_value[0], 240)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[0])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[0])),
+      240)
       << "incorrect value for amplitude_value[0], expected 240, is "
       << last_msg_->amplitude_value[0];
-  EXPECT_EQ(last_msg_->amplitude_value[1], 14)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[1])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[1])),
+      14)
       << "incorrect value for amplitude_value[1], expected 14, is "
       << last_msg_->amplitude_value[1];
-  EXPECT_EQ(last_msg_->amplitude_value[2], 179)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[2])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[2])),
+      179)
       << "incorrect value for amplitude_value[2], expected 179, is "
       << last_msg_->amplitude_value[2];
-  EXPECT_EQ(last_msg_->amplitude_value[3], 186)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[3])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[3])),
+      186)
       << "incorrect value for amplitude_value[3], expected 186, is "
       << last_msg_->amplitude_value[3];
-  EXPECT_EQ(last_msg_->amplitude_value[4], 227)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[4])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[4])),
+      227)
       << "incorrect value for amplitude_value[4], expected 227, is "
       << last_msg_->amplitude_value[4];
-  EXPECT_EQ(last_msg_->amplitude_value[5], 244)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[5])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[5])),
+      244)
       << "incorrect value for amplitude_value[5], expected 244, is "
       << last_msg_->amplitude_value[5];
-  EXPECT_EQ(last_msg_->amplitude_value[6], 173)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[6])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[6])),
+      173)
       << "incorrect value for amplitude_value[6], expected 173, is "
       << last_msg_->amplitude_value[6];
-  EXPECT_EQ(last_msg_->amplitude_value[7], 240)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[7])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[7])),
+      240)
       << "incorrect value for amplitude_value[7], expected 240, is "
       << last_msg_->amplitude_value[7];
-  EXPECT_EQ(last_msg_->amplitude_value[8], 182)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[8])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[8])),
+      182)
       << "incorrect value for amplitude_value[8], expected 182, is "
       << last_msg_->amplitude_value[8];
-  EXPECT_EQ(last_msg_->amplitude_value[9], 71)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[9])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[9])),
+      71)
       << "incorrect value for amplitude_value[9], expected 71, is "
       << last_msg_->amplitude_value[9];
-  EXPECT_EQ(last_msg_->amplitude_value[10], 166)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[10])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[10])),
+      166)
       << "incorrect value for amplitude_value[10], expected 166, is "
       << last_msg_->amplitude_value[10];
-  EXPECT_EQ(last_msg_->amplitude_value[11], 117)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[11])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[11])),
+      117)
       << "incorrect value for amplitude_value[11], expected 117, is "
       << last_msg_->amplitude_value[11];
-  EXPECT_EQ(last_msg_->amplitude_value[12], 196)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[12])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[12])),
+      196)
       << "incorrect value for amplitude_value[12], expected 196, is "
       << last_msg_->amplitude_value[12];
-  EXPECT_EQ(last_msg_->amplitude_value[13], 13)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[13])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[13])),
+      13)
       << "incorrect value for amplitude_value[13], expected 13, is "
       << last_msg_->amplitude_value[13];
-  EXPECT_EQ(last_msg_->amplitude_value[14], 44)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[14])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[14])),
+      44)
       << "incorrect value for amplitude_value[14], expected 44, is "
       << last_msg_->amplitude_value[14];
-  EXPECT_EQ(last_msg_->amplitude_value[15], 27)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[15])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[15])),
+      27)
       << "incorrect value for amplitude_value[15], expected 27, is "
       << last_msg_->amplitude_value[15];
-  EXPECT_EQ(last_msg_->amplitude_value[16], 33)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[16])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[16])),
+      33)
       << "incorrect value for amplitude_value[16], expected 33, is "
       << last_msg_->amplitude_value[16];
-  EXPECT_EQ(last_msg_->amplitude_value[17], 28)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[17])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[17])),
+      28)
       << "incorrect value for amplitude_value[17], expected 28, is "
       << last_msg_->amplitude_value[17];
-  EXPECT_EQ(last_msg_->amplitude_value[18], 67)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[18])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[18])),
+      67)
       << "incorrect value for amplitude_value[18], expected 67, is "
       << last_msg_->amplitude_value[18];
-  EXPECT_EQ(last_msg_->amplitude_value[19], 254)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[19])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[19])),
+      254)
       << "incorrect value for amplitude_value[19], expected 254, is "
       << last_msg_->amplitude_value[19];
-  EXPECT_EQ(last_msg_->amplitude_value[20], 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[20])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[20])),
+      3)
       << "incorrect value for amplitude_value[20], expected 3, is "
       << last_msg_->amplitude_value[20];
-  EXPECT_EQ(last_msg_->amplitude_value[21], 249)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[21])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[21])),
+      249)
       << "incorrect value for amplitude_value[21], expected 249, is "
       << last_msg_->amplitude_value[21];
-  EXPECT_EQ(last_msg_->amplitude_value[22], 92)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[22])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[22])),
+      92)
       << "incorrect value for amplitude_value[22], expected 92, is "
       << last_msg_->amplitude_value[22];
-  EXPECT_EQ(last_msg_->amplitude_value[23], 44)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[23])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[23])),
+      44)
       << "incorrect value for amplitude_value[23], expected 44, is "
       << last_msg_->amplitude_value[23];
-  EXPECT_EQ(last_msg_->amplitude_value[24], 122)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[24])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[24])),
+      122)
       << "incorrect value for amplitude_value[24], expected 122, is "
       << last_msg_->amplitude_value[24];
-  EXPECT_EQ(last_msg_->amplitude_value[25], 169)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[25])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[25])),
+      169)
       << "incorrect value for amplitude_value[25], expected 169, is "
       << last_msg_->amplitude_value[25];
-  EXPECT_EQ(last_msg_->amplitude_value[26], 77)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[26])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[26])),
+      77)
       << "incorrect value for amplitude_value[26], expected 77, is "
       << last_msg_->amplitude_value[26];
-  EXPECT_EQ(last_msg_->amplitude_value[27], 186)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[27])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[27])),
+      186)
       << "incorrect value for amplitude_value[27], expected 186, is "
       << last_msg_->amplitude_value[27];
-  EXPECT_EQ(last_msg_->amplitude_value[28], 68)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[28])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[28])),
+      68)
       << "incorrect value for amplitude_value[28], expected 68, is "
       << last_msg_->amplitude_value[28];
-  EXPECT_EQ(last_msg_->amplitude_value[29], 135)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[29])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[29])),
+      135)
       << "incorrect value for amplitude_value[29], expected 135, is "
       << last_msg_->amplitude_value[29];
-  EXPECT_EQ(last_msg_->amplitude_value[30], 63)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[30])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[30])),
+      63)
       << "incorrect value for amplitude_value[30], expected 63, is "
       << last_msg_->amplitude_value[30];
-  EXPECT_EQ(last_msg_->amplitude_value[31], 168)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[31])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[31])),
+      168)
       << "incorrect value for amplitude_value[31], expected 168, is "
       << last_msg_->amplitude_value[31];
-  EXPECT_EQ(last_msg_->amplitude_value[32], 162)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[32])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[32])),
+      162)
       << "incorrect value for amplitude_value[32], expected 162, is "
       << last_msg_->amplitude_value[32];
-  EXPECT_EQ(last_msg_->amplitude_value[33], 89)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[33])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[33])),
+      89)
       << "incorrect value for amplitude_value[33], expected 89, is "
       << last_msg_->amplitude_value[33];
-  EXPECT_EQ(last_msg_->amplitude_value[34], 36)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[34])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[34])),
+      36)
       << "incorrect value for amplitude_value[34], expected 36, is "
       << last_msg_->amplitude_value[34];
-  EXPECT_EQ(last_msg_->amplitude_value[35], 186)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[35])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[35])),
+      186)
       << "incorrect value for amplitude_value[35], expected 186, is "
       << last_msg_->amplitude_value[35];
-  EXPECT_EQ(last_msg_->amplitude_value[36], 99)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[36])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[36])),
+      99)
       << "incorrect value for amplitude_value[36], expected 99, is "
       << last_msg_->amplitude_value[36];
-  EXPECT_EQ(last_msg_->amplitude_value[37], 63)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[37])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[37])),
+      63)
       << "incorrect value for amplitude_value[37], expected 63, is "
       << last_msg_->amplitude_value[37];
-  EXPECT_EQ(last_msg_->amplitude_value[38], 105)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[38])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[38])),
+      105)
       << "incorrect value for amplitude_value[38], expected 105, is "
       << last_msg_->amplitude_value[38];
-  EXPECT_EQ(last_msg_->amplitude_value[39], 116)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[39])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[39])),
+      116)
       << "incorrect value for amplitude_value[39], expected 116, is "
       << last_msg_->amplitude_value[39];
-  EXPECT_EQ(last_msg_->amplitude_value[40], 216)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[40])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[40])),
+      216)
       << "incorrect value for amplitude_value[40], expected 216, is "
       << last_msg_->amplitude_value[40];
-  EXPECT_EQ(last_msg_->amplitude_value[41], 44)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[41])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[41])),
+      44)
       << "incorrect value for amplitude_value[41], expected 44, is "
       << last_msg_->amplitude_value[41];
-  EXPECT_EQ(last_msg_->amplitude_value[42], 67)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[42])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[42])),
+      67)
       << "incorrect value for amplitude_value[42], expected 67, is "
       << last_msg_->amplitude_value[42];
-  EXPECT_EQ(last_msg_->amplitude_value[43], 212)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[43])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[43])),
+      212)
       << "incorrect value for amplitude_value[43], expected 212, is "
       << last_msg_->amplitude_value[43];
-  EXPECT_EQ(last_msg_->amplitude_value[44], 156)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[44])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[44])),
+      156)
       << "incorrect value for amplitude_value[44], expected 156, is "
       << last_msg_->amplitude_value[44];
-  EXPECT_EQ(last_msg_->amplitude_value[45], 75)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[45])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[45])),
+      75)
       << "incorrect value for amplitude_value[45], expected 75, is "
       << last_msg_->amplitude_value[45];
-  EXPECT_EQ(last_msg_->amplitude_value[46], 81)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[46])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[46])),
+      81)
       << "incorrect value for amplitude_value[46], expected 81, is "
       << last_msg_->amplitude_value[46];
-  EXPECT_EQ(last_msg_->amplitude_value[47], 53)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[47])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[47])),
+      53)
       << "incorrect value for amplitude_value[47], expected 53, is "
       << last_msg_->amplitude_value[47];
-  EXPECT_EQ(last_msg_->amplitude_value[48], 250)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[48])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[48])),
+      250)
       << "incorrect value for amplitude_value[48], expected 250, is "
       << last_msg_->amplitude_value[48];
-  EXPECT_EQ(last_msg_->amplitude_value[49], 225)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[49])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[49])),
+      225)
       << "incorrect value for amplitude_value[49], expected 225, is "
       << last_msg_->amplitude_value[49];
-  EXPECT_EQ(last_msg_->amplitude_value[50], 23)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[50])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[50])),
+      23)
       << "incorrect value for amplitude_value[50], expected 23, is "
       << last_msg_->amplitude_value[50];
-  EXPECT_EQ(last_msg_->amplitude_value[51], 205)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[51])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[51])),
+      205)
       << "incorrect value for amplitude_value[51], expected 205, is "
       << last_msg_->amplitude_value[51];
-  EXPECT_EQ(last_msg_->amplitude_value[52], 26)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[52])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[52])),
+      26)
       << "incorrect value for amplitude_value[52], expected 26, is "
       << last_msg_->amplitude_value[52];
-  EXPECT_EQ(last_msg_->amplitude_value[53], 34)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[53])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[53])),
+      34)
       << "incorrect value for amplitude_value[53], expected 34, is "
       << last_msg_->amplitude_value[53];
-  EXPECT_EQ(last_msg_->amplitude_value[54], 119)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[54])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[54])),
+      119)
       << "incorrect value for amplitude_value[54], expected 119, is "
       << last_msg_->amplitude_value[54];
-  EXPECT_EQ(last_msg_->amplitude_value[55], 50)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[55])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[55])),
+      50)
       << "incorrect value for amplitude_value[55], expected 50, is "
       << last_msg_->amplitude_value[55];
-  EXPECT_EQ(last_msg_->amplitude_value[56], 101)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[56])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[56])),
+      101)
       << "incorrect value for amplitude_value[56], expected 101, is "
       << last_msg_->amplitude_value[56];
-  EXPECT_EQ(last_msg_->amplitude_value[57], 64)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[57])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[57])),
+      64)
       << "incorrect value for amplitude_value[57], expected 64, is "
       << last_msg_->amplitude_value[57];
-  EXPECT_EQ(last_msg_->amplitude_value[58], 7)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[58])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[58])),
+      7)
       << "incorrect value for amplitude_value[58], expected 7, is "
       << last_msg_->amplitude_value[58];
-  EXPECT_EQ(last_msg_->amplitude_value[59], 231)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[59])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[59])),
+      231)
       << "incorrect value for amplitude_value[59], expected 231, is "
       << last_msg_->amplitude_value[59];
-  EXPECT_EQ(last_msg_->amplitude_value[60], 124)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[60])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[60])),
+      124)
       << "incorrect value for amplitude_value[60], expected 124, is "
       << last_msg_->amplitude_value[60];
-  EXPECT_EQ(last_msg_->amplitude_value[61], 183)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[61])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[61])),
+      183)
       << "incorrect value for amplitude_value[61], expected 183, is "
       << last_msg_->amplitude_value[61];
-  EXPECT_EQ(last_msg_->amplitude_value[62], 203)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[62])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[62])),
+      203)
       << "incorrect value for amplitude_value[62], expected 203, is "
       << last_msg_->amplitude_value[62];
-  EXPECT_EQ(last_msg_->amplitude_value[63], 102)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[63])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[63])),
+      102)
       << "incorrect value for amplitude_value[63], expected 102, is "
       << last_msg_->amplitude_value[63];
-  EXPECT_EQ(last_msg_->amplitude_value[64], 234)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[64])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[64])),
+      234)
       << "incorrect value for amplitude_value[64], expected 234, is "
       << last_msg_->amplitude_value[64];
-  EXPECT_EQ(last_msg_->amplitude_value[65], 84)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[65])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[65])),
+      84)
       << "incorrect value for amplitude_value[65], expected 84, is "
       << last_msg_->amplitude_value[65];
-  EXPECT_EQ(last_msg_->amplitude_value[66], 83)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[66])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[66])),
+      83)
       << "incorrect value for amplitude_value[66], expected 83, is "
       << last_msg_->amplitude_value[66];
-  EXPECT_EQ(last_msg_->amplitude_value[67], 208)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[67])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[67])),
+      208)
       << "incorrect value for amplitude_value[67], expected 208, is "
       << last_msg_->amplitude_value[67];
-  EXPECT_EQ(last_msg_->amplitude_value[68], 23)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[68])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[68])),
+      23)
       << "incorrect value for amplitude_value[68], expected 23, is "
       << last_msg_->amplitude_value[68];
-  EXPECT_EQ(last_msg_->amplitude_value[69], 68)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[69])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[69])),
+      68)
       << "incorrect value for amplitude_value[69], expected 68, is "
       << last_msg_->amplitude_value[69];
-  EXPECT_EQ(last_msg_->amplitude_value[70], 54)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[70])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[70])),
+      54)
       << "incorrect value for amplitude_value[70], expected 54, is "
       << last_msg_->amplitude_value[70];
-  EXPECT_EQ(last_msg_->amplitude_value[71], 179)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[71])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[71])),
+      179)
       << "incorrect value for amplitude_value[71], expected 179, is "
       << last_msg_->amplitude_value[71];
-  EXPECT_EQ(last_msg_->amplitude_value[72], 98)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[72])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[72])),
+      98)
       << "incorrect value for amplitude_value[72], expected 98, is "
       << last_msg_->amplitude_value[72];
-  EXPECT_EQ(last_msg_->amplitude_value[73], 96)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[73])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[73])),
+      96)
       << "incorrect value for amplitude_value[73], expected 96, is "
       << last_msg_->amplitude_value[73];
-  EXPECT_EQ(last_msg_->amplitude_value[74], 116)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[74])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[74])),
+      116)
       << "incorrect value for amplitude_value[74], expected 116, is "
       << last_msg_->amplitude_value[74];
-  EXPECT_EQ(last_msg_->amplitude_value[75], 244)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[75])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[75])),
+      244)
       << "incorrect value for amplitude_value[75], expected 244, is "
       << last_msg_->amplitude_value[75];
-  EXPECT_EQ(last_msg_->amplitude_value[76], 246)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[76])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[76])),
+      246)
       << "incorrect value for amplitude_value[76], expected 246, is "
       << last_msg_->amplitude_value[76];
-  EXPECT_EQ(last_msg_->amplitude_value[77], 94)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[77])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[77])),
+      94)
       << "incorrect value for amplitude_value[77], expected 94, is "
       << last_msg_->amplitude_value[77];
-  EXPECT_EQ(last_msg_->amplitude_value[78], 104)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[78])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[78])),
+      104)
       << "incorrect value for amplitude_value[78], expected 104, is "
       << last_msg_->amplitude_value[78];
-  EXPECT_EQ(last_msg_->amplitude_value[79], 94)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[79])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[79])),
+      94)
       << "incorrect value for amplitude_value[79], expected 94, is "
       << last_msg_->amplitude_value[79];
-  EXPECT_EQ(last_msg_->amplitude_value[80], 13)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[80])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[80])),
+      13)
       << "incorrect value for amplitude_value[80], expected 13, is "
       << last_msg_->amplitude_value[80];
-  EXPECT_EQ(last_msg_->amplitude_value[81], 56)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[81])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[81])),
+      56)
       << "incorrect value for amplitude_value[81], expected 56, is "
       << last_msg_->amplitude_value[81];
-  EXPECT_EQ(last_msg_->amplitude_value[82], 210)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[82])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[82])),
+      210)
       << "incorrect value for amplitude_value[82], expected 210, is "
       << last_msg_->amplitude_value[82];
-  EXPECT_EQ(last_msg_->amplitude_value[83], 18)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[83])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[83])),
+      18)
       << "incorrect value for amplitude_value[83], expected 18, is "
       << last_msg_->amplitude_value[83];
-  EXPECT_EQ(last_msg_->amplitude_value[84], 191)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[84])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[84])),
+      191)
       << "incorrect value for amplitude_value[84], expected 191, is "
       << last_msg_->amplitude_value[84];
-  EXPECT_EQ(last_msg_->amplitude_value[85], 22)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[85])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[85])),
+      22)
       << "incorrect value for amplitude_value[85], expected 22, is "
       << last_msg_->amplitude_value[85];
-  EXPECT_EQ(last_msg_->amplitude_value[86], 133)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[86])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[86])),
+      133)
       << "incorrect value for amplitude_value[86], expected 133, is "
       << last_msg_->amplitude_value[86];
-  EXPECT_EQ(last_msg_->amplitude_value[87], 81)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[87])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[87])),
+      81)
       << "incorrect value for amplitude_value[87], expected 81, is "
       << last_msg_->amplitude_value[87];
-  EXPECT_EQ(last_msg_->amplitude_value[88], 153)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[88])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[88])),
+      153)
       << "incorrect value for amplitude_value[88], expected 153, is "
       << last_msg_->amplitude_value[88];
-  EXPECT_EQ(last_msg_->amplitude_value[89], 159)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[89])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[89])),
+      159)
       << "incorrect value for amplitude_value[89], expected 159, is "
       << last_msg_->amplitude_value[89];
-  EXPECT_EQ(last_msg_->amplitude_value[90], 161)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[90])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[90])),
+      161)
       << "incorrect value for amplitude_value[90], expected 161, is "
       << last_msg_->amplitude_value[90];
-  EXPECT_EQ(last_msg_->amplitude_value[91], 219)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[91])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[91])),
+      219)
       << "incorrect value for amplitude_value[91], expected 219, is "
       << last_msg_->amplitude_value[91];
-  EXPECT_EQ(last_msg_->amplitude_value[92], 59)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[92])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[92])),
+      59)
       << "incorrect value for amplitude_value[92], expected 59, is "
       << last_msg_->amplitude_value[92];
-  EXPECT_EQ(last_msg_->amplitude_value[93], 21)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[93])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[93])),
+      21)
       << "incorrect value for amplitude_value[93], expected 21, is "
       << last_msg_->amplitude_value[93];
-  EXPECT_EQ(last_msg_->amplitude_value[94], 164)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[94])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[94])),
+      164)
       << "incorrect value for amplitude_value[94], expected 164, is "
       << last_msg_->amplitude_value[94];
-  EXPECT_EQ(last_msg_->amplitude_value[95], 121)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[95])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[95])),
+      121)
       << "incorrect value for amplitude_value[95], expected 121, is "
       << last_msg_->amplitude_value[95];
-  EXPECT_EQ(last_msg_->amplitude_value[96], 145)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[96])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[96])),
+      145)
       << "incorrect value for amplitude_value[96], expected 145, is "
       << last_msg_->amplitude_value[96];
-  EXPECT_EQ(last_msg_->amplitude_value[97], 203)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[97])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[97])),
+      203)
       << "incorrect value for amplitude_value[97], expected 203, is "
       << last_msg_->amplitude_value[97];
-  EXPECT_EQ(last_msg_->amplitude_value[98], 171)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[98])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[98])),
+      171)
       << "incorrect value for amplitude_value[98], expected 171, is "
       << last_msg_->amplitude_value[98];
-  EXPECT_EQ(last_msg_->amplitude_value[99], 132)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[99])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[99])),
+      132)
       << "incorrect value for amplitude_value[99], expected 132, is "
       << last_msg_->amplitude_value[99];
-  EXPECT_EQ(last_msg_->amplitude_value[100], 57)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[100])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[100])),
+      57)
       << "incorrect value for amplitude_value[100], expected 57, is "
       << last_msg_->amplitude_value[100];
-  EXPECT_EQ(last_msg_->amplitude_value[101], 180)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[101])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[101])),
+      180)
       << "incorrect value for amplitude_value[101], expected 180, is "
       << last_msg_->amplitude_value[101];
-  EXPECT_EQ(last_msg_->amplitude_value[102], 102)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[102])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[102])),
+      102)
       << "incorrect value for amplitude_value[102], expected 102, is "
       << last_msg_->amplitude_value[102];
-  EXPECT_EQ(last_msg_->amplitude_value[103], 101)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[103])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[103])),
+      101)
       << "incorrect value for amplitude_value[103], expected 101, is "
       << last_msg_->amplitude_value[103];
-  EXPECT_EQ(last_msg_->amplitude_value[104], 11)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[104])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[104])),
+      11)
       << "incorrect value for amplitude_value[104], expected 11, is "
       << last_msg_->amplitude_value[104];
-  EXPECT_EQ(last_msg_->amplitude_value[105], 229)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[105])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[105])),
+      229)
       << "incorrect value for amplitude_value[105], expected 229, is "
       << last_msg_->amplitude_value[105];
-  EXPECT_EQ(last_msg_->amplitude_value[106], 175)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[106])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[106])),
+      175)
       << "incorrect value for amplitude_value[106], expected 175, is "
       << last_msg_->amplitude_value[106];
-  EXPECT_EQ(last_msg_->amplitude_value[107], 145)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[107])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[107])),
+      145)
       << "incorrect value for amplitude_value[107], expected 145, is "
       << last_msg_->amplitude_value[107];
-  EXPECT_EQ(last_msg_->amplitude_value[108], 73)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[108])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[108])),
+      73)
       << "incorrect value for amplitude_value[108], expected 73, is "
       << last_msg_->amplitude_value[108];
-  EXPECT_EQ(last_msg_->amplitude_value[109], 72)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[109])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[109])),
+      72)
       << "incorrect value for amplitude_value[109], expected 72, is "
       << last_msg_->amplitude_value[109];
-  EXPECT_EQ(last_msg_->amplitude_value[110], 124)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[110])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[110])),
+      124)
       << "incorrect value for amplitude_value[110], expected 124, is "
       << last_msg_->amplitude_value[110];
-  EXPECT_EQ(last_msg_->amplitude_value[111], 4)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[111])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[111])),
+      4)
       << "incorrect value for amplitude_value[111], expected 4, is "
       << last_msg_->amplitude_value[111];
-  EXPECT_EQ(last_msg_->amplitude_value[112], 184)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[112])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[112])),
+      184)
       << "incorrect value for amplitude_value[112], expected 184, is "
       << last_msg_->amplitude_value[112];
-  EXPECT_EQ(last_msg_->amplitude_value[113], 228)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[113])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[113])),
+      228)
       << "incorrect value for amplitude_value[113], expected 228, is "
       << last_msg_->amplitude_value[113];
-  EXPECT_EQ(last_msg_->amplitude_value[114], 61)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[114])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[114])),
+      61)
       << "incorrect value for amplitude_value[114], expected 61, is "
       << last_msg_->amplitude_value[114];
-  EXPECT_EQ(last_msg_->amplitude_value[115], 234)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[115])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[115])),
+      234)
       << "incorrect value for amplitude_value[115], expected 234, is "
       << last_msg_->amplitude_value[115];
-  EXPECT_EQ(last_msg_->amplitude_value[116], 218)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[116])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[116])),
+      218)
       << "incorrect value for amplitude_value[116], expected 218, is "
       << last_msg_->amplitude_value[116];
-  EXPECT_EQ(last_msg_->amplitude_value[117], 62)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[117])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[117])),
+      62)
       << "incorrect value for amplitude_value[117], expected 62, is "
       << last_msg_->amplitude_value[117];
-  EXPECT_EQ(last_msg_->amplitude_value[118], 226)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[118])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[118])),
+      226)
       << "incorrect value for amplitude_value[118], expected 226, is "
       << last_msg_->amplitude_value[118];
-  EXPECT_EQ(last_msg_->amplitude_value[119], 217)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[119])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[119])),
+      217)
       << "incorrect value for amplitude_value[119], expected 217, is "
       << last_msg_->amplitude_value[119];
-  EXPECT_EQ(last_msg_->amplitude_value[120], 193)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[120])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[120])),
+      193)
       << "incorrect value for amplitude_value[120], expected 193, is "
       << last_msg_->amplitude_value[120];
-  EXPECT_EQ(last_msg_->amplitude_value[121], 7)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[121])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[121])),
+      7)
       << "incorrect value for amplitude_value[121], expected 7, is "
       << last_msg_->amplitude_value[121];
-  EXPECT_EQ(last_msg_->amplitude_value[122], 109)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[122])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[122])),
+      109)
       << "incorrect value for amplitude_value[122], expected 109, is "
       << last_msg_->amplitude_value[122];
-  EXPECT_EQ(last_msg_->amplitude_value[123], 44)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[123])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[123])),
+      44)
       << "incorrect value for amplitude_value[123], expected 44, is "
       << last_msg_->amplitude_value[123];
-  EXPECT_EQ(last_msg_->amplitude_value[124], 83)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[124])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[124])),
+      83)
       << "incorrect value for amplitude_value[124], expected 83, is "
       << last_msg_->amplitude_value[124];
-  EXPECT_EQ(last_msg_->amplitude_value[125], 201)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[125])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[125])),
+      201)
       << "incorrect value for amplitude_value[125], expected 201, is "
       << last_msg_->amplitude_value[125];
-  EXPECT_EQ(last_msg_->amplitude_value[126], 20)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[126])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[126])),
+      20)
       << "incorrect value for amplitude_value[126], expected 20, is "
       << last_msg_->amplitude_value[126];
-  EXPECT_EQ(last_msg_->amplitude_value[127], 101)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[127])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[127])),
+      101)
       << "incorrect value for amplitude_value[127], expected 101, is "
       << last_msg_->amplitude_value[127];
-  EXPECT_EQ(last_msg_->amplitude_value[128], 9)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[128])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[128])),
+      9)
       << "incorrect value for amplitude_value[128], expected 9, is "
       << last_msg_->amplitude_value[128];
-  EXPECT_EQ(last_msg_->amplitude_value[129], 140)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[129])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[129])),
+      140)
       << "incorrect value for amplitude_value[129], expected 140, is "
       << last_msg_->amplitude_value[129];
-  EXPECT_EQ(last_msg_->amplitude_value[130], 186)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[130])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[130])),
+      186)
       << "incorrect value for amplitude_value[130], expected 186, is "
       << last_msg_->amplitude_value[130];
-  EXPECT_EQ(last_msg_->amplitude_value[131], 162)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[131])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[131])),
+      162)
       << "incorrect value for amplitude_value[131], expected 162, is "
       << last_msg_->amplitude_value[131];
-  EXPECT_EQ(last_msg_->amplitude_value[132], 81)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[132])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[132])),
+      81)
       << "incorrect value for amplitude_value[132], expected 81, is "
       << last_msg_->amplitude_value[132];
-  EXPECT_EQ(last_msg_->amplitude_value[133], 91)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[133])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[133])),
+      91)
       << "incorrect value for amplitude_value[133], expected 91, is "
       << last_msg_->amplitude_value[133];
-  EXPECT_EQ(last_msg_->amplitude_value[134], 30)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[134])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[134])),
+      30)
       << "incorrect value for amplitude_value[134], expected 30, is "
       << last_msg_->amplitude_value[134];
-  EXPECT_EQ(last_msg_->amplitude_value[135], 231)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[135])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[135])),
+      231)
       << "incorrect value for amplitude_value[135], expected 231, is "
       << last_msg_->amplitude_value[135];
-  EXPECT_EQ(last_msg_->amplitude_value[136], 161)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[136])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[136])),
+      161)
       << "incorrect value for amplitude_value[136], expected 161, is "
       << last_msg_->amplitude_value[136];
-  EXPECT_EQ(last_msg_->amplitude_value[137], 81)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[137])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[137])),
+      81)
       << "incorrect value for amplitude_value[137], expected 81, is "
       << last_msg_->amplitude_value[137];
-  EXPECT_EQ(last_msg_->amplitude_value[138], 216)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[138])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[138])),
+      216)
       << "incorrect value for amplitude_value[138], expected 216, is "
       << last_msg_->amplitude_value[138];
-  EXPECT_EQ(last_msg_->amplitude_value[139], 114)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[139])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[139])),
+      114)
       << "incorrect value for amplitude_value[139], expected 114, is "
       << last_msg_->amplitude_value[139];
-  EXPECT_EQ(last_msg_->amplitude_value[140], 60)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[140])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[140])),
+      60)
       << "incorrect value for amplitude_value[140], expected 60, is "
       << last_msg_->amplitude_value[140];
-  EXPECT_EQ(last_msg_->amplitude_value[141], 231)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[141])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[141])),
+      231)
       << "incorrect value for amplitude_value[141], expected 231, is "
       << last_msg_->amplitude_value[141];
-  EXPECT_EQ(last_msg_->amplitude_value[142], 163)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[142])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[142])),
+      163)
       << "incorrect value for amplitude_value[142], expected 163, is "
       << last_msg_->amplitude_value[142];
-  EXPECT_EQ(last_msg_->amplitude_value[143], 163)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[143])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[143])),
+      163)
       << "incorrect value for amplitude_value[143], expected 163, is "
       << last_msg_->amplitude_value[143];
-  EXPECT_EQ(last_msg_->amplitude_value[144], 49)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[144])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[144])),
+      49)
       << "incorrect value for amplitude_value[144], expected 49, is "
       << last_msg_->amplitude_value[144];
-  EXPECT_EQ(last_msg_->amplitude_value[145], 237)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[145])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[145])),
+      237)
       << "incorrect value for amplitude_value[145], expected 237, is "
       << last_msg_->amplitude_value[145];
-  EXPECT_EQ(last_msg_->amplitude_value[146], 244)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[146])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[146])),
+      244)
       << "incorrect value for amplitude_value[146], expected 244, is "
       << last_msg_->amplitude_value[146];
-  EXPECT_EQ(last_msg_->amplitude_value[147], 185)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[147])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[147])),
+      185)
       << "incorrect value for amplitude_value[147], expected 185, is "
       << last_msg_->amplitude_value[147];
-  EXPECT_EQ(last_msg_->amplitude_value[148], 240)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[148])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[148])),
+      240)
       << "incorrect value for amplitude_value[148], expected 240, is "
       << last_msg_->amplitude_value[148];
-  EXPECT_EQ(last_msg_->amplitude_value[149], 89)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[149])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[149])),
+      89)
       << "incorrect value for amplitude_value[149], expected 89, is "
       << last_msg_->amplitude_value[149];
-  EXPECT_EQ(last_msg_->amplitude_value[150], 143)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[150])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[150])),
+      143)
       << "incorrect value for amplitude_value[150], expected 143, is "
       << last_msg_->amplitude_value[150];
-  EXPECT_EQ(last_msg_->amplitude_value[151], 174)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[151])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[151])),
+      174)
       << "incorrect value for amplitude_value[151], expected 174, is "
       << last_msg_->amplitude_value[151];
-  EXPECT_EQ(last_msg_->amplitude_value[152], 165)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[152])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[152])),
+      165)
       << "incorrect value for amplitude_value[152], expected 165, is "
       << last_msg_->amplitude_value[152];
-  EXPECT_EQ(last_msg_->amplitude_value[153], 211)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[153])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[153])),
+      211)
       << "incorrect value for amplitude_value[153], expected 211, is "
       << last_msg_->amplitude_value[153];
-  EXPECT_EQ(last_msg_->amplitude_value[154], 241)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[154])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[154])),
+      241)
       << "incorrect value for amplitude_value[154], expected 241, is "
       << last_msg_->amplitude_value[154];
-  EXPECT_EQ(last_msg_->amplitude_value[155], 13)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[155])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[155])),
+      13)
       << "incorrect value for amplitude_value[155], expected 13, is "
       << last_msg_->amplitude_value[155];
-  EXPECT_EQ(last_msg_->amplitude_value[156], 16)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[156])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[156])),
+      16)
       << "incorrect value for amplitude_value[156], expected 16, is "
       << last_msg_->amplitude_value[156];
-  EXPECT_EQ(last_msg_->amplitude_value[157], 61)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[157])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[157])),
+      61)
       << "incorrect value for amplitude_value[157], expected 61, is "
       << last_msg_->amplitude_value[157];
-  EXPECT_EQ(last_msg_->amplitude_value[158], 141)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[158])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[158])),
+      141)
       << "incorrect value for amplitude_value[158], expected 141, is "
       << last_msg_->amplitude_value[158];
-  EXPECT_EQ(last_msg_->amplitude_value[159], 101)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[159])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[159])),
+      101)
       << "incorrect value for amplitude_value[159], expected 101, is "
       << last_msg_->amplitude_value[159];
-  EXPECT_EQ(last_msg_->amplitude_value[160], 89)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[160])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[160])),
+      89)
       << "incorrect value for amplitude_value[160], expected 89, is "
       << last_msg_->amplitude_value[160];
-  EXPECT_EQ(last_msg_->amplitude_value[161], 37)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[161])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[161])),
+      37)
       << "incorrect value for amplitude_value[161], expected 37, is "
       << last_msg_->amplitude_value[161];
-  EXPECT_EQ(last_msg_->amplitude_value[162], 117)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[162])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[162])),
+      117)
       << "incorrect value for amplitude_value[162], expected 117, is "
       << last_msg_->amplitude_value[162];
-  EXPECT_EQ(last_msg_->amplitude_value[163], 189)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[163])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[163])),
+      189)
       << "incorrect value for amplitude_value[163], expected 189, is "
       << last_msg_->amplitude_value[163];
-  EXPECT_EQ(last_msg_->amplitude_value[164], 86)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[164])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[164])),
+      86)
       << "incorrect value for amplitude_value[164], expected 86, is "
       << last_msg_->amplitude_value[164];
-  EXPECT_EQ(last_msg_->amplitude_value[165], 118)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[165])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[165])),
+      118)
       << "incorrect value for amplitude_value[165], expected 118, is "
       << last_msg_->amplitude_value[165];
-  EXPECT_EQ(last_msg_->amplitude_value[166], 176)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[166])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[166])),
+      176)
       << "incorrect value for amplitude_value[166], expected 176, is "
       << last_msg_->amplitude_value[166];
-  EXPECT_EQ(last_msg_->amplitude_value[167], 228)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[167])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[167])),
+      228)
       << "incorrect value for amplitude_value[167], expected 228, is "
       << last_msg_->amplitude_value[167];
-  EXPECT_EQ(last_msg_->amplitude_value[168], 12)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[168])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[168])),
+      12)
       << "incorrect value for amplitude_value[168], expected 12, is "
       << last_msg_->amplitude_value[168];
-  EXPECT_EQ(last_msg_->amplitude_value[169], 14)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[169])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[169])),
+      14)
       << "incorrect value for amplitude_value[169], expected 14, is "
       << last_msg_->amplitude_value[169];
-  EXPECT_EQ(last_msg_->amplitude_value[170], 119)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[170])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[170])),
+      119)
       << "incorrect value for amplitude_value[170], expected 119, is "
       << last_msg_->amplitude_value[170];
-  EXPECT_EQ(last_msg_->amplitude_value[171], 135)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[171])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[171])),
+      135)
       << "incorrect value for amplitude_value[171], expected 135, is "
       << last_msg_->amplitude_value[171];
-  EXPECT_EQ(last_msg_->amplitude_value[172], 129)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[172])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[172])),
+      129)
       << "incorrect value for amplitude_value[172], expected 129, is "
       << last_msg_->amplitude_value[172];
-  EXPECT_EQ(last_msg_->amplitude_value[173], 243)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[173])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[173])),
+      243)
       << "incorrect value for amplitude_value[173], expected 243, is "
       << last_msg_->amplitude_value[173];
-  EXPECT_EQ(last_msg_->amplitude_value[174], 50)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[174])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[174])),
+      50)
       << "incorrect value for amplitude_value[174], expected 50, is "
       << last_msg_->amplitude_value[174];
-  EXPECT_EQ(last_msg_->amplitude_value[175], 29)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[175])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[175])),
+      29)
       << "incorrect value for amplitude_value[175], expected 29, is "
       << last_msg_->amplitude_value[175];
-  EXPECT_EQ(last_msg_->amplitude_value[176], 207)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[176])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[176])),
+      207)
       << "incorrect value for amplitude_value[176], expected 207, is "
       << last_msg_->amplitude_value[176];
-  EXPECT_EQ(last_msg_->amplitude_value[177], 198)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[177])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[177])),
+      198)
       << "incorrect value for amplitude_value[177], expected 198, is "
       << last_msg_->amplitude_value[177];
-  EXPECT_EQ(last_msg_->amplitude_value[178], 117)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[178])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[178])),
+      117)
       << "incorrect value for amplitude_value[178], expected 117, is "
       << last_msg_->amplitude_value[178];
-  EXPECT_EQ(last_msg_->amplitude_value[179], 100)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[179])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[179])),
+      100)
       << "incorrect value for amplitude_value[179], expected 100, is "
       << last_msg_->amplitude_value[179];
-  EXPECT_EQ(last_msg_->amplitude_value[180], 225)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[180])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[180])),
+      225)
       << "incorrect value for amplitude_value[180], expected 225, is "
       << last_msg_->amplitude_value[180];
-  EXPECT_EQ(last_msg_->amplitude_value[181], 6)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[181])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[181])),
+      6)
       << "incorrect value for amplitude_value[181], expected 6, is "
       << last_msg_->amplitude_value[181];
-  EXPECT_EQ(last_msg_->amplitude_value[182], 139)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[182])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[182])),
+      139)
       << "incorrect value for amplitude_value[182], expected 139, is "
       << last_msg_->amplitude_value[182];
-  EXPECT_EQ(last_msg_->amplitude_value[183], 110)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[183])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[183])),
+      110)
       << "incorrect value for amplitude_value[183], expected 110, is "
       << last_msg_->amplitude_value[183];
-  EXPECT_EQ(last_msg_->amplitude_value[184], 39)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[184])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[184])),
+      39)
       << "incorrect value for amplitude_value[184], expected 39, is "
       << last_msg_->amplitude_value[184];
-  EXPECT_EQ(last_msg_->amplitude_value[185], 210)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[185])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[185])),
+      210)
       << "incorrect value for amplitude_value[185], expected 210, is "
       << last_msg_->amplitude_value[185];
-  EXPECT_EQ(last_msg_->amplitude_value[186], 68)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[186])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[186])),
+      68)
       << "incorrect value for amplitude_value[186], expected 68, is "
       << last_msg_->amplitude_value[186];
-  EXPECT_EQ(last_msg_->amplitude_value[187], 199)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[187])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[187])),
+      199)
       << "incorrect value for amplitude_value[187], expected 199, is "
       << last_msg_->amplitude_value[187];
-  EXPECT_EQ(last_msg_->amplitude_value[188], 43)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[188])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[188])),
+      43)
       << "incorrect value for amplitude_value[188], expected 43, is "
       << last_msg_->amplitude_value[188];
-  EXPECT_EQ(last_msg_->amplitude_value[189], 132)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[189])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[189])),
+      132)
       << "incorrect value for amplitude_value[189], expected 132, is "
       << last_msg_->amplitude_value[189];
-  EXPECT_EQ(last_msg_->amplitude_value[190], 64)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[190])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[190])),
+      64)
       << "incorrect value for amplitude_value[190], expected 64, is "
       << last_msg_->amplitude_value[190];
-  EXPECT_EQ(last_msg_->amplitude_value[191], 17)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[191])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[191])),
+      17)
       << "incorrect value for amplitude_value[191], expected 17, is "
       << last_msg_->amplitude_value[191];
-  EXPECT_EQ(last_msg_->amplitude_value[192], 51)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[192])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[192])),
+      51)
       << "incorrect value for amplitude_value[192], expected 51, is "
       << last_msg_->amplitude_value[192];
-  EXPECT_EQ(last_msg_->amplitude_value[193], 173)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[193])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[193])),
+      173)
       << "incorrect value for amplitude_value[193], expected 173, is "
       << last_msg_->amplitude_value[193];
-  EXPECT_EQ(last_msg_->amplitude_value[194], 181)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[194])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[194])),
+      181)
       << "incorrect value for amplitude_value[194], expected 181, is "
       << last_msg_->amplitude_value[194];
-  EXPECT_EQ(last_msg_->amplitude_value[195], 12)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[195])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[195])),
+      12)
       << "incorrect value for amplitude_value[195], expected 12, is "
       << last_msg_->amplitude_value[195];
-  EXPECT_EQ(last_msg_->amplitude_value[196], 140)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[196])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[196])),
+      140)
       << "incorrect value for amplitude_value[196], expected 140, is "
       << last_msg_->amplitude_value[196];
-  EXPECT_EQ(last_msg_->amplitude_value[197], 16)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[197])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[197])),
+      16)
       << "incorrect value for amplitude_value[197], expected 16, is "
       << last_msg_->amplitude_value[197];
-  EXPECT_EQ(last_msg_->amplitude_value[198], 247)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[198])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[198])),
+      247)
       << "incorrect value for amplitude_value[198], expected 247, is "
       << last_msg_->amplitude_value[198];
-  EXPECT_EQ(last_msg_->amplitude_value[199], 84)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[199])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[199])),
+      84)
       << "incorrect value for amplitude_value[199], expected 84, is "
       << last_msg_->amplitude_value[199];
-  EXPECT_EQ(last_msg_->amplitude_value[200], 183)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[200])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[200])),
+      183)
       << "incorrect value for amplitude_value[200], expected 183, is "
       << last_msg_->amplitude_value[200];
-  EXPECT_EQ(last_msg_->amplitude_value[201], 105)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[201])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[201])),
+      105)
       << "incorrect value for amplitude_value[201], expected 105, is "
       << last_msg_->amplitude_value[201];
-  EXPECT_EQ(last_msg_->amplitude_value[202], 39)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[202])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[202])),
+      39)
       << "incorrect value for amplitude_value[202], expected 39, is "
       << last_msg_->amplitude_value[202];
-  EXPECT_EQ(last_msg_->amplitude_value[203], 157)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[203])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[203])),
+      157)
       << "incorrect value for amplitude_value[203], expected 157, is "
       << last_msg_->amplitude_value[203];
-  EXPECT_EQ(last_msg_->amplitude_value[204], 77)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[204])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[204])),
+      77)
       << "incorrect value for amplitude_value[204], expected 77, is "
       << last_msg_->amplitude_value[204];
-  EXPECT_EQ(last_msg_->amplitude_value[205], 30)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[205])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[205])),
+      30)
       << "incorrect value for amplitude_value[205], expected 30, is "
       << last_msg_->amplitude_value[205];
-  EXPECT_EQ(last_msg_->amplitude_value[206], 205)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[206])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[206])),
+      205)
       << "incorrect value for amplitude_value[206], expected 205, is "
       << last_msg_->amplitude_value[206];
-  EXPECT_EQ(last_msg_->amplitude_value[207], 194)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[207])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[207])),
+      194)
       << "incorrect value for amplitude_value[207], expected 194, is "
       << last_msg_->amplitude_value[207];
-  EXPECT_EQ(last_msg_->amplitude_value[208], 59)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[208])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[208])),
+      59)
       << "incorrect value for amplitude_value[208], expected 59, is "
       << last_msg_->amplitude_value[208];
-  EXPECT_EQ(last_msg_->amplitude_value[209], 64)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[209])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[209])),
+      64)
       << "incorrect value for amplitude_value[209], expected 64, is "
       << last_msg_->amplitude_value[209];
-  EXPECT_EQ(last_msg_->amplitude_value[210], 241)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[210])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[210])),
+      241)
       << "incorrect value for amplitude_value[210], expected 241, is "
       << last_msg_->amplitude_value[210];
-  EXPECT_EQ(last_msg_->amplitude_value[211], 183)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[211])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[211])),
+      183)
       << "incorrect value for amplitude_value[211], expected 183, is "
       << last_msg_->amplitude_value[211];
-  EXPECT_EQ(last_msg_->amplitude_value[212], 238)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[212])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[212])),
+      238)
       << "incorrect value for amplitude_value[212], expected 238, is "
       << last_msg_->amplitude_value[212];
-  EXPECT_EQ(last_msg_->amplitude_value[213], 105)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[213])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[213])),
+      105)
       << "incorrect value for amplitude_value[213], expected 105, is "
       << last_msg_->amplitude_value[213];
-  EXPECT_EQ(last_msg_->amplitude_value[214], 181)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[214])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[214])),
+      181)
       << "incorrect value for amplitude_value[214], expected 181, is "
       << last_msg_->amplitude_value[214];
-  EXPECT_EQ(last_msg_->amplitude_value[215], 170)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[215])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[215])),
+      170)
       << "incorrect value for amplitude_value[215], expected 170, is "
       << last_msg_->amplitude_value[215];
-  EXPECT_EQ(last_msg_->amplitude_value[216], 45)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[216])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[216])),
+      45)
       << "incorrect value for amplitude_value[216], expected 45, is "
       << last_msg_->amplitude_value[216];
-  EXPECT_EQ(last_msg_->amplitude_value[217], 8)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[217])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[217])),
+      8)
       << "incorrect value for amplitude_value[217], expected 8, is "
       << last_msg_->amplitude_value[217];
-  EXPECT_EQ(last_msg_->amplitude_value[218], 166)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[218])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[218])),
+      166)
       << "incorrect value for amplitude_value[218], expected 166, is "
       << last_msg_->amplitude_value[218];
-  EXPECT_EQ(last_msg_->amplitude_value[219], 164)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[219])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[219])),
+      164)
       << "incorrect value for amplitude_value[219], expected 164, is "
       << last_msg_->amplitude_value[219];
-  EXPECT_EQ(last_msg_->amplitude_value[220], 238)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[220])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[220])),
+      238)
       << "incorrect value for amplitude_value[220], expected 238, is "
       << last_msg_->amplitude_value[220];
-  EXPECT_EQ(last_msg_->amplitude_value[221], 83)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[221])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[221])),
+      83)
       << "incorrect value for amplitude_value[221], expected 83, is "
       << last_msg_->amplitude_value[221];
-  EXPECT_EQ(last_msg_->amplitude_value[222], 148)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[222])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[222])),
+      148)
       << "incorrect value for amplitude_value[222], expected 148, is "
       << last_msg_->amplitude_value[222];
-  EXPECT_EQ(last_msg_->amplitude_value[223], 173)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[223])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[223])),
+      173)
       << "incorrect value for amplitude_value[223], expected 173, is "
       << last_msg_->amplitude_value[223];
-  EXPECT_EQ(last_msg_->amplitude_value[224], 108)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[224])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[224])),
+      108)
       << "incorrect value for amplitude_value[224], expected 108, is "
       << last_msg_->amplitude_value[224];
-  EXPECT_EQ(last_msg_->amplitude_value[225], 228)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[225])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[225])),
+      228)
       << "incorrect value for amplitude_value[225], expected 228, is "
       << last_msg_->amplitude_value[225];
-  EXPECT_EQ(last_msg_->amplitude_value[226], 67)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[226])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[226])),
+      67)
       << "incorrect value for amplitude_value[226], expected 67, is "
       << last_msg_->amplitude_value[226];
-  EXPECT_EQ(last_msg_->amplitude_value[227], 89)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[227])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[227])),
+      89)
       << "incorrect value for amplitude_value[227], expected 89, is "
       << last_msg_->amplitude_value[227];
-  EXPECT_EQ(last_msg_->amplitude_value[228], 189)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[228])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[228])),
+      189)
       << "incorrect value for amplitude_value[228], expected 189, is "
       << last_msg_->amplitude_value[228];
-  EXPECT_EQ(last_msg_->amplitude_value[229], 67)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[229])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[229])),
+      67)
       << "incorrect value for amplitude_value[229], expected 67, is "
       << last_msg_->amplitude_value[229];
-  EXPECT_EQ(last_msg_->amplitude_value[230], 26)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->amplitude_value[230])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->amplitude_value[230])),
+      26)
       << "incorrect value for amplitude_value[230], expected 26, is "
       << last_msg_->amplitude_value[230];
-  EXPECT_EQ(last_msg_->channel_tag, 5878)
+  EXPECT_EQ(get_as<decltype(last_msg_->channel_tag)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->channel_tag)),
+            5878)
       << "incorrect value for channel_tag, expected 5878, is "
       << last_msg_->channel_tag;
   EXPECT_LT((last_msg_->freq_ref * 100 - 6348.20019531 * 100), 0.05)
@@ -2227,9 +2929,13 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgSpecanDep0, Test) {
   EXPECT_LT((last_msg_->freq_step * 100 - 4608.20019531 * 100), 0.05)
       << "incorrect value for freq_step, expected 4608.20019531, is "
       << last_msg_->freq_step;
-  EXPECT_EQ(last_msg_->t.tow, 992295133)
+  EXPECT_EQ(get_as<decltype(last_msg_->t.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->t.tow)),
+            992295133)
       << "incorrect value for t.tow, expected 992295133, is "
       << last_msg_->t.tow;
-  EXPECT_EQ(last_msg_->t.wn, 6957)
+  EXPECT_EQ(get_as<decltype(last_msg_->t.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->t.wn)),
+            6957)
       << "incorrect value for t.wn, expected 6957, is " << last_msg_->t.wn;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_piksi_MsgThreadState.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_piksi_MsgThreadState.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/piksi.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_piksi_MsgThreadState0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -122,7 +129,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgThreadState0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->cpu, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->cpu)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cpu)),
+            0)
       << "incorrect value for cpu, expected 0, is " << last_msg_->cpu;
   {
     const char check_string[] = {
@@ -133,7 +142,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgThreadState0, Test) {
         << "incorrect value for last_msg_->name, expected string '"
         << check_string << "', is '" << last_msg_->name << "'";
   }
-  EXPECT_EQ(last_msg_->stack_free, 2460)
+  EXPECT_EQ(get_as<decltype(last_msg_->stack_free)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->stack_free)),
+            2460)
       << "incorrect value for stack_free, expected 2460, is "
       << last_msg_->stack_free;
 }
@@ -230,7 +241,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgThreadState1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->cpu, 595)
+  EXPECT_EQ(get_as<decltype(last_msg_->cpu)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cpu)),
+            595)
       << "incorrect value for cpu, expected 595, is " << last_msg_->cpu;
   {
     const char check_string[] = {
@@ -241,7 +254,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgThreadState1, Test) {
         << "incorrect value for last_msg_->name, expected string '"
         << check_string << "', is '" << last_msg_->name << "'";
   }
-  EXPECT_EQ(last_msg_->stack_free, 36)
+  EXPECT_EQ(get_as<decltype(last_msg_->stack_free)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->stack_free)),
+            36)
       << "incorrect value for stack_free, expected 36, is "
       << last_msg_->stack_free;
 }
@@ -338,7 +353,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgThreadState2, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->cpu, 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->cpu)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cpu)),
+            14)
       << "incorrect value for cpu, expected 14, is " << last_msg_->cpu;
   {
     const char check_string[] = {
@@ -349,7 +366,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgThreadState2, Test) {
         << "incorrect value for last_msg_->name, expected string '"
         << check_string << "', is '" << last_msg_->name << "'";
   }
-  EXPECT_EQ(last_msg_->stack_free, 1140)
+  EXPECT_EQ(get_as<decltype(last_msg_->stack_free)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->stack_free)),
+            1140)
       << "incorrect value for stack_free, expected 1140, is "
       << last_msg_->stack_free;
 }
@@ -446,7 +465,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgThreadState3, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->cpu, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->cpu)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cpu)),
+            1)
       << "incorrect value for cpu, expected 1, is " << last_msg_->cpu;
   {
     const char check_string[] = {
@@ -457,7 +478,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgThreadState3, Test) {
         << "incorrect value for last_msg_->name, expected string '"
         << check_string << "', is '" << last_msg_->name << "'";
   }
-  EXPECT_EQ(last_msg_->stack_free, 5060)
+  EXPECT_EQ(get_as<decltype(last_msg_->stack_free)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->stack_free)),
+            5060)
       << "incorrect value for stack_free, expected 5060, is "
       << last_msg_->stack_free;
 }
@@ -555,7 +578,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgThreadState4, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->cpu, 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->cpu)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cpu)),
+            7)
       << "incorrect value for cpu, expected 7, is " << last_msg_->cpu;
   {
     const char check_string[] = {(char)109, (char)97,  (char)110, (char)97,
@@ -567,7 +592,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgThreadState4, Test) {
         << "incorrect value for last_msg_->name, expected string '"
         << check_string << "', is '" << last_msg_->name << "'";
   }
-  EXPECT_EQ(last_msg_->stack_free, 2324)
+  EXPECT_EQ(get_as<decltype(last_msg_->stack_free)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->stack_free)),
+            2324)
       << "incorrect value for stack_free, expected 2324, is "
       << last_msg_->stack_free;
 }
@@ -664,7 +691,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgThreadState5, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->cpu, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->cpu)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cpu)),
+            0)
       << "incorrect value for cpu, expected 0, is " << last_msg_->cpu;
   {
     const char check_string[] = {
@@ -675,7 +704,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgThreadState5, Test) {
         << "incorrect value for last_msg_->name, expected string '"
         << check_string << "', is '" << last_msg_->name << "'";
   }
-  EXPECT_EQ(last_msg_->stack_free, 2452)
+  EXPECT_EQ(get_as<decltype(last_msg_->stack_free)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->stack_free)),
+            2452)
       << "incorrect value for stack_free, expected 2452, is "
       << last_msg_->stack_free;
 }
@@ -772,7 +803,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgThreadState6, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->cpu, 484)
+  EXPECT_EQ(get_as<decltype(last_msg_->cpu)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cpu)),
+            484)
       << "incorrect value for cpu, expected 484, is " << last_msg_->cpu;
   {
     const char check_string[] = {
@@ -783,7 +816,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgThreadState6, Test) {
         << "incorrect value for last_msg_->name, expected string '"
         << check_string << "', is '" << last_msg_->name << "'";
   }
-  EXPECT_EQ(last_msg_->stack_free, 36)
+  EXPECT_EQ(get_as<decltype(last_msg_->stack_free)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->stack_free)),
+            36)
       << "incorrect value for stack_free, expected 36, is "
       << last_msg_->stack_free;
 }
@@ -880,7 +915,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgThreadState7, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->cpu, 394)
+  EXPECT_EQ(get_as<decltype(last_msg_->cpu)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cpu)),
+            394)
       << "incorrect value for cpu, expected 394, is " << last_msg_->cpu;
   {
     const char check_string[] = {
@@ -891,7 +928,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgThreadState7, Test) {
         << "incorrect value for last_msg_->name, expected string '"
         << check_string << "', is '" << last_msg_->name << "'";
   }
-  EXPECT_EQ(last_msg_->stack_free, 1884)
+  EXPECT_EQ(get_as<decltype(last_msg_->stack_free)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->stack_free)),
+            1884)
       << "incorrect value for stack_free, expected 1884, is "
       << last_msg_->stack_free;
 }
@@ -988,7 +1027,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgThreadState8, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->cpu, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->cpu)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cpu)),
+            1)
       << "incorrect value for cpu, expected 1, is " << last_msg_->cpu;
   {
     const char check_string[] = {
@@ -999,7 +1040,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgThreadState8, Test) {
         << "incorrect value for last_msg_->name, expected string '"
         << check_string << "', is '" << last_msg_->name << "'";
   }
-  EXPECT_EQ(last_msg_->stack_free, 3076)
+  EXPECT_EQ(get_as<decltype(last_msg_->stack_free)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->stack_free)),
+            3076)
       << "incorrect value for stack_free, expected 3076, is "
       << last_msg_->stack_free;
 }
@@ -1097,7 +1140,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgThreadState9, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->cpu, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->cpu)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cpu)),
+            10)
       << "incorrect value for cpu, expected 10, is " << last_msg_->cpu;
   {
     const char check_string[] = {(char)109, (char)97,  (char)110, (char)97,
@@ -1109,7 +1154,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgThreadState9, Test) {
         << "incorrect value for last_msg_->name, expected string '"
         << check_string << "', is '" << last_msg_->name << "'";
   }
-  EXPECT_EQ(last_msg_->stack_free, 2428)
+  EXPECT_EQ(get_as<decltype(last_msg_->stack_free)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->stack_free)),
+            2428)
       << "incorrect value for stack_free, expected 2428, is "
       << last_msg_->stack_free;
 }
@@ -1207,7 +1254,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgThreadState10, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->cpu, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->cpu)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cpu)),
+            0)
       << "incorrect value for cpu, expected 0, is " << last_msg_->cpu;
   {
     const char check_string[] = {(char)109, (char)97,  (char)110, (char)97,
@@ -1219,7 +1268,9 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgThreadState10, Test) {
         << "incorrect value for last_msg_->name, expected string '"
         << check_string << "', is '" << last_msg_->name << "'";
   }
-  EXPECT_EQ(last_msg_->stack_free, 2332)
+  EXPECT_EQ(get_as<decltype(last_msg_->stack_free)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->stack_free)),
+            2332)
       << "incorrect value for stack_free, expected 2332, is "
       << last_msg_->stack_free;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_piksi_MsgUartState.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_piksi_MsgUartState.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/piksi.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_piksi_MsgUartState0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -140,73 +147,123 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgUartState0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 57544);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->latency.avg, 319865629)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.avg)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.avg)),
+            319865629)
       << "incorrect value for latency.avg, expected 319865629, is "
       << last_msg_->latency.avg;
-  EXPECT_EQ(last_msg_->latency.current, 364253831)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.current)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.current)),
+            364253831)
       << "incorrect value for latency.current, expected 364253831, is "
       << last_msg_->latency.current;
-  EXPECT_EQ(last_msg_->latency.lmax, -611749622)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.lmax)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.lmax)),
+            -611749622)
       << "incorrect value for latency.lmax, expected -611749622, is "
       << last_msg_->latency.lmax;
-  EXPECT_EQ(last_msg_->latency.lmin, 289902239)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.lmin)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.lmin)),
+            289902239)
       << "incorrect value for latency.lmin, expected 289902239, is "
       << last_msg_->latency.lmin;
-  EXPECT_EQ(last_msg_->obs_period.avg, -1002717658)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs_period.avg)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs_period.avg)),
+            -1002717658)
       << "incorrect value for obs_period.avg, expected -1002717658, is "
       << last_msg_->obs_period.avg;
-  EXPECT_EQ(last_msg_->obs_period.current, -2080697488)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->obs_period.current)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->obs_period.current)),
+      -2080697488)
       << "incorrect value for obs_period.current, expected -2080697488, is "
       << last_msg_->obs_period.current;
-  EXPECT_EQ(last_msg_->obs_period.pmax, -1628133123)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs_period.pmax)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs_period.pmax)),
+            -1628133123)
       << "incorrect value for obs_period.pmax, expected -1628133123, is "
       << last_msg_->obs_period.pmax;
-  EXPECT_EQ(last_msg_->obs_period.pmin, 1869323177)
+  EXPECT_EQ(get_as<decltype(last_msg_->obs_period.pmin)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->obs_period.pmin)),
+            1869323177)
       << "incorrect value for obs_period.pmin, expected 1869323177, is "
       << last_msg_->obs_period.pmin;
-  EXPECT_EQ(last_msg_->uart_a.crc_error_count, 25177)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_a.crc_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_a.crc_error_count)),
+            25177)
       << "incorrect value for uart_a.crc_error_count, expected 25177, is "
       << last_msg_->uart_a.crc_error_count;
-  EXPECT_EQ(last_msg_->uart_a.io_error_count, 47183)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->uart_a.io_error_count)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->uart_a.io_error_count)),
+      47183)
       << "incorrect value for uart_a.io_error_count, expected 47183, is "
       << last_msg_->uart_a.io_error_count;
-  EXPECT_EQ(last_msg_->uart_a.rx_buffer_level, 244)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_a.rx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_a.rx_buffer_level)),
+            244)
       << "incorrect value for uart_a.rx_buffer_level, expected 244, is "
       << last_msg_->uart_a.rx_buffer_level;
   EXPECT_LT((last_msg_->uart_a.rx_throughput * 100 - 1853.19995117 * 100), 0.05)
       << "incorrect value for uart_a.rx_throughput, expected 1853.19995117, is "
       << last_msg_->uart_a.rx_throughput;
-  EXPECT_EQ(last_msg_->uart_a.tx_buffer_level, 138)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_a.tx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_a.tx_buffer_level)),
+            138)
       << "incorrect value for uart_a.tx_buffer_level, expected 138, is "
       << last_msg_->uart_a.tx_buffer_level;
   EXPECT_LT((last_msg_->uart_a.tx_throughput * 100 - 7765.20019531 * 100), 0.05)
       << "incorrect value for uart_a.tx_throughput, expected 7765.20019531, is "
       << last_msg_->uart_a.tx_throughput;
-  EXPECT_EQ(last_msg_->uart_b.crc_error_count, 4297)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_b.crc_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_b.crc_error_count)),
+            4297)
       << "incorrect value for uart_b.crc_error_count, expected 4297, is "
       << last_msg_->uart_b.crc_error_count;
-  EXPECT_EQ(last_msg_->uart_b.io_error_count, 63847)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->uart_b.io_error_count)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->uart_b.io_error_count)),
+      63847)
       << "incorrect value for uart_b.io_error_count, expected 63847, is "
       << last_msg_->uart_b.io_error_count;
-  EXPECT_EQ(last_msg_->uart_b.rx_buffer_level, 161)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_b.rx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_b.rx_buffer_level)),
+            161)
       << "incorrect value for uart_b.rx_buffer_level, expected 161, is "
       << last_msg_->uart_b.rx_buffer_level;
   EXPECT_LT((last_msg_->uart_b.rx_throughput * 100 - 6760.20019531 * 100), 0.05)
       << "incorrect value for uart_b.rx_throughput, expected 6760.20019531, is "
       << last_msg_->uart_b.rx_throughput;
-  EXPECT_EQ(last_msg_->uart_b.tx_buffer_level, 143)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_b.tx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_b.tx_buffer_level)),
+            143)
       << "incorrect value for uart_b.tx_buffer_level, expected 143, is "
       << last_msg_->uart_b.tx_buffer_level;
   EXPECT_LT((last_msg_->uart_b.tx_throughput * 100 - 6441.20019531 * 100), 0.05)
       << "incorrect value for uart_b.tx_throughput, expected 6441.20019531, is "
       << last_msg_->uart_b.tx_throughput;
-  EXPECT_EQ(last_msg_->uart_ftdi.crc_error_count, 38359)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.crc_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.crc_error_count)),
+            38359)
       << "incorrect value for uart_ftdi.crc_error_count, expected 38359, is "
       << last_msg_->uart_ftdi.crc_error_count;
-  EXPECT_EQ(last_msg_->uart_ftdi.io_error_count, 6653)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.io_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.io_error_count)),
+            6653)
       << "incorrect value for uart_ftdi.io_error_count, expected 6653, is "
       << last_msg_->uart_ftdi.io_error_count;
-  EXPECT_EQ(last_msg_->uart_ftdi.rx_buffer_level, 24)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.rx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.rx_buffer_level)),
+            24)
       << "incorrect value for uart_ftdi.rx_buffer_level, expected 24, is "
       << last_msg_->uart_ftdi.rx_buffer_level;
   EXPECT_LT((last_msg_->uart_ftdi.rx_throughput * 100 - 2173.19995117 * 100),
@@ -214,7 +271,10 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgUartState0, Test) {
       << "incorrect value for uart_ftdi.rx_throughput, expected 2173.19995117, "
          "is "
       << last_msg_->uart_ftdi.rx_throughput;
-  EXPECT_EQ(last_msg_->uart_ftdi.tx_buffer_level, 218)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.tx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.tx_buffer_level)),
+            218)
       << "incorrect value for uart_ftdi.tx_buffer_level, expected 218, is "
       << last_msg_->uart_ftdi.tx_buffer_level;
   EXPECT_LT((last_msg_->uart_ftdi.tx_throughput * 100 - 5954.20019531 * 100),
@@ -329,31 +389,51 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgUartState1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->latency.avg, -1)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.avg)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.avg)),
+            -1)
       << "incorrect value for latency.avg, expected -1, is "
       << last_msg_->latency.avg;
-  EXPECT_EQ(last_msg_->latency.current, -1)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.current)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.current)),
+            -1)
       << "incorrect value for latency.current, expected -1, is "
       << last_msg_->latency.current;
-  EXPECT_EQ(last_msg_->latency.lmax, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.lmax)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.lmax)),
+            0)
       << "incorrect value for latency.lmax, expected 0, is "
       << last_msg_->latency.lmax;
-  EXPECT_EQ(last_msg_->latency.lmin, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.lmin)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.lmin)),
+            0)
       << "incorrect value for latency.lmin, expected 0, is "
       << last_msg_->latency.lmin;
-  EXPECT_EQ(last_msg_->uart_a.crc_error_count, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_a.crc_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_a.crc_error_count)),
+            0)
       << "incorrect value for uart_a.crc_error_count, expected 0, is "
       << last_msg_->uart_a.crc_error_count;
-  EXPECT_EQ(last_msg_->uart_a.io_error_count, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->uart_a.io_error_count)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->uart_a.io_error_count)),
+      0)
       << "incorrect value for uart_a.io_error_count, expected 0, is "
       << last_msg_->uart_a.io_error_count;
-  EXPECT_EQ(last_msg_->uart_a.rx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_a.rx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_a.rx_buffer_level)),
+            0)
       << "incorrect value for uart_a.rx_buffer_level, expected 0, is "
       << last_msg_->uart_a.rx_buffer_level;
   EXPECT_LT((last_msg_->uart_a.rx_throughput * 100 - 0.0 * 100), 0.05)
       << "incorrect value for uart_a.rx_throughput, expected 0.0, is "
       << last_msg_->uart_a.rx_throughput;
-  EXPECT_EQ(last_msg_->uart_a.tx_buffer_level, 24)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_a.tx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_a.tx_buffer_level)),
+            24)
       << "incorrect value for uart_a.tx_buffer_level, expected 24, is "
       << last_msg_->uart_a.tx_buffer_level;
   EXPECT_LT((last_msg_->uart_a.tx_throughput * 100 - 0.866197228432 * 100),
@@ -361,31 +441,52 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgUartState1, Test) {
       << "incorrect value for uart_a.tx_throughput, expected 0.866197228432, "
          "is "
       << last_msg_->uart_a.tx_throughput;
-  EXPECT_EQ(last_msg_->uart_b.crc_error_count, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_b.crc_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_b.crc_error_count)),
+            0)
       << "incorrect value for uart_b.crc_error_count, expected 0, is "
       << last_msg_->uart_b.crc_error_count;
-  EXPECT_EQ(last_msg_->uart_b.io_error_count, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->uart_b.io_error_count)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->uart_b.io_error_count)),
+      0)
       << "incorrect value for uart_b.io_error_count, expected 0, is "
       << last_msg_->uart_b.io_error_count;
-  EXPECT_EQ(last_msg_->uart_b.rx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_b.rx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_b.rx_buffer_level)),
+            0)
       << "incorrect value for uart_b.rx_buffer_level, expected 0, is "
       << last_msg_->uart_b.rx_buffer_level;
   EXPECT_LT((last_msg_->uart_b.rx_throughput * 100 - 0.0 * 100), 0.05)
       << "incorrect value for uart_b.rx_throughput, expected 0.0, is "
       << last_msg_->uart_b.rx_throughput;
-  EXPECT_EQ(last_msg_->uart_b.tx_buffer_level, 40)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_b.tx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_b.tx_buffer_level)),
+            40)
       << "incorrect value for uart_b.tx_buffer_level, expected 40, is "
       << last_msg_->uart_b.tx_buffer_level;
   EXPECT_LT((last_msg_->uart_b.tx_throughput * 100 - 2.9718310833 * 100), 0.05)
       << "incorrect value for uart_b.tx_throughput, expected 2.9718310833, is "
       << last_msg_->uart_b.tx_throughput;
-  EXPECT_EQ(last_msg_->uart_ftdi.crc_error_count, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.crc_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.crc_error_count)),
+            0)
       << "incorrect value for uart_ftdi.crc_error_count, expected 0, is "
       << last_msg_->uart_ftdi.crc_error_count;
-  EXPECT_EQ(last_msg_->uart_ftdi.io_error_count, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.io_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.io_error_count)),
+            0)
       << "incorrect value for uart_ftdi.io_error_count, expected 0, is "
       << last_msg_->uart_ftdi.io_error_count;
-  EXPECT_EQ(last_msg_->uart_ftdi.rx_buffer_level, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.rx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.rx_buffer_level)),
+            1)
       << "incorrect value for uart_ftdi.rx_buffer_level, expected 1, is "
       << last_msg_->uart_ftdi.rx_buffer_level;
   EXPECT_LT((last_msg_->uart_ftdi.rx_throughput * 100 - 0.0352112688124 * 100),
@@ -393,7 +494,10 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgUartState1, Test) {
       << "incorrect value for uart_ftdi.rx_throughput, expected "
          "0.0352112688124, is "
       << last_msg_->uart_ftdi.rx_throughput;
-  EXPECT_EQ(last_msg_->uart_ftdi.tx_buffer_level, 81)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.tx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.tx_buffer_level)),
+            81)
       << "incorrect value for uart_ftdi.tx_buffer_level, expected 81, is "
       << last_msg_->uart_ftdi.tx_buffer_level;
   EXPECT_LT((last_msg_->uart_ftdi.tx_throughput * 100 - 5.06338024139 * 100),
@@ -508,31 +612,51 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgUartState2, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->latency.avg, -1)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.avg)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.avg)),
+            -1)
       << "incorrect value for latency.avg, expected -1, is "
       << last_msg_->latency.avg;
-  EXPECT_EQ(last_msg_->latency.current, -1)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.current)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.current)),
+            -1)
       << "incorrect value for latency.current, expected -1, is "
       << last_msg_->latency.current;
-  EXPECT_EQ(last_msg_->latency.lmax, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.lmax)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.lmax)),
+            0)
       << "incorrect value for latency.lmax, expected 0, is "
       << last_msg_->latency.lmax;
-  EXPECT_EQ(last_msg_->latency.lmin, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.lmin)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.lmin)),
+            0)
       << "incorrect value for latency.lmin, expected 0, is "
       << last_msg_->latency.lmin;
-  EXPECT_EQ(last_msg_->uart_a.crc_error_count, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_a.crc_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_a.crc_error_count)),
+            0)
       << "incorrect value for uart_a.crc_error_count, expected 0, is "
       << last_msg_->uart_a.crc_error_count;
-  EXPECT_EQ(last_msg_->uart_a.io_error_count, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->uart_a.io_error_count)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->uart_a.io_error_count)),
+      0)
       << "incorrect value for uart_a.io_error_count, expected 0, is "
       << last_msg_->uart_a.io_error_count;
-  EXPECT_EQ(last_msg_->uart_a.rx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_a.rx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_a.rx_buffer_level)),
+            0)
       << "incorrect value for uart_a.rx_buffer_level, expected 0, is "
       << last_msg_->uart_a.rx_buffer_level;
   EXPECT_LT((last_msg_->uart_a.rx_throughput * 100 - 0.0 * 100), 0.05)
       << "incorrect value for uart_a.rx_throughput, expected 0.0, is "
       << last_msg_->uart_a.rx_throughput;
-  EXPECT_EQ(last_msg_->uart_a.tx_buffer_level, 24)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_a.tx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_a.tx_buffer_level)),
+            24)
       << "incorrect value for uart_a.tx_buffer_level, expected 24, is "
       << last_msg_->uart_a.tx_buffer_level;
   EXPECT_LT((last_msg_->uart_a.tx_throughput * 100 - 0.874647915363 * 100),
@@ -540,31 +664,52 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgUartState2, Test) {
       << "incorrect value for uart_a.tx_throughput, expected 0.874647915363, "
          "is "
       << last_msg_->uart_a.tx_throughput;
-  EXPECT_EQ(last_msg_->uart_b.crc_error_count, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_b.crc_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_b.crc_error_count)),
+            0)
       << "incorrect value for uart_b.crc_error_count, expected 0, is "
       << last_msg_->uart_b.crc_error_count;
-  EXPECT_EQ(last_msg_->uart_b.io_error_count, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->uart_b.io_error_count)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->uart_b.io_error_count)),
+      0)
       << "incorrect value for uart_b.io_error_count, expected 0, is "
       << last_msg_->uart_b.io_error_count;
-  EXPECT_EQ(last_msg_->uart_b.rx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_b.rx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_b.rx_buffer_level)),
+            0)
       << "incorrect value for uart_b.rx_buffer_level, expected 0, is "
       << last_msg_->uart_b.rx_buffer_level;
   EXPECT_LT((last_msg_->uart_b.rx_throughput * 100 - 0.0 * 100), 0.05)
       << "incorrect value for uart_b.rx_throughput, expected 0.0, is "
       << last_msg_->uart_b.rx_throughput;
-  EXPECT_EQ(last_msg_->uart_b.tx_buffer_level, 40)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_b.tx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_b.tx_buffer_level)),
+            40)
       << "incorrect value for uart_b.tx_buffer_level, expected 40, is "
       << last_msg_->uart_b.tx_buffer_level;
   EXPECT_LT((last_msg_->uart_b.tx_throughput * 100 - 2.99577474594 * 100), 0.05)
       << "incorrect value for uart_b.tx_throughput, expected 2.99577474594, is "
       << last_msg_->uart_b.tx_throughput;
-  EXPECT_EQ(last_msg_->uart_ftdi.crc_error_count, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.crc_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.crc_error_count)),
+            0)
       << "incorrect value for uart_ftdi.crc_error_count, expected 0, is "
       << last_msg_->uart_ftdi.crc_error_count;
-  EXPECT_EQ(last_msg_->uart_ftdi.io_error_count, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.io_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.io_error_count)),
+            0)
       << "incorrect value for uart_ftdi.io_error_count, expected 0, is "
       << last_msg_->uart_ftdi.io_error_count;
-  EXPECT_EQ(last_msg_->uart_ftdi.rx_buffer_level, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.rx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.rx_buffer_level)),
+            1)
       << "incorrect value for uart_ftdi.rx_buffer_level, expected 1, is "
       << last_msg_->uart_ftdi.rx_buffer_level;
   EXPECT_LT((last_msg_->uart_ftdi.rx_throughput * 100 - 0.352112680674 * 100),
@@ -572,7 +717,10 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgUartState2, Test) {
       << "incorrect value for uart_ftdi.rx_throughput, expected "
          "0.352112680674, is "
       << last_msg_->uart_ftdi.rx_throughput;
-  EXPECT_EQ(last_msg_->uart_ftdi.tx_buffer_level, 85)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.tx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.tx_buffer_level)),
+            85)
       << "incorrect value for uart_ftdi.tx_buffer_level, expected 85, is "
       << last_msg_->uart_ftdi.tx_buffer_level;
   EXPECT_LT((last_msg_->uart_ftdi.tx_throughput * 100 - 6.79014110565 * 100),

--- a/c/test/legacy/cpp/auto_check_sbp_piksi_MsgUartStateDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_piksi_MsgUartStateDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/piksi.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_piksi_MsgUartStateDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -134,67 +141,111 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgUartStateDepA0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->latency.avg, -1)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.avg)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.avg)),
+            -1)
       << "incorrect value for latency.avg, expected -1, is "
       << last_msg_->latency.avg;
-  EXPECT_EQ(last_msg_->latency.current, -1)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.current)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.current)),
+            -1)
       << "incorrect value for latency.current, expected -1, is "
       << last_msg_->latency.current;
-  EXPECT_EQ(last_msg_->latency.lmax, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.lmax)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.lmax)),
+            0)
       << "incorrect value for latency.lmax, expected 0, is "
       << last_msg_->latency.lmax;
-  EXPECT_EQ(last_msg_->latency.lmin, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.lmin)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.lmin)),
+            0)
       << "incorrect value for latency.lmin, expected 0, is "
       << last_msg_->latency.lmin;
-  EXPECT_EQ(last_msg_->uart_a.crc_error_count, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_a.crc_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_a.crc_error_count)),
+            0)
       << "incorrect value for uart_a.crc_error_count, expected 0, is "
       << last_msg_->uart_a.crc_error_count;
-  EXPECT_EQ(last_msg_->uart_a.io_error_count, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->uart_a.io_error_count)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->uart_a.io_error_count)),
+      0)
       << "incorrect value for uart_a.io_error_count, expected 0, is "
       << last_msg_->uart_a.io_error_count;
-  EXPECT_EQ(last_msg_->uart_a.rx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_a.rx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_a.rx_buffer_level)),
+            0)
       << "incorrect value for uart_a.rx_buffer_level, expected 0, is "
       << last_msg_->uart_a.rx_buffer_level;
   EXPECT_LT((last_msg_->uart_a.rx_throughput * 100 - 0.0 * 100), 0.05)
       << "incorrect value for uart_a.rx_throughput, expected 0.0, is "
       << last_msg_->uart_a.rx_throughput;
-  EXPECT_EQ(last_msg_->uart_a.tx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_a.tx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_a.tx_buffer_level)),
+            0)
       << "incorrect value for uart_a.tx_buffer_level, expected 0, is "
       << last_msg_->uart_a.tx_buffer_level;
   EXPECT_LT((last_msg_->uart_a.tx_throughput * 100 - 0.0 * 100), 0.05)
       << "incorrect value for uart_a.tx_throughput, expected 0.0, is "
       << last_msg_->uart_a.tx_throughput;
-  EXPECT_EQ(last_msg_->uart_b.crc_error_count, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_b.crc_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_b.crc_error_count)),
+            0)
       << "incorrect value for uart_b.crc_error_count, expected 0, is "
       << last_msg_->uart_b.crc_error_count;
-  EXPECT_EQ(last_msg_->uart_b.io_error_count, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->uart_b.io_error_count)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->uart_b.io_error_count)),
+      0)
       << "incorrect value for uart_b.io_error_count, expected 0, is "
       << last_msg_->uart_b.io_error_count;
-  EXPECT_EQ(last_msg_->uart_b.rx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_b.rx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_b.rx_buffer_level)),
+            0)
       << "incorrect value for uart_b.rx_buffer_level, expected 0, is "
       << last_msg_->uart_b.rx_buffer_level;
   EXPECT_LT((last_msg_->uart_b.rx_throughput * 100 - 0.0 * 100), 0.05)
       << "incorrect value for uart_b.rx_throughput, expected 0.0, is "
       << last_msg_->uart_b.rx_throughput;
-  EXPECT_EQ(last_msg_->uart_b.tx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_b.tx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_b.tx_buffer_level)),
+            0)
       << "incorrect value for uart_b.tx_buffer_level, expected 0, is "
       << last_msg_->uart_b.tx_buffer_level;
   EXPECT_LT((last_msg_->uart_b.tx_throughput * 100 - 0.0 * 100), 0.05)
       << "incorrect value for uart_b.tx_throughput, expected 0.0, is "
       << last_msg_->uart_b.tx_throughput;
-  EXPECT_EQ(last_msg_->uart_ftdi.crc_error_count, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.crc_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.crc_error_count)),
+            0)
       << "incorrect value for uart_ftdi.crc_error_count, expected 0, is "
       << last_msg_->uart_ftdi.crc_error_count;
-  EXPECT_EQ(last_msg_->uart_ftdi.io_error_count, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.io_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.io_error_count)),
+            0)
       << "incorrect value for uart_ftdi.io_error_count, expected 0, is "
       << last_msg_->uart_ftdi.io_error_count;
-  EXPECT_EQ(last_msg_->uart_ftdi.rx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.rx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.rx_buffer_level)),
+            0)
       << "incorrect value for uart_ftdi.rx_buffer_level, expected 0, is "
       << last_msg_->uart_ftdi.rx_buffer_level;
   EXPECT_LT((last_msg_->uart_ftdi.rx_throughput * 100 - 0.0 * 100), 0.05)
       << "incorrect value for uart_ftdi.rx_throughput, expected 0.0, is "
       << last_msg_->uart_ftdi.rx_throughput;
-  EXPECT_EQ(last_msg_->uart_ftdi.tx_buffer_level, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.tx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.tx_buffer_level)),
+            15)
       << "incorrect value for uart_ftdi.tx_buffer_level, expected 15, is "
       << last_msg_->uart_ftdi.tx_buffer_level;
   EXPECT_LT((last_msg_->uart_ftdi.tx_throughput * 100 - 11.6000003815 * 100),
@@ -308,67 +359,111 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgUartStateDepA1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->latency.avg, -1)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.avg)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.avg)),
+            -1)
       << "incorrect value for latency.avg, expected -1, is "
       << last_msg_->latency.avg;
-  EXPECT_EQ(last_msg_->latency.current, -1)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.current)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.current)),
+            -1)
       << "incorrect value for latency.current, expected -1, is "
       << last_msg_->latency.current;
-  EXPECT_EQ(last_msg_->latency.lmax, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.lmax)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.lmax)),
+            0)
       << "incorrect value for latency.lmax, expected 0, is "
       << last_msg_->latency.lmax;
-  EXPECT_EQ(last_msg_->latency.lmin, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.lmin)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.lmin)),
+            0)
       << "incorrect value for latency.lmin, expected 0, is "
       << last_msg_->latency.lmin;
-  EXPECT_EQ(last_msg_->uart_a.crc_error_count, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_a.crc_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_a.crc_error_count)),
+            0)
       << "incorrect value for uart_a.crc_error_count, expected 0, is "
       << last_msg_->uart_a.crc_error_count;
-  EXPECT_EQ(last_msg_->uart_a.io_error_count, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->uart_a.io_error_count)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->uart_a.io_error_count)),
+      0)
       << "incorrect value for uart_a.io_error_count, expected 0, is "
       << last_msg_->uart_a.io_error_count;
-  EXPECT_EQ(last_msg_->uart_a.rx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_a.rx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_a.rx_buffer_level)),
+            0)
       << "incorrect value for uart_a.rx_buffer_level, expected 0, is "
       << last_msg_->uart_a.rx_buffer_level;
   EXPECT_LT((last_msg_->uart_a.rx_throughput * 100 - 0.0 * 100), 0.05)
       << "incorrect value for uart_a.rx_throughput, expected 0.0, is "
       << last_msg_->uart_a.rx_throughput;
-  EXPECT_EQ(last_msg_->uart_a.tx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_a.tx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_a.tx_buffer_level)),
+            0)
       << "incorrect value for uart_a.tx_buffer_level, expected 0, is "
       << last_msg_->uart_a.tx_buffer_level;
   EXPECT_LT((last_msg_->uart_a.tx_throughput * 100 - 0.0 * 100), 0.05)
       << "incorrect value for uart_a.tx_throughput, expected 0.0, is "
       << last_msg_->uart_a.tx_throughput;
-  EXPECT_EQ(last_msg_->uart_b.crc_error_count, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_b.crc_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_b.crc_error_count)),
+            0)
       << "incorrect value for uart_b.crc_error_count, expected 0, is "
       << last_msg_->uart_b.crc_error_count;
-  EXPECT_EQ(last_msg_->uart_b.io_error_count, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->uart_b.io_error_count)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->uart_b.io_error_count)),
+      0)
       << "incorrect value for uart_b.io_error_count, expected 0, is "
       << last_msg_->uart_b.io_error_count;
-  EXPECT_EQ(last_msg_->uart_b.rx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_b.rx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_b.rx_buffer_level)),
+            0)
       << "incorrect value for uart_b.rx_buffer_level, expected 0, is "
       << last_msg_->uart_b.rx_buffer_level;
   EXPECT_LT((last_msg_->uart_b.rx_throughput * 100 - 0.0 * 100), 0.05)
       << "incorrect value for uart_b.rx_throughput, expected 0.0, is "
       << last_msg_->uart_b.rx_throughput;
-  EXPECT_EQ(last_msg_->uart_b.tx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_b.tx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_b.tx_buffer_level)),
+            0)
       << "incorrect value for uart_b.tx_buffer_level, expected 0, is "
       << last_msg_->uart_b.tx_buffer_level;
   EXPECT_LT((last_msg_->uart_b.tx_throughput * 100 - 0.0 * 100), 0.05)
       << "incorrect value for uart_b.tx_throughput, expected 0.0, is "
       << last_msg_->uart_b.tx_throughput;
-  EXPECT_EQ(last_msg_->uart_ftdi.crc_error_count, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.crc_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.crc_error_count)),
+            0)
       << "incorrect value for uart_ftdi.crc_error_count, expected 0, is "
       << last_msg_->uart_ftdi.crc_error_count;
-  EXPECT_EQ(last_msg_->uart_ftdi.io_error_count, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.io_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.io_error_count)),
+            0)
       << "incorrect value for uart_ftdi.io_error_count, expected 0, is "
       << last_msg_->uart_ftdi.io_error_count;
-  EXPECT_EQ(last_msg_->uart_ftdi.rx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.rx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.rx_buffer_level)),
+            0)
       << "incorrect value for uart_ftdi.rx_buffer_level, expected 0, is "
       << last_msg_->uart_ftdi.rx_buffer_level;
   EXPECT_LT((last_msg_->uart_ftdi.rx_throughput * 100 - 0.0 * 100), 0.05)
       << "incorrect value for uart_ftdi.rx_throughput, expected 0.0, is "
       << last_msg_->uart_ftdi.rx_throughput;
-  EXPECT_EQ(last_msg_->uart_ftdi.tx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.tx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.tx_buffer_level)),
+            0)
       << "incorrect value for uart_ftdi.tx_buffer_level, expected 0, is "
       << last_msg_->uart_ftdi.tx_buffer_level;
   EXPECT_LT((last_msg_->uart_ftdi.tx_throughput * 100 - 0.0659999996424 * 100),
@@ -482,67 +577,111 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgUartStateDepA2, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->latency.avg, -1)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.avg)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.avg)),
+            -1)
       << "incorrect value for latency.avg, expected -1, is "
       << last_msg_->latency.avg;
-  EXPECT_EQ(last_msg_->latency.current, -1)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.current)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.current)),
+            -1)
       << "incorrect value for latency.current, expected -1, is "
       << last_msg_->latency.current;
-  EXPECT_EQ(last_msg_->latency.lmax, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.lmax)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.lmax)),
+            0)
       << "incorrect value for latency.lmax, expected 0, is "
       << last_msg_->latency.lmax;
-  EXPECT_EQ(last_msg_->latency.lmin, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.lmin)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.lmin)),
+            0)
       << "incorrect value for latency.lmin, expected 0, is "
       << last_msg_->latency.lmin;
-  EXPECT_EQ(last_msg_->uart_a.crc_error_count, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_a.crc_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_a.crc_error_count)),
+            0)
       << "incorrect value for uart_a.crc_error_count, expected 0, is "
       << last_msg_->uart_a.crc_error_count;
-  EXPECT_EQ(last_msg_->uart_a.io_error_count, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->uart_a.io_error_count)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->uart_a.io_error_count)),
+      0)
       << "incorrect value for uart_a.io_error_count, expected 0, is "
       << last_msg_->uart_a.io_error_count;
-  EXPECT_EQ(last_msg_->uart_a.rx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_a.rx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_a.rx_buffer_level)),
+            0)
       << "incorrect value for uart_a.rx_buffer_level, expected 0, is "
       << last_msg_->uart_a.rx_buffer_level;
   EXPECT_LT((last_msg_->uart_a.rx_throughput * 100 - 0.0 * 100), 0.05)
       << "incorrect value for uart_a.rx_throughput, expected 0.0, is "
       << last_msg_->uart_a.rx_throughput;
-  EXPECT_EQ(last_msg_->uart_a.tx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_a.tx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_a.tx_buffer_level)),
+            0)
       << "incorrect value for uart_a.tx_buffer_level, expected 0, is "
       << last_msg_->uart_a.tx_buffer_level;
   EXPECT_LT((last_msg_->uart_a.tx_throughput * 100 - 0.0 * 100), 0.05)
       << "incorrect value for uart_a.tx_throughput, expected 0.0, is "
       << last_msg_->uart_a.tx_throughput;
-  EXPECT_EQ(last_msg_->uart_b.crc_error_count, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_b.crc_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_b.crc_error_count)),
+            0)
       << "incorrect value for uart_b.crc_error_count, expected 0, is "
       << last_msg_->uart_b.crc_error_count;
-  EXPECT_EQ(last_msg_->uart_b.io_error_count, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->uart_b.io_error_count)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->uart_b.io_error_count)),
+      0)
       << "incorrect value for uart_b.io_error_count, expected 0, is "
       << last_msg_->uart_b.io_error_count;
-  EXPECT_EQ(last_msg_->uart_b.rx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_b.rx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_b.rx_buffer_level)),
+            0)
       << "incorrect value for uart_b.rx_buffer_level, expected 0, is "
       << last_msg_->uart_b.rx_buffer_level;
   EXPECT_LT((last_msg_->uart_b.rx_throughput * 100 - 0.0 * 100), 0.05)
       << "incorrect value for uart_b.rx_throughput, expected 0.0, is "
       << last_msg_->uart_b.rx_throughput;
-  EXPECT_EQ(last_msg_->uart_b.tx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_b.tx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_b.tx_buffer_level)),
+            0)
       << "incorrect value for uart_b.tx_buffer_level, expected 0, is "
       << last_msg_->uart_b.tx_buffer_level;
   EXPECT_LT((last_msg_->uart_b.tx_throughput * 100 - 0.0 * 100), 0.05)
       << "incorrect value for uart_b.tx_throughput, expected 0.0, is "
       << last_msg_->uart_b.tx_throughput;
-  EXPECT_EQ(last_msg_->uart_ftdi.crc_error_count, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.crc_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.crc_error_count)),
+            0)
       << "incorrect value for uart_ftdi.crc_error_count, expected 0, is "
       << last_msg_->uart_ftdi.crc_error_count;
-  EXPECT_EQ(last_msg_->uart_ftdi.io_error_count, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.io_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.io_error_count)),
+            0)
       << "incorrect value for uart_ftdi.io_error_count, expected 0, is "
       << last_msg_->uart_ftdi.io_error_count;
-  EXPECT_EQ(last_msg_->uart_ftdi.rx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.rx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.rx_buffer_level)),
+            0)
       << "incorrect value for uart_ftdi.rx_buffer_level, expected 0, is "
       << last_msg_->uart_ftdi.rx_buffer_level;
   EXPECT_LT((last_msg_->uart_ftdi.rx_throughput * 100 - 0.0 * 100), 0.05)
       << "incorrect value for uart_ftdi.rx_throughput, expected 0.0, is "
       << last_msg_->uart_ftdi.rx_throughput;
-  EXPECT_EQ(last_msg_->uart_ftdi.tx_buffer_level, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.tx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.tx_buffer_level)),
+            10)
       << "incorrect value for uart_ftdi.tx_buffer_level, expected 10, is "
       << last_msg_->uart_ftdi.tx_buffer_level;
   EXPECT_LT((last_msg_->uart_ftdi.tx_throughput * 100 - 0.138999998569 * 100),
@@ -656,67 +795,111 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgUartStateDepA3, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->latency.avg, -1)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.avg)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.avg)),
+            -1)
       << "incorrect value for latency.avg, expected -1, is "
       << last_msg_->latency.avg;
-  EXPECT_EQ(last_msg_->latency.current, -1)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.current)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.current)),
+            -1)
       << "incorrect value for latency.current, expected -1, is "
       << last_msg_->latency.current;
-  EXPECT_EQ(last_msg_->latency.lmax, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.lmax)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.lmax)),
+            0)
       << "incorrect value for latency.lmax, expected 0, is "
       << last_msg_->latency.lmax;
-  EXPECT_EQ(last_msg_->latency.lmin, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.lmin)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.lmin)),
+            0)
       << "incorrect value for latency.lmin, expected 0, is "
       << last_msg_->latency.lmin;
-  EXPECT_EQ(last_msg_->uart_a.crc_error_count, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_a.crc_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_a.crc_error_count)),
+            0)
       << "incorrect value for uart_a.crc_error_count, expected 0, is "
       << last_msg_->uart_a.crc_error_count;
-  EXPECT_EQ(last_msg_->uart_a.io_error_count, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->uart_a.io_error_count)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->uart_a.io_error_count)),
+      0)
       << "incorrect value for uart_a.io_error_count, expected 0, is "
       << last_msg_->uart_a.io_error_count;
-  EXPECT_EQ(last_msg_->uart_a.rx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_a.rx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_a.rx_buffer_level)),
+            0)
       << "incorrect value for uart_a.rx_buffer_level, expected 0, is "
       << last_msg_->uart_a.rx_buffer_level;
   EXPECT_LT((last_msg_->uart_a.rx_throughput * 100 - 0.0 * 100), 0.05)
       << "incorrect value for uart_a.rx_throughput, expected 0.0, is "
       << last_msg_->uart_a.rx_throughput;
-  EXPECT_EQ(last_msg_->uart_a.tx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_a.tx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_a.tx_buffer_level)),
+            0)
       << "incorrect value for uart_a.tx_buffer_level, expected 0, is "
       << last_msg_->uart_a.tx_buffer_level;
   EXPECT_LT((last_msg_->uart_a.tx_throughput * 100 - 0.0 * 100), 0.05)
       << "incorrect value for uart_a.tx_throughput, expected 0.0, is "
       << last_msg_->uart_a.tx_throughput;
-  EXPECT_EQ(last_msg_->uart_b.crc_error_count, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_b.crc_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_b.crc_error_count)),
+            0)
       << "incorrect value for uart_b.crc_error_count, expected 0, is "
       << last_msg_->uart_b.crc_error_count;
-  EXPECT_EQ(last_msg_->uart_b.io_error_count, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->uart_b.io_error_count)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->uart_b.io_error_count)),
+      0)
       << "incorrect value for uart_b.io_error_count, expected 0, is "
       << last_msg_->uart_b.io_error_count;
-  EXPECT_EQ(last_msg_->uart_b.rx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_b.rx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_b.rx_buffer_level)),
+            0)
       << "incorrect value for uart_b.rx_buffer_level, expected 0, is "
       << last_msg_->uart_b.rx_buffer_level;
   EXPECT_LT((last_msg_->uart_b.rx_throughput * 100 - 0.0 * 100), 0.05)
       << "incorrect value for uart_b.rx_throughput, expected 0.0, is "
       << last_msg_->uart_b.rx_throughput;
-  EXPECT_EQ(last_msg_->uart_b.tx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_b.tx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_b.tx_buffer_level)),
+            0)
       << "incorrect value for uart_b.tx_buffer_level, expected 0, is "
       << last_msg_->uart_b.tx_buffer_level;
   EXPECT_LT((last_msg_->uart_b.tx_throughput * 100 - 0.0 * 100), 0.05)
       << "incorrect value for uart_b.tx_throughput, expected 0.0, is "
       << last_msg_->uart_b.tx_throughput;
-  EXPECT_EQ(last_msg_->uart_ftdi.crc_error_count, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.crc_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.crc_error_count)),
+            0)
       << "incorrect value for uart_ftdi.crc_error_count, expected 0, is "
       << last_msg_->uart_ftdi.crc_error_count;
-  EXPECT_EQ(last_msg_->uart_ftdi.io_error_count, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.io_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.io_error_count)),
+            0)
       << "incorrect value for uart_ftdi.io_error_count, expected 0, is "
       << last_msg_->uart_ftdi.io_error_count;
-  EXPECT_EQ(last_msg_->uart_ftdi.rx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.rx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.rx_buffer_level)),
+            0)
       << "incorrect value for uart_ftdi.rx_buffer_level, expected 0, is "
       << last_msg_->uart_ftdi.rx_buffer_level;
   EXPECT_LT((last_msg_->uart_ftdi.rx_throughput * 100 - 0.0 * 100), 0.05)
       << "incorrect value for uart_ftdi.rx_throughput, expected 0.0, is "
       << last_msg_->uart_ftdi.rx_throughput;
-  EXPECT_EQ(last_msg_->uart_ftdi.tx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.tx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.tx_buffer_level)),
+            0)
       << "incorrect value for uart_ftdi.tx_buffer_level, expected 0, is "
       << last_msg_->uart_ftdi.tx_buffer_level;
   EXPECT_LT((last_msg_->uart_ftdi.tx_throughput * 100 - 0.0659999996424 * 100),
@@ -831,25 +1014,42 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgUartStateDepA4, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->latency.avg, -1)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.avg)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.avg)),
+            -1)
       << "incorrect value for latency.avg, expected -1, is "
       << last_msg_->latency.avg;
-  EXPECT_EQ(last_msg_->latency.current, -1)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.current)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.current)),
+            -1)
       << "incorrect value for latency.current, expected -1, is "
       << last_msg_->latency.current;
-  EXPECT_EQ(last_msg_->latency.lmax, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.lmax)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.lmax)),
+            0)
       << "incorrect value for latency.lmax, expected 0, is "
       << last_msg_->latency.lmax;
-  EXPECT_EQ(last_msg_->latency.lmin, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.lmin)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.lmin)),
+            0)
       << "incorrect value for latency.lmin, expected 0, is "
       << last_msg_->latency.lmin;
-  EXPECT_EQ(last_msg_->uart_a.crc_error_count, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_a.crc_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_a.crc_error_count)),
+            0)
       << "incorrect value for uart_a.crc_error_count, expected 0, is "
       << last_msg_->uart_a.crc_error_count;
-  EXPECT_EQ(last_msg_->uart_a.io_error_count, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->uart_a.io_error_count)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->uart_a.io_error_count)),
+      0)
       << "incorrect value for uart_a.io_error_count, expected 0, is "
       << last_msg_->uart_a.io_error_count;
-  EXPECT_EQ(last_msg_->uart_a.rx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_a.rx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_a.rx_buffer_level)),
+            0)
       << "incorrect value for uart_a.rx_buffer_level, expected 0, is "
       << last_msg_->uart_a.rx_buffer_level;
   EXPECT_LT((last_msg_->uart_a.rx_throughput * 100 - 0.00819672085345 * 100),
@@ -857,25 +1057,40 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgUartStateDepA4, Test) {
       << "incorrect value for uart_a.rx_throughput, expected 0.00819672085345, "
          "is "
       << last_msg_->uart_a.rx_throughput;
-  EXPECT_EQ(last_msg_->uart_a.tx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_a.tx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_a.tx_buffer_level)),
+            0)
       << "incorrect value for uart_a.tx_buffer_level, expected 0, is "
       << last_msg_->uart_a.tx_buffer_level;
   EXPECT_LT((last_msg_->uart_a.tx_throughput * 100 - 0.0 * 100), 0.05)
       << "incorrect value for uart_a.tx_throughput, expected 0.0, is "
       << last_msg_->uart_a.tx_throughput;
-  EXPECT_EQ(last_msg_->uart_b.crc_error_count, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_b.crc_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_b.crc_error_count)),
+            0)
       << "incorrect value for uart_b.crc_error_count, expected 0, is "
       << last_msg_->uart_b.crc_error_count;
-  EXPECT_EQ(last_msg_->uart_b.io_error_count, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->uart_b.io_error_count)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->uart_b.io_error_count)),
+      0)
       << "incorrect value for uart_b.io_error_count, expected 0, is "
       << last_msg_->uart_b.io_error_count;
-  EXPECT_EQ(last_msg_->uart_b.rx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_b.rx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_b.rx_buffer_level)),
+            0)
       << "incorrect value for uart_b.rx_buffer_level, expected 0, is "
       << last_msg_->uart_b.rx_buffer_level;
   EXPECT_LT((last_msg_->uart_b.rx_throughput * 100 - 0.0 * 100), 0.05)
       << "incorrect value for uart_b.rx_throughput, expected 0.0, is "
       << last_msg_->uart_b.rx_throughput;
-  EXPECT_EQ(last_msg_->uart_b.tx_buffer_level, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_b.tx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_b.tx_buffer_level)),
+            2)
       << "incorrect value for uart_b.tx_buffer_level, expected 2, is "
       << last_msg_->uart_b.tx_buffer_level;
   EXPECT_LT((last_msg_->uart_b.tx_throughput * 100 - 0.098360657692 * 100),
@@ -883,19 +1098,31 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgUartStateDepA4, Test) {
       << "incorrect value for uart_b.tx_throughput, expected 0.098360657692, "
          "is "
       << last_msg_->uart_b.tx_throughput;
-  EXPECT_EQ(last_msg_->uart_ftdi.crc_error_count, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.crc_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.crc_error_count)),
+            0)
       << "incorrect value for uart_ftdi.crc_error_count, expected 0, is "
       << last_msg_->uart_ftdi.crc_error_count;
-  EXPECT_EQ(last_msg_->uart_ftdi.io_error_count, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.io_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.io_error_count)),
+            0)
       << "incorrect value for uart_ftdi.io_error_count, expected 0, is "
       << last_msg_->uart_ftdi.io_error_count;
-  EXPECT_EQ(last_msg_->uart_ftdi.rx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.rx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.rx_buffer_level)),
+            0)
       << "incorrect value for uart_ftdi.rx_buffer_level, expected 0, is "
       << last_msg_->uart_ftdi.rx_buffer_level;
   EXPECT_LT((last_msg_->uart_ftdi.rx_throughput * 100 - 0.0 * 100), 0.05)
       << "incorrect value for uart_ftdi.rx_throughput, expected 0.0, is "
       << last_msg_->uart_ftdi.rx_throughput;
-  EXPECT_EQ(last_msg_->uart_ftdi.tx_buffer_level, 38)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.tx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.tx_buffer_level)),
+            38)
       << "incorrect value for uart_ftdi.tx_buffer_level, expected 38, is "
       << last_msg_->uart_ftdi.tx_buffer_level;
   EXPECT_LT((last_msg_->uart_ftdi.tx_throughput * 100 - 0.493999987841 * 100),
@@ -1010,31 +1237,51 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgUartStateDepA5, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->latency.avg, -1)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.avg)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.avg)),
+            -1)
       << "incorrect value for latency.avg, expected -1, is "
       << last_msg_->latency.avg;
-  EXPECT_EQ(last_msg_->latency.current, -1)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.current)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.current)),
+            -1)
       << "incorrect value for latency.current, expected -1, is "
       << last_msg_->latency.current;
-  EXPECT_EQ(last_msg_->latency.lmax, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.lmax)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.lmax)),
+            0)
       << "incorrect value for latency.lmax, expected 0, is "
       << last_msg_->latency.lmax;
-  EXPECT_EQ(last_msg_->latency.lmin, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency.lmin)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency.lmin)),
+            0)
       << "incorrect value for latency.lmin, expected 0, is "
       << last_msg_->latency.lmin;
-  EXPECT_EQ(last_msg_->uart_a.crc_error_count, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_a.crc_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_a.crc_error_count)),
+            0)
       << "incorrect value for uart_a.crc_error_count, expected 0, is "
       << last_msg_->uart_a.crc_error_count;
-  EXPECT_EQ(last_msg_->uart_a.io_error_count, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->uart_a.io_error_count)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->uart_a.io_error_count)),
+      0)
       << "incorrect value for uart_a.io_error_count, expected 0, is "
       << last_msg_->uart_a.io_error_count;
-  EXPECT_EQ(last_msg_->uart_a.rx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_a.rx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_a.rx_buffer_level)),
+            0)
       << "incorrect value for uart_a.rx_buffer_level, expected 0, is "
       << last_msg_->uart_a.rx_buffer_level;
   EXPECT_LT((last_msg_->uart_a.rx_throughput * 100 - 0.0 * 100), 0.05)
       << "incorrect value for uart_a.rx_throughput, expected 0.0, is "
       << last_msg_->uart_a.rx_throughput;
-  EXPECT_EQ(last_msg_->uart_a.tx_buffer_level, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_a.tx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_a.tx_buffer_level)),
+            2)
       << "incorrect value for uart_a.tx_buffer_level, expected 2, is "
       << last_msg_->uart_a.tx_buffer_level;
   EXPECT_LT((last_msg_->uart_a.tx_throughput * 100 - 0.0120000001043 * 100),
@@ -1042,19 +1289,31 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgUartStateDepA5, Test) {
       << "incorrect value for uart_a.tx_throughput, expected 0.0120000001043, "
          "is "
       << last_msg_->uart_a.tx_throughput;
-  EXPECT_EQ(last_msg_->uart_b.crc_error_count, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_b.crc_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_b.crc_error_count)),
+            0)
       << "incorrect value for uart_b.crc_error_count, expected 0, is "
       << last_msg_->uart_b.crc_error_count;
-  EXPECT_EQ(last_msg_->uart_b.io_error_count, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->uart_b.io_error_count)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->uart_b.io_error_count)),
+      0)
       << "incorrect value for uart_b.io_error_count, expected 0, is "
       << last_msg_->uart_b.io_error_count;
-  EXPECT_EQ(last_msg_->uart_b.rx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_b.rx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_b.rx_buffer_level)),
+            0)
       << "incorrect value for uart_b.rx_buffer_level, expected 0, is "
       << last_msg_->uart_b.rx_buffer_level;
   EXPECT_LT((last_msg_->uart_b.rx_throughput * 100 - 0.0 * 100), 0.05)
       << "incorrect value for uart_b.rx_throughput, expected 0.0, is "
       << last_msg_->uart_b.rx_throughput;
-  EXPECT_EQ(last_msg_->uart_b.tx_buffer_level, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_b.tx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_b.tx_buffer_level)),
+            2)
       << "incorrect value for uart_b.tx_buffer_level, expected 2, is "
       << last_msg_->uart_b.tx_buffer_level;
   EXPECT_LT((last_msg_->uart_b.tx_throughput * 100 - 0.0120000001043 * 100),
@@ -1062,19 +1321,31 @@ TEST_F(Test_legacy_auto_check_sbp_piksi_MsgUartStateDepA5, Test) {
       << "incorrect value for uart_b.tx_throughput, expected 0.0120000001043, "
          "is "
       << last_msg_->uart_b.tx_throughput;
-  EXPECT_EQ(last_msg_->uart_ftdi.crc_error_count, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.crc_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.crc_error_count)),
+            0)
       << "incorrect value for uart_ftdi.crc_error_count, expected 0, is "
       << last_msg_->uart_ftdi.crc_error_count;
-  EXPECT_EQ(last_msg_->uart_ftdi.io_error_count, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.io_error_count)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.io_error_count)),
+            0)
       << "incorrect value for uart_ftdi.io_error_count, expected 0, is "
       << last_msg_->uart_ftdi.io_error_count;
-  EXPECT_EQ(last_msg_->uart_ftdi.rx_buffer_level, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.rx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.rx_buffer_level)),
+            0)
       << "incorrect value for uart_ftdi.rx_buffer_level, expected 0, is "
       << last_msg_->uart_ftdi.rx_buffer_level;
   EXPECT_LT((last_msg_->uart_ftdi.rx_throughput * 100 - 0.0 * 100), 0.05)
       << "incorrect value for uart_ftdi.rx_throughput, expected 0.0, is "
       << last_msg_->uart_ftdi.rx_throughput;
-  EXPECT_EQ(last_msg_->uart_ftdi.tx_buffer_level, 50)
+  EXPECT_EQ(get_as<decltype(last_msg_->uart_ftdi.tx_buffer_level)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->uart_ftdi.tx_buffer_level)),
+            50)
       << "incorrect value for uart_ftdi.tx_buffer_level, expected 50, is "
       << last_msg_->uart_ftdi.tx_buffer_level;
   EXPECT_LT((last_msg_->uart_ftdi.tx_throughput * 100 - 1.31500005722 * 100),

--- a/c/test/legacy/cpp/auto_check_sbp_profiling_MsgMeasurementPoint.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_profiling_MsgMeasurementPoint.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/profiling.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_profiling_MsgMeasurementPoint0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -137,24 +144,40 @@ TEST_F(Test_legacy_auto_check_sbp_profiling_MsgMeasurementPoint0, Test) {
         << "incorrect value for last_msg_->func, expected string '"
         << check_string << "', is '" << last_msg_->func << "'";
   }
-  EXPECT_EQ(last_msg_->id, 2496234002)
+  EXPECT_EQ(get_as<decltype(last_msg_->id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->id)),
+            2496234002)
       << "incorrect value for id, expected 2496234002, is " << last_msg_->id;
-  EXPECT_EQ(last_msg_->line, 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->line)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->line)),
+            18)
       << "incorrect value for line, expected 18, is " << last_msg_->line;
-  EXPECT_EQ(last_msg_->max, 40)
+  EXPECT_EQ(get_as<decltype(last_msg_->max)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->max)),
+            40)
       << "incorrect value for max, expected 40, is " << last_msg_->max;
-  EXPECT_EQ(last_msg_->min, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->min)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->min)),
+            2)
       << "incorrect value for min, expected 2, is " << last_msg_->min;
-  EXPECT_EQ(last_msg_->num_executions, 180)
+  EXPECT_EQ(get_as<decltype(last_msg_->num_executions)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->num_executions)),
+            180)
       << "incorrect value for num_executions, expected 180, is "
       << last_msg_->num_executions;
-  EXPECT_EQ(last_msg_->return_addr, 93877475527042)
+  EXPECT_EQ(get_as<decltype(last_msg_->return_addr)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->return_addr)),
+            93877475527042)
       << "incorrect value for return_addr, expected 93877475527042, is "
       << last_msg_->return_addr;
-  EXPECT_EQ(last_msg_->slice_time, 261963842)
+  EXPECT_EQ(get_as<decltype(last_msg_->slice_time)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->slice_time)),
+            261963842)
       << "incorrect value for slice_time, expected 261963842, is "
       << last_msg_->slice_time;
-  EXPECT_EQ(last_msg_->total_time, 2042)
+  EXPECT_EQ(get_as<decltype(last_msg_->total_time)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->total_time)),
+            2042)
       << "incorrect value for total_time, expected 2042, is "
       << last_msg_->total_time;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_sbas_MsgSbasRaw.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_sbas_MsgSbasRaw.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/sbas.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_sbas_MsgSbasRaw0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -251,82 +258,144 @@ TEST_F(Test_legacy_auto_check_sbp_sbas_MsgSbasRaw0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 51228);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->data[0], 23)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[0])),
+            23)
       << "incorrect value for data[0], expected 23, is " << last_msg_->data[0];
-  EXPECT_EQ(last_msg_->data[1], 255)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[1])),
+            255)
       << "incorrect value for data[1], expected 255, is " << last_msg_->data[1];
-  EXPECT_EQ(last_msg_->data[2], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[2])),
+            0)
       << "incorrect value for data[2], expected 0, is " << last_msg_->data[2];
-  EXPECT_EQ(last_msg_->data[3], 23)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[3])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[3])),
+            23)
       << "incorrect value for data[3], expected 23, is " << last_msg_->data[3];
-  EXPECT_EQ(last_msg_->data[4], 255)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[4])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[4])),
+            255)
       << "incorrect value for data[4], expected 255, is " << last_msg_->data[4];
-  EXPECT_EQ(last_msg_->data[5], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[5])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[5])),
+            0)
       << "incorrect value for data[5], expected 0, is " << last_msg_->data[5];
-  EXPECT_EQ(last_msg_->data[6], 23)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[6])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[6])),
+            23)
       << "incorrect value for data[6], expected 23, is " << last_msg_->data[6];
-  EXPECT_EQ(last_msg_->data[7], 255)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[7])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[7])),
+            255)
       << "incorrect value for data[7], expected 255, is " << last_msg_->data[7];
-  EXPECT_EQ(last_msg_->data[8], 127)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[8])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[8])),
+            127)
       << "incorrect value for data[8], expected 127, is " << last_msg_->data[8];
-  EXPECT_EQ(last_msg_->data[9], 240)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[9])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[9])),
+            240)
       << "incorrect value for data[9], expected 240, is " << last_msg_->data[9];
-  EXPECT_EQ(last_msg_->data[10], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[10])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[10])),
+            2)
       << "incorrect value for data[10], expected 2, is " << last_msg_->data[10];
-  EXPECT_EQ(last_msg_->data[11], 255)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[11])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[11])),
+            255)
       << "incorrect value for data[11], expected 255, is "
       << last_msg_->data[11];
-  EXPECT_EQ(last_msg_->data[12], 192)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[12])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[12])),
+            192)
       << "incorrect value for data[12], expected 192, is "
       << last_msg_->data[12];
-  EXPECT_EQ(last_msg_->data[13], 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[13])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[13])),
+            3)
       << "incorrect value for data[13], expected 3, is " << last_msg_->data[13];
-  EXPECT_EQ(last_msg_->data[14], 127)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[14])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[14])),
+            127)
       << "incorrect value for data[14], expected 127, is "
       << last_msg_->data[14];
-  EXPECT_EQ(last_msg_->data[15], 247)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[15])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[15])),
+            247)
       << "incorrect value for data[15], expected 247, is "
       << last_msg_->data[15];
-  EXPECT_EQ(last_msg_->data[16], 255)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[16])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[16])),
+            255)
       << "incorrect value for data[16], expected 255, is "
       << last_msg_->data[16];
-  EXPECT_EQ(last_msg_->data[17], 127)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[17])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[17])),
+            127)
       << "incorrect value for data[17], expected 127, is "
       << last_msg_->data[17];
-  EXPECT_EQ(last_msg_->data[18], 247)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[18])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[18])),
+            247)
       << "incorrect value for data[18], expected 247, is "
       << last_msg_->data[18];
-  EXPECT_EQ(last_msg_->data[19], 255)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[19])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[19])),
+            255)
       << "incorrect value for data[19], expected 255, is "
       << last_msg_->data[19];
-  EXPECT_EQ(last_msg_->data[20], 229)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[20])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[20])),
+            229)
       << "incorrect value for data[20], expected 229, is "
       << last_msg_->data[20];
-  EXPECT_EQ(last_msg_->data[21], 229)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[21])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[21])),
+            229)
       << "incorrect value for data[21], expected 229, is "
       << last_msg_->data[21];
-  EXPECT_EQ(last_msg_->data[22], 238)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[22])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[22])),
+            238)
       << "incorrect value for data[22], expected 238, is "
       << last_msg_->data[22];
-  EXPECT_EQ(last_msg_->data[23], 170)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[23])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[23])),
+            170)
       << "incorrect value for data[23], expected 170, is "
       << last_msg_->data[23];
-  EXPECT_EQ(last_msg_->data[24], 175)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[24])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[24])),
+            175)
       << "incorrect value for data[24], expected 175, is "
       << last_msg_->data[24];
-  EXPECT_EQ(last_msg_->data[25], 255)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[25])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[25])),
+            255)
       << "incorrect value for data[25], expected 255, is "
       << last_msg_->data[25];
-  EXPECT_EQ(last_msg_->data[26], 240)
+  EXPECT_EQ(get_as<decltype(last_msg_->data[26])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->data[26])),
+            240)
       << "incorrect value for data[26], expected 240, is "
       << last_msg_->data[26];
-  EXPECT_EQ(last_msg_->message_type, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->message_type)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->message_type)),
+            4)
       << "incorrect value for message_type, expected 4, is "
       << last_msg_->message_type;
-  EXPECT_EQ(last_msg_->sid.code, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.code)),
+            2)
       << "incorrect value for sid.code, expected 2, is " << last_msg_->sid.code;
-  EXPECT_EQ(last_msg_->sid.sat, 131)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.sat)),
+            131)
       << "incorrect value for sid.sat, expected 131, is " << last_msg_->sid.sat;
-  EXPECT_EQ(last_msg_->tow, 501867721)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            501867721)
       << "incorrect value for tow, expected 501867721, is " << last_msg_->tow;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_settings_MsgSettingsReadByIndexDone.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_settings_MsgSettingsReadByIndexDone.cc
@@ -29,3 +29,10 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/settings.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}

--- a/c/test/legacy/cpp/auto_check_sbp_settings_MsgSettingsReadByIndexReq.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_settings_MsgSettingsReadByIndexReq.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/settings.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_settings_MsgSettingsReadByIndexReq0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -112,6 +119,8 @@ TEST_F(Test_legacy_auto_check_sbp_settings_MsgSettingsReadByIndexReq0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 31610);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->index, 8948)
+  EXPECT_EQ(get_as<decltype(last_msg_->index)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->index)),
+            8948)
       << "incorrect value for index, expected 8948, is " << last_msg_->index;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_settings_MsgSettingsReadByIndexResp.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_settings_MsgSettingsReadByIndexResp.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/settings.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_settings_MsgSettingsReadByIndexResp0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -137,7 +144,9 @@ TEST_F(Test_legacy_auto_check_sbp_settings_MsgSettingsReadByIndexResp0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->index, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->index)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->index)),
+            0)
       << "incorrect value for index, expected 0, is " << last_msg_->index;
   {
     const char check_string[] = {
@@ -257,7 +266,9 @@ TEST_F(Test_legacy_auto_check_sbp_settings_MsgSettingsReadByIndexResp1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->index, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->index)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->index)),
+            1)
       << "incorrect value for index, expected 1, is " << last_msg_->index;
   {
     const char check_string[] = {
@@ -370,7 +381,9 @@ TEST_F(Test_legacy_auto_check_sbp_settings_MsgSettingsReadByIndexResp2, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->index, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->index)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->index)),
+            2)
       << "incorrect value for index, expected 2, is " << last_msg_->index;
   {
     const char check_string[] = {
@@ -482,7 +495,9 @@ TEST_F(Test_legacy_auto_check_sbp_settings_MsgSettingsReadByIndexResp3, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->index, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->index)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->index)),
+            3)
       << "incorrect value for index, expected 3, is " << last_msg_->index;
   {
     const char check_string[] = {
@@ -594,7 +609,9 @@ TEST_F(Test_legacy_auto_check_sbp_settings_MsgSettingsReadByIndexResp4, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->index, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->index)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->index)),
+            4)
       << "incorrect value for index, expected 4, is " << last_msg_->index;
   {
     const char check_string[] = {

--- a/c/test/legacy/cpp/auto_check_sbp_settings_MsgSettingsReadReq.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_settings_MsgSettingsReadReq.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/settings.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_settings_MsgSettingsReadReq0
     : public ::testing::Test,
       public sbp::LegacyState,

--- a/c/test/legacy/cpp/auto_check_sbp_settings_MsgSettingsReadResp.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_settings_MsgSettingsReadResp.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/settings.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_settings_MsgSettingsReadResp0
     : public ::testing::Test,
       public sbp::LegacyState,

--- a/c/test/legacy/cpp/auto_check_sbp_settings_MsgSettingsRegister.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_settings_MsgSettingsRegister.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/settings.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_settings_MsgSettingsRegister0
     : public ::testing::Test,
       public sbp::LegacyState,

--- a/c/test/legacy/cpp/auto_check_sbp_settings_MsgSettingsRegisterResp.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_settings_MsgSettingsRegisterResp.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/settings.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_settings_MsgSettingsRegisterResp0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -151,6 +158,8 @@ TEST_F(Test_legacy_auto_check_sbp_settings_MsgSettingsRegisterResp0, Test) {
         << "incorrect value for last_msg_->setting, expected string '"
         << check_string << "', is '" << last_msg_->setting << "'";
   }
-  EXPECT_EQ(last_msg_->status, 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->status)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->status)),
+            18)
       << "incorrect value for status, expected 18, is " << last_msg_->status;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_settings_MsgSettingsSave.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_settings_MsgSettingsSave.cc
@@ -29,3 +29,10 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/settings.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}

--- a/c/test/legacy/cpp/auto_check_sbp_settings_MsgSettingsWrite.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_settings_MsgSettingsWrite.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/settings.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_settings_MsgSettingsWrite0
     : public ::testing::Test,
       public sbp::LegacyState,

--- a/c/test/legacy/cpp/auto_check_sbp_settings_MsgSettingsWriteResp.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_settings_MsgSettingsWriteResp.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/settings.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_settings_MsgSettingsWriteResp0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -151,6 +158,8 @@ TEST_F(Test_legacy_auto_check_sbp_settings_MsgSettingsWriteResp0, Test) {
         << "incorrect value for last_msg_->setting, expected string '"
         << check_string << "', is '" << last_msg_->setting << "'";
   }
-  EXPECT_EQ(last_msg_->status, 152)
+  EXPECT_EQ(get_as<decltype(last_msg_->status)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->status)),
+            152)
       << "incorrect value for status, expected 152, is " << last_msg_->status;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_signing_MsgCertificateChain.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_signing_MsgCertificateChain.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/signing.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_signing_MsgCertificateChain0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -919,424 +926,840 @@ TEST_F(Test_legacy_auto_check_sbp_signing_MsgCertificateChain0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->corrections_certificate[0], 20)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[0])),
+            20)
       << "incorrect value for corrections_certificate[0], expected 20, is "
       << last_msg_->corrections_certificate[0];
-  EXPECT_EQ(last_msg_->corrections_certificate[1], 21)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[1])),
+            21)
       << "incorrect value for corrections_certificate[1], expected 21, is "
       << last_msg_->corrections_certificate[1];
-  EXPECT_EQ(last_msg_->corrections_certificate[2], 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[2])),
+            22)
       << "incorrect value for corrections_certificate[2], expected 22, is "
       << last_msg_->corrections_certificate[2];
-  EXPECT_EQ(last_msg_->corrections_certificate[3], 23)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[3])),
+            23)
       << "incorrect value for corrections_certificate[3], expected 23, is "
       << last_msg_->corrections_certificate[3];
-  EXPECT_EQ(last_msg_->corrections_certificate[4], 24)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[4])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[4])),
+            24)
       << "incorrect value for corrections_certificate[4], expected 24, is "
       << last_msg_->corrections_certificate[4];
-  EXPECT_EQ(last_msg_->corrections_certificate[5], 25)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[5])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[5])),
+            25)
       << "incorrect value for corrections_certificate[5], expected 25, is "
       << last_msg_->corrections_certificate[5];
-  EXPECT_EQ(last_msg_->corrections_certificate[6], 26)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[6])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[6])),
+            26)
       << "incorrect value for corrections_certificate[6], expected 26, is "
       << last_msg_->corrections_certificate[6];
-  EXPECT_EQ(last_msg_->corrections_certificate[7], 27)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[7])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[7])),
+            27)
       << "incorrect value for corrections_certificate[7], expected 27, is "
       << last_msg_->corrections_certificate[7];
-  EXPECT_EQ(last_msg_->corrections_certificate[8], 28)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[8])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[8])),
+            28)
       << "incorrect value for corrections_certificate[8], expected 28, is "
       << last_msg_->corrections_certificate[8];
-  EXPECT_EQ(last_msg_->corrections_certificate[9], 29)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[9])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[9])),
+            29)
       << "incorrect value for corrections_certificate[9], expected 29, is "
       << last_msg_->corrections_certificate[9];
-  EXPECT_EQ(last_msg_->corrections_certificate[10], 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[10])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[10])),
+            10)
       << "incorrect value for corrections_certificate[10], expected 10, is "
       << last_msg_->corrections_certificate[10];
-  EXPECT_EQ(last_msg_->corrections_certificate[11], 11)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[11])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[11])),
+            11)
       << "incorrect value for corrections_certificate[11], expected 11, is "
       << last_msg_->corrections_certificate[11];
-  EXPECT_EQ(last_msg_->corrections_certificate[12], 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[12])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[12])),
+            12)
       << "incorrect value for corrections_certificate[12], expected 12, is "
       << last_msg_->corrections_certificate[12];
-  EXPECT_EQ(last_msg_->corrections_certificate[13], 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[13])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[13])),
+            13)
       << "incorrect value for corrections_certificate[13], expected 13, is "
       << last_msg_->corrections_certificate[13];
-  EXPECT_EQ(last_msg_->corrections_certificate[14], 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[14])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[14])),
+            14)
       << "incorrect value for corrections_certificate[14], expected 14, is "
       << last_msg_->corrections_certificate[14];
-  EXPECT_EQ(last_msg_->corrections_certificate[15], 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[15])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[15])),
+            15)
       << "incorrect value for corrections_certificate[15], expected 15, is "
       << last_msg_->corrections_certificate[15];
-  EXPECT_EQ(last_msg_->corrections_certificate[16], 16)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[16])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[16])),
+            16)
       << "incorrect value for corrections_certificate[16], expected 16, is "
       << last_msg_->corrections_certificate[16];
-  EXPECT_EQ(last_msg_->corrections_certificate[17], 17)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[17])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[17])),
+            17)
       << "incorrect value for corrections_certificate[17], expected 17, is "
       << last_msg_->corrections_certificate[17];
-  EXPECT_EQ(last_msg_->corrections_certificate[18], 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[18])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[18])),
+            18)
       << "incorrect value for corrections_certificate[18], expected 18, is "
       << last_msg_->corrections_certificate[18];
-  EXPECT_EQ(last_msg_->corrections_certificate[19], 19)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[19])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[19])),
+            19)
       << "incorrect value for corrections_certificate[19], expected 19, is "
       << last_msg_->corrections_certificate[19];
-  EXPECT_EQ(last_msg_->expiration.day, 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->expiration.day)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->expiration.day)),
+            30)
       << "incorrect value for expiration.day, expected 30, is "
       << last_msg_->expiration.day;
-  EXPECT_EQ(last_msg_->expiration.hours, 12)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->expiration.hours)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->expiration.hours)),
+      12)
       << "incorrect value for expiration.hours, expected 12, is "
       << last_msg_->expiration.hours;
-  EXPECT_EQ(last_msg_->expiration.minutes, 34)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->expiration.minutes)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->expiration.minutes)),
+      34)
       << "incorrect value for expiration.minutes, expected 34, is "
       << last_msg_->expiration.minutes;
-  EXPECT_EQ(last_msg_->expiration.month, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->expiration.month)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->expiration.month)),
+      3)
       << "incorrect value for expiration.month, expected 3, is "
       << last_msg_->expiration.month;
-  EXPECT_EQ(last_msg_->expiration.ns, 123456789)
+  EXPECT_EQ(get_as<decltype(last_msg_->expiration.ns)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->expiration.ns)),
+            123456789)
       << "incorrect value for expiration.ns, expected 123456789, is "
       << last_msg_->expiration.ns;
-  EXPECT_EQ(last_msg_->expiration.seconds, 59)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->expiration.seconds)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->expiration.seconds)),
+      59)
       << "incorrect value for expiration.seconds, expected 59, is "
       << last_msg_->expiration.seconds;
-  EXPECT_EQ(last_msg_->expiration.year, 2024)
+  EXPECT_EQ(get_as<decltype(last_msg_->expiration.year)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->expiration.year)),
+            2024)
       << "incorrect value for expiration.year, expected 2024, is "
       << last_msg_->expiration.year;
-  EXPECT_EQ(last_msg_->intermediate_certificate[0], 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[0])),
+            10)
       << "incorrect value for intermediate_certificate[0], expected 10, is "
       << last_msg_->intermediate_certificate[0];
-  EXPECT_EQ(last_msg_->intermediate_certificate[1], 11)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[1])),
+            11)
       << "incorrect value for intermediate_certificate[1], expected 11, is "
       << last_msg_->intermediate_certificate[1];
-  EXPECT_EQ(last_msg_->intermediate_certificate[2], 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[2])),
+            12)
       << "incorrect value for intermediate_certificate[2], expected 12, is "
       << last_msg_->intermediate_certificate[2];
-  EXPECT_EQ(last_msg_->intermediate_certificate[3], 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[3])),
+            13)
       << "incorrect value for intermediate_certificate[3], expected 13, is "
       << last_msg_->intermediate_certificate[3];
-  EXPECT_EQ(last_msg_->intermediate_certificate[4], 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[4])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[4])),
+            14)
       << "incorrect value for intermediate_certificate[4], expected 14, is "
       << last_msg_->intermediate_certificate[4];
-  EXPECT_EQ(last_msg_->intermediate_certificate[5], 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[5])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[5])),
+            15)
       << "incorrect value for intermediate_certificate[5], expected 15, is "
       << last_msg_->intermediate_certificate[5];
-  EXPECT_EQ(last_msg_->intermediate_certificate[6], 16)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[6])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[6])),
+            16)
       << "incorrect value for intermediate_certificate[6], expected 16, is "
       << last_msg_->intermediate_certificate[6];
-  EXPECT_EQ(last_msg_->intermediate_certificate[7], 17)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[7])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[7])),
+            17)
       << "incorrect value for intermediate_certificate[7], expected 17, is "
       << last_msg_->intermediate_certificate[7];
-  EXPECT_EQ(last_msg_->intermediate_certificate[8], 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[8])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[8])),
+            18)
       << "incorrect value for intermediate_certificate[8], expected 18, is "
       << last_msg_->intermediate_certificate[8];
-  EXPECT_EQ(last_msg_->intermediate_certificate[9], 19)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[9])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[9])),
+            19)
       << "incorrect value for intermediate_certificate[9], expected 19, is "
       << last_msg_->intermediate_certificate[9];
-  EXPECT_EQ(last_msg_->intermediate_certificate[10], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[10])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[10])),
+            0)
       << "incorrect value for intermediate_certificate[10], expected 0, is "
       << last_msg_->intermediate_certificate[10];
-  EXPECT_EQ(last_msg_->intermediate_certificate[11], 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[11])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[11])),
+            1)
       << "incorrect value for intermediate_certificate[11], expected 1, is "
       << last_msg_->intermediate_certificate[11];
-  EXPECT_EQ(last_msg_->intermediate_certificate[12], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[12])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[12])),
+            2)
       << "incorrect value for intermediate_certificate[12], expected 2, is "
       << last_msg_->intermediate_certificate[12];
-  EXPECT_EQ(last_msg_->intermediate_certificate[13], 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[13])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[13])),
+            3)
       << "incorrect value for intermediate_certificate[13], expected 3, is "
       << last_msg_->intermediate_certificate[13];
-  EXPECT_EQ(last_msg_->intermediate_certificate[14], 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[14])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[14])),
+            4)
       << "incorrect value for intermediate_certificate[14], expected 4, is "
       << last_msg_->intermediate_certificate[14];
-  EXPECT_EQ(last_msg_->intermediate_certificate[15], 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[15])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[15])),
+            5)
       << "incorrect value for intermediate_certificate[15], expected 5, is "
       << last_msg_->intermediate_certificate[15];
-  EXPECT_EQ(last_msg_->intermediate_certificate[16], 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[16])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[16])),
+            6)
       << "incorrect value for intermediate_certificate[16], expected 6, is "
       << last_msg_->intermediate_certificate[16];
-  EXPECT_EQ(last_msg_->intermediate_certificate[17], 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[17])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[17])),
+            7)
       << "incorrect value for intermediate_certificate[17], expected 7, is "
       << last_msg_->intermediate_certificate[17];
-  EXPECT_EQ(last_msg_->intermediate_certificate[18], 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[18])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[18])),
+            8)
       << "incorrect value for intermediate_certificate[18], expected 8, is "
       << last_msg_->intermediate_certificate[18];
-  EXPECT_EQ(last_msg_->intermediate_certificate[19], 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[19])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[19])),
+            9)
       << "incorrect value for intermediate_certificate[19], expected 9, is "
       << last_msg_->intermediate_certificate[19];
-  EXPECT_EQ(last_msg_->root_certificate[0], 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[0])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[0])),
+      0)
       << "incorrect value for root_certificate[0], expected 0, is "
       << last_msg_->root_certificate[0];
-  EXPECT_EQ(last_msg_->root_certificate[1], 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[1])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[1])),
+      1)
       << "incorrect value for root_certificate[1], expected 1, is "
       << last_msg_->root_certificate[1];
-  EXPECT_EQ(last_msg_->root_certificate[2], 2)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[2])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[2])),
+      2)
       << "incorrect value for root_certificate[2], expected 2, is "
       << last_msg_->root_certificate[2];
-  EXPECT_EQ(last_msg_->root_certificate[3], 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[3])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[3])),
+      3)
       << "incorrect value for root_certificate[3], expected 3, is "
       << last_msg_->root_certificate[3];
-  EXPECT_EQ(last_msg_->root_certificate[4], 4)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[4])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[4])),
+      4)
       << "incorrect value for root_certificate[4], expected 4, is "
       << last_msg_->root_certificate[4];
-  EXPECT_EQ(last_msg_->root_certificate[5], 5)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[5])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[5])),
+      5)
       << "incorrect value for root_certificate[5], expected 5, is "
       << last_msg_->root_certificate[5];
-  EXPECT_EQ(last_msg_->root_certificate[6], 6)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[6])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[6])),
+      6)
       << "incorrect value for root_certificate[6], expected 6, is "
       << last_msg_->root_certificate[6];
-  EXPECT_EQ(last_msg_->root_certificate[7], 7)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[7])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[7])),
+      7)
       << "incorrect value for root_certificate[7], expected 7, is "
       << last_msg_->root_certificate[7];
-  EXPECT_EQ(last_msg_->root_certificate[8], 8)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[8])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[8])),
+      8)
       << "incorrect value for root_certificate[8], expected 8, is "
       << last_msg_->root_certificate[8];
-  EXPECT_EQ(last_msg_->root_certificate[9], 9)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[9])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[9])),
+      9)
       << "incorrect value for root_certificate[9], expected 9, is "
       << last_msg_->root_certificate[9];
-  EXPECT_EQ(last_msg_->root_certificate[10], 10)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[10])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[10])),
+      10)
       << "incorrect value for root_certificate[10], expected 10, is "
       << last_msg_->root_certificate[10];
-  EXPECT_EQ(last_msg_->root_certificate[11], 11)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[11])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[11])),
+      11)
       << "incorrect value for root_certificate[11], expected 11, is "
       << last_msg_->root_certificate[11];
-  EXPECT_EQ(last_msg_->root_certificate[12], 12)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[12])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[12])),
+      12)
       << "incorrect value for root_certificate[12], expected 12, is "
       << last_msg_->root_certificate[12];
-  EXPECT_EQ(last_msg_->root_certificate[13], 13)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[13])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[13])),
+      13)
       << "incorrect value for root_certificate[13], expected 13, is "
       << last_msg_->root_certificate[13];
-  EXPECT_EQ(last_msg_->root_certificate[14], 14)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[14])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[14])),
+      14)
       << "incorrect value for root_certificate[14], expected 14, is "
       << last_msg_->root_certificate[14];
-  EXPECT_EQ(last_msg_->root_certificate[15], 15)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[15])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[15])),
+      15)
       << "incorrect value for root_certificate[15], expected 15, is "
       << last_msg_->root_certificate[15];
-  EXPECT_EQ(last_msg_->root_certificate[16], 16)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[16])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[16])),
+      16)
       << "incorrect value for root_certificate[16], expected 16, is "
       << last_msg_->root_certificate[16];
-  EXPECT_EQ(last_msg_->root_certificate[17], 17)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[17])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[17])),
+      17)
       << "incorrect value for root_certificate[17], expected 17, is "
       << last_msg_->root_certificate[17];
-  EXPECT_EQ(last_msg_->root_certificate[18], 18)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[18])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[18])),
+      18)
       << "incorrect value for root_certificate[18], expected 18, is "
       << last_msg_->root_certificate[18];
-  EXPECT_EQ(last_msg_->root_certificate[19], 19)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[19])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[19])),
+      19)
       << "incorrect value for root_certificate[19], expected 19, is "
       << last_msg_->root_certificate[19];
-  EXPECT_EQ(last_msg_->signature.data[0], 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[0])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[0])),
+      0)
       << "incorrect value for signature.data[0], expected 0, is "
       << last_msg_->signature.data[0];
-  EXPECT_EQ(last_msg_->signature.data[1], 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[1])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[1])),
+      1)
       << "incorrect value for signature.data[1], expected 1, is "
       << last_msg_->signature.data[1];
-  EXPECT_EQ(last_msg_->signature.data[2], 2)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[2])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[2])),
+      2)
       << "incorrect value for signature.data[2], expected 2, is "
       << last_msg_->signature.data[2];
-  EXPECT_EQ(last_msg_->signature.data[3], 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[3])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[3])),
+      3)
       << "incorrect value for signature.data[3], expected 3, is "
       << last_msg_->signature.data[3];
-  EXPECT_EQ(last_msg_->signature.data[4], 4)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[4])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[4])),
+      4)
       << "incorrect value for signature.data[4], expected 4, is "
       << last_msg_->signature.data[4];
-  EXPECT_EQ(last_msg_->signature.data[5], 5)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[5])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[5])),
+      5)
       << "incorrect value for signature.data[5], expected 5, is "
       << last_msg_->signature.data[5];
-  EXPECT_EQ(last_msg_->signature.data[6], 6)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[6])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[6])),
+      6)
       << "incorrect value for signature.data[6], expected 6, is "
       << last_msg_->signature.data[6];
-  EXPECT_EQ(last_msg_->signature.data[7], 7)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[7])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[7])),
+      7)
       << "incorrect value for signature.data[7], expected 7, is "
       << last_msg_->signature.data[7];
-  EXPECT_EQ(last_msg_->signature.data[8], 8)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[8])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[8])),
+      8)
       << "incorrect value for signature.data[8], expected 8, is "
       << last_msg_->signature.data[8];
-  EXPECT_EQ(last_msg_->signature.data[9], 9)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[9])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[9])),
+      9)
       << "incorrect value for signature.data[9], expected 9, is "
       << last_msg_->signature.data[9];
-  EXPECT_EQ(last_msg_->signature.data[10], 10)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[10])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[10])),
+      10)
       << "incorrect value for signature.data[10], expected 10, is "
       << last_msg_->signature.data[10];
-  EXPECT_EQ(last_msg_->signature.data[11], 11)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[11])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[11])),
+      11)
       << "incorrect value for signature.data[11], expected 11, is "
       << last_msg_->signature.data[11];
-  EXPECT_EQ(last_msg_->signature.data[12], 12)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[12])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[12])),
+      12)
       << "incorrect value for signature.data[12], expected 12, is "
       << last_msg_->signature.data[12];
-  EXPECT_EQ(last_msg_->signature.data[13], 13)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[13])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[13])),
+      13)
       << "incorrect value for signature.data[13], expected 13, is "
       << last_msg_->signature.data[13];
-  EXPECT_EQ(last_msg_->signature.data[14], 14)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[14])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[14])),
+      14)
       << "incorrect value for signature.data[14], expected 14, is "
       << last_msg_->signature.data[14];
-  EXPECT_EQ(last_msg_->signature.data[15], 15)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[15])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[15])),
+      15)
       << "incorrect value for signature.data[15], expected 15, is "
       << last_msg_->signature.data[15];
-  EXPECT_EQ(last_msg_->signature.data[16], 16)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[16])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[16])),
+      16)
       << "incorrect value for signature.data[16], expected 16, is "
       << last_msg_->signature.data[16];
-  EXPECT_EQ(last_msg_->signature.data[17], 17)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[17])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[17])),
+      17)
       << "incorrect value for signature.data[17], expected 17, is "
       << last_msg_->signature.data[17];
-  EXPECT_EQ(last_msg_->signature.data[18], 18)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[18])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[18])),
+      18)
       << "incorrect value for signature.data[18], expected 18, is "
       << last_msg_->signature.data[18];
-  EXPECT_EQ(last_msg_->signature.data[19], 19)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[19])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[19])),
+      19)
       << "incorrect value for signature.data[19], expected 19, is "
       << last_msg_->signature.data[19];
-  EXPECT_EQ(last_msg_->signature.data[20], 20)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[20])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[20])),
+      20)
       << "incorrect value for signature.data[20], expected 20, is "
       << last_msg_->signature.data[20];
-  EXPECT_EQ(last_msg_->signature.data[21], 21)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[21])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[21])),
+      21)
       << "incorrect value for signature.data[21], expected 21, is "
       << last_msg_->signature.data[21];
-  EXPECT_EQ(last_msg_->signature.data[22], 22)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[22])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[22])),
+      22)
       << "incorrect value for signature.data[22], expected 22, is "
       << last_msg_->signature.data[22];
-  EXPECT_EQ(last_msg_->signature.data[23], 23)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[23])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[23])),
+      23)
       << "incorrect value for signature.data[23], expected 23, is "
       << last_msg_->signature.data[23];
-  EXPECT_EQ(last_msg_->signature.data[24], 24)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[24])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[24])),
+      24)
       << "incorrect value for signature.data[24], expected 24, is "
       << last_msg_->signature.data[24];
-  EXPECT_EQ(last_msg_->signature.data[25], 25)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[25])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[25])),
+      25)
       << "incorrect value for signature.data[25], expected 25, is "
       << last_msg_->signature.data[25];
-  EXPECT_EQ(last_msg_->signature.data[26], 26)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[26])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[26])),
+      26)
       << "incorrect value for signature.data[26], expected 26, is "
       << last_msg_->signature.data[26];
-  EXPECT_EQ(last_msg_->signature.data[27], 27)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[27])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[27])),
+      27)
       << "incorrect value for signature.data[27], expected 27, is "
       << last_msg_->signature.data[27];
-  EXPECT_EQ(last_msg_->signature.data[28], 28)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[28])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[28])),
+      28)
       << "incorrect value for signature.data[28], expected 28, is "
       << last_msg_->signature.data[28];
-  EXPECT_EQ(last_msg_->signature.data[29], 29)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[29])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[29])),
+      29)
       << "incorrect value for signature.data[29], expected 29, is "
       << last_msg_->signature.data[29];
-  EXPECT_EQ(last_msg_->signature.data[30], 30)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[30])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[30])),
+      30)
       << "incorrect value for signature.data[30], expected 30, is "
       << last_msg_->signature.data[30];
-  EXPECT_EQ(last_msg_->signature.data[31], 31)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[31])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[31])),
+      31)
       << "incorrect value for signature.data[31], expected 31, is "
       << last_msg_->signature.data[31];
-  EXPECT_EQ(last_msg_->signature.data[32], 32)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[32])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[32])),
+      32)
       << "incorrect value for signature.data[32], expected 32, is "
       << last_msg_->signature.data[32];
-  EXPECT_EQ(last_msg_->signature.data[33], 33)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[33])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[33])),
+      33)
       << "incorrect value for signature.data[33], expected 33, is "
       << last_msg_->signature.data[33];
-  EXPECT_EQ(last_msg_->signature.data[34], 34)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[34])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[34])),
+      34)
       << "incorrect value for signature.data[34], expected 34, is "
       << last_msg_->signature.data[34];
-  EXPECT_EQ(last_msg_->signature.data[35], 35)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[35])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[35])),
+      35)
       << "incorrect value for signature.data[35], expected 35, is "
       << last_msg_->signature.data[35];
-  EXPECT_EQ(last_msg_->signature.data[36], 36)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[36])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[36])),
+      36)
       << "incorrect value for signature.data[36], expected 36, is "
       << last_msg_->signature.data[36];
-  EXPECT_EQ(last_msg_->signature.data[37], 37)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[37])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[37])),
+      37)
       << "incorrect value for signature.data[37], expected 37, is "
       << last_msg_->signature.data[37];
-  EXPECT_EQ(last_msg_->signature.data[38], 38)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[38])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[38])),
+      38)
       << "incorrect value for signature.data[38], expected 38, is "
       << last_msg_->signature.data[38];
-  EXPECT_EQ(last_msg_->signature.data[39], 39)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[39])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[39])),
+      39)
       << "incorrect value for signature.data[39], expected 39, is "
       << last_msg_->signature.data[39];
-  EXPECT_EQ(last_msg_->signature.data[40], 40)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[40])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[40])),
+      40)
       << "incorrect value for signature.data[40], expected 40, is "
       << last_msg_->signature.data[40];
-  EXPECT_EQ(last_msg_->signature.data[41], 41)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[41])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[41])),
+      41)
       << "incorrect value for signature.data[41], expected 41, is "
       << last_msg_->signature.data[41];
-  EXPECT_EQ(last_msg_->signature.data[42], 42)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[42])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[42])),
+      42)
       << "incorrect value for signature.data[42], expected 42, is "
       << last_msg_->signature.data[42];
-  EXPECT_EQ(last_msg_->signature.data[43], 43)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[43])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[43])),
+      43)
       << "incorrect value for signature.data[43], expected 43, is "
       << last_msg_->signature.data[43];
-  EXPECT_EQ(last_msg_->signature.data[44], 44)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[44])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[44])),
+      44)
       << "incorrect value for signature.data[44], expected 44, is "
       << last_msg_->signature.data[44];
-  EXPECT_EQ(last_msg_->signature.data[45], 45)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[45])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[45])),
+      45)
       << "incorrect value for signature.data[45], expected 45, is "
       << last_msg_->signature.data[45];
-  EXPECT_EQ(last_msg_->signature.data[46], 46)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[46])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[46])),
+      46)
       << "incorrect value for signature.data[46], expected 46, is "
       << last_msg_->signature.data[46];
-  EXPECT_EQ(last_msg_->signature.data[47], 47)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[47])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[47])),
+      47)
       << "incorrect value for signature.data[47], expected 47, is "
       << last_msg_->signature.data[47];
-  EXPECT_EQ(last_msg_->signature.data[48], 48)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[48])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[48])),
+      48)
       << "incorrect value for signature.data[48], expected 48, is "
       << last_msg_->signature.data[48];
-  EXPECT_EQ(last_msg_->signature.data[49], 49)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[49])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[49])),
+      49)
       << "incorrect value for signature.data[49], expected 49, is "
       << last_msg_->signature.data[49];
-  EXPECT_EQ(last_msg_->signature.data[50], 50)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[50])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[50])),
+      50)
       << "incorrect value for signature.data[50], expected 50, is "
       << last_msg_->signature.data[50];
-  EXPECT_EQ(last_msg_->signature.data[51], 51)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[51])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[51])),
+      51)
       << "incorrect value for signature.data[51], expected 51, is "
       << last_msg_->signature.data[51];
-  EXPECT_EQ(last_msg_->signature.data[52], 52)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[52])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[52])),
+      52)
       << "incorrect value for signature.data[52], expected 52, is "
       << last_msg_->signature.data[52];
-  EXPECT_EQ(last_msg_->signature.data[53], 53)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[53])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[53])),
+      53)
       << "incorrect value for signature.data[53], expected 53, is "
       << last_msg_->signature.data[53];
-  EXPECT_EQ(last_msg_->signature.data[54], 54)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[54])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[54])),
+      54)
       << "incorrect value for signature.data[54], expected 54, is "
       << last_msg_->signature.data[54];
-  EXPECT_EQ(last_msg_->signature.data[55], 55)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[55])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[55])),
+      55)
       << "incorrect value for signature.data[55], expected 55, is "
       << last_msg_->signature.data[55];
-  EXPECT_EQ(last_msg_->signature.data[56], 56)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[56])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[56])),
+      56)
       << "incorrect value for signature.data[56], expected 56, is "
       << last_msg_->signature.data[56];
-  EXPECT_EQ(last_msg_->signature.data[57], 57)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[57])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[57])),
+      57)
       << "incorrect value for signature.data[57], expected 57, is "
       << last_msg_->signature.data[57];
-  EXPECT_EQ(last_msg_->signature.data[58], 58)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[58])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[58])),
+      58)
       << "incorrect value for signature.data[58], expected 58, is "
       << last_msg_->signature.data[58];
-  EXPECT_EQ(last_msg_->signature.data[59], 59)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[59])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[59])),
+      59)
       << "incorrect value for signature.data[59], expected 59, is "
       << last_msg_->signature.data[59];
-  EXPECT_EQ(last_msg_->signature.data[60], 60)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[60])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[60])),
+      60)
       << "incorrect value for signature.data[60], expected 60, is "
       << last_msg_->signature.data[60];
-  EXPECT_EQ(last_msg_->signature.data[61], 61)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[61])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[61])),
+      61)
       << "incorrect value for signature.data[61], expected 61, is "
       << last_msg_->signature.data[61];
-  EXPECT_EQ(last_msg_->signature.data[62], 62)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[62])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[62])),
+      62)
       << "incorrect value for signature.data[62], expected 62, is "
       << last_msg_->signature.data[62];
-  EXPECT_EQ(last_msg_->signature.data[63], 63)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[63])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[63])),
+      63)
       << "incorrect value for signature.data[63], expected 63, is "
       << last_msg_->signature.data[63];
-  EXPECT_EQ(last_msg_->signature.data[64], 64)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[64])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[64])),
+      64)
       << "incorrect value for signature.data[64], expected 64, is "
       << last_msg_->signature.data[64];
-  EXPECT_EQ(last_msg_->signature.data[65], 65)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[65])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[65])),
+      65)
       << "incorrect value for signature.data[65], expected 65, is "
       << last_msg_->signature.data[65];
-  EXPECT_EQ(last_msg_->signature.data[66], 66)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[66])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[66])),
+      66)
       << "incorrect value for signature.data[66], expected 66, is "
       << last_msg_->signature.data[66];
-  EXPECT_EQ(last_msg_->signature.data[67], 67)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[67])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[67])),
+      67)
       << "incorrect value for signature.data[67], expected 67, is "
       << last_msg_->signature.data[67];
-  EXPECT_EQ(last_msg_->signature.data[68], 68)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[68])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[68])),
+      68)
       << "incorrect value for signature.data[68], expected 68, is "
       << last_msg_->signature.data[68];
-  EXPECT_EQ(last_msg_->signature.data[69], 69)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[69])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[69])),
+      69)
       << "incorrect value for signature.data[69], expected 69, is "
       << last_msg_->signature.data[69];
-  EXPECT_EQ(last_msg_->signature.data[70], 70)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[70])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[70])),
+      70)
       << "incorrect value for signature.data[70], expected 70, is "
       << last_msg_->signature.data[70];
-  EXPECT_EQ(last_msg_->signature.data[71], 71)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[71])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[71])),
+      71)
       << "incorrect value for signature.data[71], expected 71, is "
       << last_msg_->signature.data[71];
-  EXPECT_EQ(last_msg_->signature.len, 72)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature.len)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature.len)),
+            72)
       << "incorrect value for signature.len, expected 72, is "
       << last_msg_->signature.len;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_signing_MsgCertificateChainDep.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_signing_MsgCertificateChainDep.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/signing.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_signing_MsgCertificateChainDep0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -806,397 +813,723 @@ TEST_F(Test_legacy_auto_check_sbp_signing_MsgCertificateChainDep0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->corrections_certificate[0], 20)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[0])),
+            20)
       << "incorrect value for corrections_certificate[0], expected 20, is "
       << last_msg_->corrections_certificate[0];
-  EXPECT_EQ(last_msg_->corrections_certificate[1], 21)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[1])),
+            21)
       << "incorrect value for corrections_certificate[1], expected 21, is "
       << last_msg_->corrections_certificate[1];
-  EXPECT_EQ(last_msg_->corrections_certificate[2], 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[2])),
+            22)
       << "incorrect value for corrections_certificate[2], expected 22, is "
       << last_msg_->corrections_certificate[2];
-  EXPECT_EQ(last_msg_->corrections_certificate[3], 23)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[3])),
+            23)
       << "incorrect value for corrections_certificate[3], expected 23, is "
       << last_msg_->corrections_certificate[3];
-  EXPECT_EQ(last_msg_->corrections_certificate[4], 24)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[4])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[4])),
+            24)
       << "incorrect value for corrections_certificate[4], expected 24, is "
       << last_msg_->corrections_certificate[4];
-  EXPECT_EQ(last_msg_->corrections_certificate[5], 25)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[5])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[5])),
+            25)
       << "incorrect value for corrections_certificate[5], expected 25, is "
       << last_msg_->corrections_certificate[5];
-  EXPECT_EQ(last_msg_->corrections_certificate[6], 26)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[6])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[6])),
+            26)
       << "incorrect value for corrections_certificate[6], expected 26, is "
       << last_msg_->corrections_certificate[6];
-  EXPECT_EQ(last_msg_->corrections_certificate[7], 27)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[7])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[7])),
+            27)
       << "incorrect value for corrections_certificate[7], expected 27, is "
       << last_msg_->corrections_certificate[7];
-  EXPECT_EQ(last_msg_->corrections_certificate[8], 28)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[8])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[8])),
+            28)
       << "incorrect value for corrections_certificate[8], expected 28, is "
       << last_msg_->corrections_certificate[8];
-  EXPECT_EQ(last_msg_->corrections_certificate[9], 29)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[9])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[9])),
+            29)
       << "incorrect value for corrections_certificate[9], expected 29, is "
       << last_msg_->corrections_certificate[9];
-  EXPECT_EQ(last_msg_->corrections_certificate[10], 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[10])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[10])),
+            10)
       << "incorrect value for corrections_certificate[10], expected 10, is "
       << last_msg_->corrections_certificate[10];
-  EXPECT_EQ(last_msg_->corrections_certificate[11], 11)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[11])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[11])),
+            11)
       << "incorrect value for corrections_certificate[11], expected 11, is "
       << last_msg_->corrections_certificate[11];
-  EXPECT_EQ(last_msg_->corrections_certificate[12], 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[12])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[12])),
+            12)
       << "incorrect value for corrections_certificate[12], expected 12, is "
       << last_msg_->corrections_certificate[12];
-  EXPECT_EQ(last_msg_->corrections_certificate[13], 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[13])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[13])),
+            13)
       << "incorrect value for corrections_certificate[13], expected 13, is "
       << last_msg_->corrections_certificate[13];
-  EXPECT_EQ(last_msg_->corrections_certificate[14], 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[14])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[14])),
+            14)
       << "incorrect value for corrections_certificate[14], expected 14, is "
       << last_msg_->corrections_certificate[14];
-  EXPECT_EQ(last_msg_->corrections_certificate[15], 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[15])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[15])),
+            15)
       << "incorrect value for corrections_certificate[15], expected 15, is "
       << last_msg_->corrections_certificate[15];
-  EXPECT_EQ(last_msg_->corrections_certificate[16], 16)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[16])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[16])),
+            16)
       << "incorrect value for corrections_certificate[16], expected 16, is "
       << last_msg_->corrections_certificate[16];
-  EXPECT_EQ(last_msg_->corrections_certificate[17], 17)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[17])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[17])),
+            17)
       << "incorrect value for corrections_certificate[17], expected 17, is "
       << last_msg_->corrections_certificate[17];
-  EXPECT_EQ(last_msg_->corrections_certificate[18], 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[18])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[18])),
+            18)
       << "incorrect value for corrections_certificate[18], expected 18, is "
       << last_msg_->corrections_certificate[18];
-  EXPECT_EQ(last_msg_->corrections_certificate[19], 19)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrections_certificate[19])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->corrections_certificate[19])),
+            19)
       << "incorrect value for corrections_certificate[19], expected 19, is "
       << last_msg_->corrections_certificate[19];
-  EXPECT_EQ(last_msg_->expiration.day, 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->expiration.day)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->expiration.day)),
+            30)
       << "incorrect value for expiration.day, expected 30, is "
       << last_msg_->expiration.day;
-  EXPECT_EQ(last_msg_->expiration.hours, 12)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->expiration.hours)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->expiration.hours)),
+      12)
       << "incorrect value for expiration.hours, expected 12, is "
       << last_msg_->expiration.hours;
-  EXPECT_EQ(last_msg_->expiration.minutes, 34)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->expiration.minutes)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->expiration.minutes)),
+      34)
       << "incorrect value for expiration.minutes, expected 34, is "
       << last_msg_->expiration.minutes;
-  EXPECT_EQ(last_msg_->expiration.month, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->expiration.month)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->expiration.month)),
+      3)
       << "incorrect value for expiration.month, expected 3, is "
       << last_msg_->expiration.month;
-  EXPECT_EQ(last_msg_->expiration.ns, 123456789)
+  EXPECT_EQ(get_as<decltype(last_msg_->expiration.ns)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->expiration.ns)),
+            123456789)
       << "incorrect value for expiration.ns, expected 123456789, is "
       << last_msg_->expiration.ns;
-  EXPECT_EQ(last_msg_->expiration.seconds, 59)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->expiration.seconds)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->expiration.seconds)),
+      59)
       << "incorrect value for expiration.seconds, expected 59, is "
       << last_msg_->expiration.seconds;
-  EXPECT_EQ(last_msg_->expiration.year, 2024)
+  EXPECT_EQ(get_as<decltype(last_msg_->expiration.year)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->expiration.year)),
+            2024)
       << "incorrect value for expiration.year, expected 2024, is "
       << last_msg_->expiration.year;
-  EXPECT_EQ(last_msg_->intermediate_certificate[0], 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[0])),
+            10)
       << "incorrect value for intermediate_certificate[0], expected 10, is "
       << last_msg_->intermediate_certificate[0];
-  EXPECT_EQ(last_msg_->intermediate_certificate[1], 11)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[1])),
+            11)
       << "incorrect value for intermediate_certificate[1], expected 11, is "
       << last_msg_->intermediate_certificate[1];
-  EXPECT_EQ(last_msg_->intermediate_certificate[2], 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[2])),
+            12)
       << "incorrect value for intermediate_certificate[2], expected 12, is "
       << last_msg_->intermediate_certificate[2];
-  EXPECT_EQ(last_msg_->intermediate_certificate[3], 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[3])),
+            13)
       << "incorrect value for intermediate_certificate[3], expected 13, is "
       << last_msg_->intermediate_certificate[3];
-  EXPECT_EQ(last_msg_->intermediate_certificate[4], 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[4])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[4])),
+            14)
       << "incorrect value for intermediate_certificate[4], expected 14, is "
       << last_msg_->intermediate_certificate[4];
-  EXPECT_EQ(last_msg_->intermediate_certificate[5], 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[5])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[5])),
+            15)
       << "incorrect value for intermediate_certificate[5], expected 15, is "
       << last_msg_->intermediate_certificate[5];
-  EXPECT_EQ(last_msg_->intermediate_certificate[6], 16)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[6])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[6])),
+            16)
       << "incorrect value for intermediate_certificate[6], expected 16, is "
       << last_msg_->intermediate_certificate[6];
-  EXPECT_EQ(last_msg_->intermediate_certificate[7], 17)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[7])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[7])),
+            17)
       << "incorrect value for intermediate_certificate[7], expected 17, is "
       << last_msg_->intermediate_certificate[7];
-  EXPECT_EQ(last_msg_->intermediate_certificate[8], 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[8])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[8])),
+            18)
       << "incorrect value for intermediate_certificate[8], expected 18, is "
       << last_msg_->intermediate_certificate[8];
-  EXPECT_EQ(last_msg_->intermediate_certificate[9], 19)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[9])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[9])),
+            19)
       << "incorrect value for intermediate_certificate[9], expected 19, is "
       << last_msg_->intermediate_certificate[9];
-  EXPECT_EQ(last_msg_->intermediate_certificate[10], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[10])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[10])),
+            0)
       << "incorrect value for intermediate_certificate[10], expected 0, is "
       << last_msg_->intermediate_certificate[10];
-  EXPECT_EQ(last_msg_->intermediate_certificate[11], 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[11])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[11])),
+            1)
       << "incorrect value for intermediate_certificate[11], expected 1, is "
       << last_msg_->intermediate_certificate[11];
-  EXPECT_EQ(last_msg_->intermediate_certificate[12], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[12])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[12])),
+            2)
       << "incorrect value for intermediate_certificate[12], expected 2, is "
       << last_msg_->intermediate_certificate[12];
-  EXPECT_EQ(last_msg_->intermediate_certificate[13], 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[13])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[13])),
+            3)
       << "incorrect value for intermediate_certificate[13], expected 3, is "
       << last_msg_->intermediate_certificate[13];
-  EXPECT_EQ(last_msg_->intermediate_certificate[14], 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[14])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[14])),
+            4)
       << "incorrect value for intermediate_certificate[14], expected 4, is "
       << last_msg_->intermediate_certificate[14];
-  EXPECT_EQ(last_msg_->intermediate_certificate[15], 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[15])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[15])),
+            5)
       << "incorrect value for intermediate_certificate[15], expected 5, is "
       << last_msg_->intermediate_certificate[15];
-  EXPECT_EQ(last_msg_->intermediate_certificate[16], 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[16])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[16])),
+            6)
       << "incorrect value for intermediate_certificate[16], expected 6, is "
       << last_msg_->intermediate_certificate[16];
-  EXPECT_EQ(last_msg_->intermediate_certificate[17], 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[17])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[17])),
+            7)
       << "incorrect value for intermediate_certificate[17], expected 7, is "
       << last_msg_->intermediate_certificate[17];
-  EXPECT_EQ(last_msg_->intermediate_certificate[18], 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[18])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[18])),
+            8)
       << "incorrect value for intermediate_certificate[18], expected 8, is "
       << last_msg_->intermediate_certificate[18];
-  EXPECT_EQ(last_msg_->intermediate_certificate[19], 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->intermediate_certificate[19])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->intermediate_certificate[19])),
+            9)
       << "incorrect value for intermediate_certificate[19], expected 9, is "
       << last_msg_->intermediate_certificate[19];
-  EXPECT_EQ(last_msg_->root_certificate[0], 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[0])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[0])),
+      0)
       << "incorrect value for root_certificate[0], expected 0, is "
       << last_msg_->root_certificate[0];
-  EXPECT_EQ(last_msg_->root_certificate[1], 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[1])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[1])),
+      1)
       << "incorrect value for root_certificate[1], expected 1, is "
       << last_msg_->root_certificate[1];
-  EXPECT_EQ(last_msg_->root_certificate[2], 2)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[2])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[2])),
+      2)
       << "incorrect value for root_certificate[2], expected 2, is "
       << last_msg_->root_certificate[2];
-  EXPECT_EQ(last_msg_->root_certificate[3], 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[3])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[3])),
+      3)
       << "incorrect value for root_certificate[3], expected 3, is "
       << last_msg_->root_certificate[3];
-  EXPECT_EQ(last_msg_->root_certificate[4], 4)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[4])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[4])),
+      4)
       << "incorrect value for root_certificate[4], expected 4, is "
       << last_msg_->root_certificate[4];
-  EXPECT_EQ(last_msg_->root_certificate[5], 5)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[5])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[5])),
+      5)
       << "incorrect value for root_certificate[5], expected 5, is "
       << last_msg_->root_certificate[5];
-  EXPECT_EQ(last_msg_->root_certificate[6], 6)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[6])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[6])),
+      6)
       << "incorrect value for root_certificate[6], expected 6, is "
       << last_msg_->root_certificate[6];
-  EXPECT_EQ(last_msg_->root_certificate[7], 7)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[7])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[7])),
+      7)
       << "incorrect value for root_certificate[7], expected 7, is "
       << last_msg_->root_certificate[7];
-  EXPECT_EQ(last_msg_->root_certificate[8], 8)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[8])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[8])),
+      8)
       << "incorrect value for root_certificate[8], expected 8, is "
       << last_msg_->root_certificate[8];
-  EXPECT_EQ(last_msg_->root_certificate[9], 9)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[9])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[9])),
+      9)
       << "incorrect value for root_certificate[9], expected 9, is "
       << last_msg_->root_certificate[9];
-  EXPECT_EQ(last_msg_->root_certificate[10], 10)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[10])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[10])),
+      10)
       << "incorrect value for root_certificate[10], expected 10, is "
       << last_msg_->root_certificate[10];
-  EXPECT_EQ(last_msg_->root_certificate[11], 11)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[11])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[11])),
+      11)
       << "incorrect value for root_certificate[11], expected 11, is "
       << last_msg_->root_certificate[11];
-  EXPECT_EQ(last_msg_->root_certificate[12], 12)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[12])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[12])),
+      12)
       << "incorrect value for root_certificate[12], expected 12, is "
       << last_msg_->root_certificate[12];
-  EXPECT_EQ(last_msg_->root_certificate[13], 13)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[13])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[13])),
+      13)
       << "incorrect value for root_certificate[13], expected 13, is "
       << last_msg_->root_certificate[13];
-  EXPECT_EQ(last_msg_->root_certificate[14], 14)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[14])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[14])),
+      14)
       << "incorrect value for root_certificate[14], expected 14, is "
       << last_msg_->root_certificate[14];
-  EXPECT_EQ(last_msg_->root_certificate[15], 15)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[15])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[15])),
+      15)
       << "incorrect value for root_certificate[15], expected 15, is "
       << last_msg_->root_certificate[15];
-  EXPECT_EQ(last_msg_->root_certificate[16], 16)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[16])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[16])),
+      16)
       << "incorrect value for root_certificate[16], expected 16, is "
       << last_msg_->root_certificate[16];
-  EXPECT_EQ(last_msg_->root_certificate[17], 17)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[17])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[17])),
+      17)
       << "incorrect value for root_certificate[17], expected 17, is "
       << last_msg_->root_certificate[17];
-  EXPECT_EQ(last_msg_->root_certificate[18], 18)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[18])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[18])),
+      18)
       << "incorrect value for root_certificate[18], expected 18, is "
       << last_msg_->root_certificate[18];
-  EXPECT_EQ(last_msg_->root_certificate[19], 19)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->root_certificate[19])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->root_certificate[19])),
+      19)
       << "incorrect value for root_certificate[19], expected 19, is "
       << last_msg_->root_certificate[19];
-  EXPECT_EQ(last_msg_->signature[0], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[0])),
+            0)
       << "incorrect value for signature[0], expected 0, is "
       << last_msg_->signature[0];
-  EXPECT_EQ(last_msg_->signature[1], 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[1])),
+            1)
       << "incorrect value for signature[1], expected 1, is "
       << last_msg_->signature[1];
-  EXPECT_EQ(last_msg_->signature[2], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[2])),
+            2)
       << "incorrect value for signature[2], expected 2, is "
       << last_msg_->signature[2];
-  EXPECT_EQ(last_msg_->signature[3], 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[3])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[3])),
+            3)
       << "incorrect value for signature[3], expected 3, is "
       << last_msg_->signature[3];
-  EXPECT_EQ(last_msg_->signature[4], 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[4])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[4])),
+            4)
       << "incorrect value for signature[4], expected 4, is "
       << last_msg_->signature[4];
-  EXPECT_EQ(last_msg_->signature[5], 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[5])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[5])),
+            5)
       << "incorrect value for signature[5], expected 5, is "
       << last_msg_->signature[5];
-  EXPECT_EQ(last_msg_->signature[6], 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[6])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[6])),
+            6)
       << "incorrect value for signature[6], expected 6, is "
       << last_msg_->signature[6];
-  EXPECT_EQ(last_msg_->signature[7], 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[7])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[7])),
+            7)
       << "incorrect value for signature[7], expected 7, is "
       << last_msg_->signature[7];
-  EXPECT_EQ(last_msg_->signature[8], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[8])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[8])),
+            0)
       << "incorrect value for signature[8], expected 0, is "
       << last_msg_->signature[8];
-  EXPECT_EQ(last_msg_->signature[9], 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[9])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[9])),
+            1)
       << "incorrect value for signature[9], expected 1, is "
       << last_msg_->signature[9];
-  EXPECT_EQ(last_msg_->signature[10], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[10])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[10])),
+            2)
       << "incorrect value for signature[10], expected 2, is "
       << last_msg_->signature[10];
-  EXPECT_EQ(last_msg_->signature[11], 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[11])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[11])),
+            3)
       << "incorrect value for signature[11], expected 3, is "
       << last_msg_->signature[11];
-  EXPECT_EQ(last_msg_->signature[12], 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[12])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[12])),
+            4)
       << "incorrect value for signature[12], expected 4, is "
       << last_msg_->signature[12];
-  EXPECT_EQ(last_msg_->signature[13], 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[13])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[13])),
+            5)
       << "incorrect value for signature[13], expected 5, is "
       << last_msg_->signature[13];
-  EXPECT_EQ(last_msg_->signature[14], 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[14])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[14])),
+            6)
       << "incorrect value for signature[14], expected 6, is "
       << last_msg_->signature[14];
-  EXPECT_EQ(last_msg_->signature[15], 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[15])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[15])),
+            7)
       << "incorrect value for signature[15], expected 7, is "
       << last_msg_->signature[15];
-  EXPECT_EQ(last_msg_->signature[16], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[16])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[16])),
+            0)
       << "incorrect value for signature[16], expected 0, is "
       << last_msg_->signature[16];
-  EXPECT_EQ(last_msg_->signature[17], 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[17])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[17])),
+            1)
       << "incorrect value for signature[17], expected 1, is "
       << last_msg_->signature[17];
-  EXPECT_EQ(last_msg_->signature[18], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[18])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[18])),
+            2)
       << "incorrect value for signature[18], expected 2, is "
       << last_msg_->signature[18];
-  EXPECT_EQ(last_msg_->signature[19], 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[19])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[19])),
+            3)
       << "incorrect value for signature[19], expected 3, is "
       << last_msg_->signature[19];
-  EXPECT_EQ(last_msg_->signature[20], 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[20])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[20])),
+            4)
       << "incorrect value for signature[20], expected 4, is "
       << last_msg_->signature[20];
-  EXPECT_EQ(last_msg_->signature[21], 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[21])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[21])),
+            5)
       << "incorrect value for signature[21], expected 5, is "
       << last_msg_->signature[21];
-  EXPECT_EQ(last_msg_->signature[22], 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[22])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[22])),
+            6)
       << "incorrect value for signature[22], expected 6, is "
       << last_msg_->signature[22];
-  EXPECT_EQ(last_msg_->signature[23], 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[23])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[23])),
+            7)
       << "incorrect value for signature[23], expected 7, is "
       << last_msg_->signature[23];
-  EXPECT_EQ(last_msg_->signature[24], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[24])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[24])),
+            0)
       << "incorrect value for signature[24], expected 0, is "
       << last_msg_->signature[24];
-  EXPECT_EQ(last_msg_->signature[25], 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[25])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[25])),
+            1)
       << "incorrect value for signature[25], expected 1, is "
       << last_msg_->signature[25];
-  EXPECT_EQ(last_msg_->signature[26], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[26])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[26])),
+            2)
       << "incorrect value for signature[26], expected 2, is "
       << last_msg_->signature[26];
-  EXPECT_EQ(last_msg_->signature[27], 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[27])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[27])),
+            3)
       << "incorrect value for signature[27], expected 3, is "
       << last_msg_->signature[27];
-  EXPECT_EQ(last_msg_->signature[28], 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[28])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[28])),
+            4)
       << "incorrect value for signature[28], expected 4, is "
       << last_msg_->signature[28];
-  EXPECT_EQ(last_msg_->signature[29], 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[29])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[29])),
+            5)
       << "incorrect value for signature[29], expected 5, is "
       << last_msg_->signature[29];
-  EXPECT_EQ(last_msg_->signature[30], 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[30])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[30])),
+            6)
       << "incorrect value for signature[30], expected 6, is "
       << last_msg_->signature[30];
-  EXPECT_EQ(last_msg_->signature[31], 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[31])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[31])),
+            7)
       << "incorrect value for signature[31], expected 7, is "
       << last_msg_->signature[31];
-  EXPECT_EQ(last_msg_->signature[32], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[32])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[32])),
+            0)
       << "incorrect value for signature[32], expected 0, is "
       << last_msg_->signature[32];
-  EXPECT_EQ(last_msg_->signature[33], 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[33])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[33])),
+            1)
       << "incorrect value for signature[33], expected 1, is "
       << last_msg_->signature[33];
-  EXPECT_EQ(last_msg_->signature[34], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[34])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[34])),
+            2)
       << "incorrect value for signature[34], expected 2, is "
       << last_msg_->signature[34];
-  EXPECT_EQ(last_msg_->signature[35], 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[35])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[35])),
+            3)
       << "incorrect value for signature[35], expected 3, is "
       << last_msg_->signature[35];
-  EXPECT_EQ(last_msg_->signature[36], 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[36])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[36])),
+            4)
       << "incorrect value for signature[36], expected 4, is "
       << last_msg_->signature[36];
-  EXPECT_EQ(last_msg_->signature[37], 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[37])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[37])),
+            5)
       << "incorrect value for signature[37], expected 5, is "
       << last_msg_->signature[37];
-  EXPECT_EQ(last_msg_->signature[38], 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[38])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[38])),
+            6)
       << "incorrect value for signature[38], expected 6, is "
       << last_msg_->signature[38];
-  EXPECT_EQ(last_msg_->signature[39], 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[39])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[39])),
+            7)
       << "incorrect value for signature[39], expected 7, is "
       << last_msg_->signature[39];
-  EXPECT_EQ(last_msg_->signature[40], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[40])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[40])),
+            0)
       << "incorrect value for signature[40], expected 0, is "
       << last_msg_->signature[40];
-  EXPECT_EQ(last_msg_->signature[41], 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[41])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[41])),
+            1)
       << "incorrect value for signature[41], expected 1, is "
       << last_msg_->signature[41];
-  EXPECT_EQ(last_msg_->signature[42], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[42])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[42])),
+            2)
       << "incorrect value for signature[42], expected 2, is "
       << last_msg_->signature[42];
-  EXPECT_EQ(last_msg_->signature[43], 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[43])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[43])),
+            3)
       << "incorrect value for signature[43], expected 3, is "
       << last_msg_->signature[43];
-  EXPECT_EQ(last_msg_->signature[44], 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[44])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[44])),
+            4)
       << "incorrect value for signature[44], expected 4, is "
       << last_msg_->signature[44];
-  EXPECT_EQ(last_msg_->signature[45], 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[45])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[45])),
+            5)
       << "incorrect value for signature[45], expected 5, is "
       << last_msg_->signature[45];
-  EXPECT_EQ(last_msg_->signature[46], 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[46])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[46])),
+            6)
       << "incorrect value for signature[46], expected 6, is "
       << last_msg_->signature[46];
-  EXPECT_EQ(last_msg_->signature[47], 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[47])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[47])),
+            7)
       << "incorrect value for signature[47], expected 7, is "
       << last_msg_->signature[47];
-  EXPECT_EQ(last_msg_->signature[48], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[48])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[48])),
+            0)
       << "incorrect value for signature[48], expected 0, is "
       << last_msg_->signature[48];
-  EXPECT_EQ(last_msg_->signature[49], 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[49])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[49])),
+            1)
       << "incorrect value for signature[49], expected 1, is "
       << last_msg_->signature[49];
-  EXPECT_EQ(last_msg_->signature[50], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[50])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[50])),
+            2)
       << "incorrect value for signature[50], expected 2, is "
       << last_msg_->signature[50];
-  EXPECT_EQ(last_msg_->signature[51], 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[51])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[51])),
+            3)
       << "incorrect value for signature[51], expected 3, is "
       << last_msg_->signature[51];
-  EXPECT_EQ(last_msg_->signature[52], 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[52])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[52])),
+            4)
       << "incorrect value for signature[52], expected 4, is "
       << last_msg_->signature[52];
-  EXPECT_EQ(last_msg_->signature[53], 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[53])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[53])),
+            5)
       << "incorrect value for signature[53], expected 5, is "
       << last_msg_->signature[53];
-  EXPECT_EQ(last_msg_->signature[54], 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[54])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[54])),
+            6)
       << "incorrect value for signature[54], expected 6, is "
       << last_msg_->signature[54];
-  EXPECT_EQ(last_msg_->signature[55], 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[55])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[55])),
+            7)
       << "incorrect value for signature[55], expected 7, is "
       << last_msg_->signature[55];
-  EXPECT_EQ(last_msg_->signature[56], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[56])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[56])),
+            0)
       << "incorrect value for signature[56], expected 0, is "
       << last_msg_->signature[56];
-  EXPECT_EQ(last_msg_->signature[57], 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[57])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[57])),
+            1)
       << "incorrect value for signature[57], expected 1, is "
       << last_msg_->signature[57];
-  EXPECT_EQ(last_msg_->signature[58], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[58])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[58])),
+            2)
       << "incorrect value for signature[58], expected 2, is "
       << last_msg_->signature[58];
-  EXPECT_EQ(last_msg_->signature[59], 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[59])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[59])),
+            3)
       << "incorrect value for signature[59], expected 3, is "
       << last_msg_->signature[59];
-  EXPECT_EQ(last_msg_->signature[60], 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[60])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[60])),
+            4)
       << "incorrect value for signature[60], expected 4, is "
       << last_msg_->signature[60];
-  EXPECT_EQ(last_msg_->signature[61], 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[61])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[61])),
+            5)
       << "incorrect value for signature[61], expected 5, is "
       << last_msg_->signature[61];
-  EXPECT_EQ(last_msg_->signature[62], 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[62])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[62])),
+            6)
       << "incorrect value for signature[62], expected 6, is "
       << last_msg_->signature[62];
-  EXPECT_EQ(last_msg_->signature[63], 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[63])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[63])),
+            7)
       << "incorrect value for signature[63], expected 7, is "
       << last_msg_->signature[63];
 }

--- a/c/test/legacy/cpp/auto_check_sbp_signing_MsgEcdsaCertificate.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_signing_MsgEcdsaCertificate.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/signing.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_signing_MsgEcdsaCertificate0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -1636,761 +1643,1518 @@ TEST_F(Test_legacy_auto_check_sbp_signing_MsgEcdsaCertificate0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->certificate_bytes[0], 180)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[0])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[0])),
+      180)
       << "incorrect value for certificate_bytes[0], expected 180, is "
       << last_msg_->certificate_bytes[0];
-  EXPECT_EQ(last_msg_->certificate_bytes[1], 160)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[1])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[1])),
+      160)
       << "incorrect value for certificate_bytes[1], expected 160, is "
       << last_msg_->certificate_bytes[1];
-  EXPECT_EQ(last_msg_->certificate_bytes[2], 116)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[2])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[2])),
+      116)
       << "incorrect value for certificate_bytes[2], expected 116, is "
       << last_msg_->certificate_bytes[2];
-  EXPECT_EQ(last_msg_->certificate_bytes[3], 77)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[3])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[3])),
+      77)
       << "incorrect value for certificate_bytes[3], expected 77, is "
       << last_msg_->certificate_bytes[3];
-  EXPECT_EQ(last_msg_->certificate_bytes[4], 243)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[4])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[4])),
+      243)
       << "incorrect value for certificate_bytes[4], expected 243, is "
       << last_msg_->certificate_bytes[4];
-  EXPECT_EQ(last_msg_->certificate_bytes[5], 28)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[5])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[5])),
+      28)
       << "incorrect value for certificate_bytes[5], expected 28, is "
       << last_msg_->certificate_bytes[5];
-  EXPECT_EQ(last_msg_->certificate_bytes[6], 173)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[6])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[6])),
+      173)
       << "incorrect value for certificate_bytes[6], expected 173, is "
       << last_msg_->certificate_bytes[6];
-  EXPECT_EQ(last_msg_->certificate_bytes[7], 36)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[7])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[7])),
+      36)
       << "incorrect value for certificate_bytes[7], expected 36, is "
       << last_msg_->certificate_bytes[7];
-  EXPECT_EQ(last_msg_->certificate_bytes[8], 86)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[8])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[8])),
+      86)
       << "incorrect value for certificate_bytes[8], expected 86, is "
       << last_msg_->certificate_bytes[8];
-  EXPECT_EQ(last_msg_->certificate_bytes[9], 33)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[9])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[9])),
+      33)
       << "incorrect value for certificate_bytes[9], expected 33, is "
       << last_msg_->certificate_bytes[9];
-  EXPECT_EQ(last_msg_->certificate_bytes[10], 8)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[10])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[10])),
+      8)
       << "incorrect value for certificate_bytes[10], expected 8, is "
       << last_msg_->certificate_bytes[10];
-  EXPECT_EQ(last_msg_->certificate_bytes[11], 31)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[11])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[11])),
+      31)
       << "incorrect value for certificate_bytes[11], expected 31, is "
       << last_msg_->certificate_bytes[11];
-  EXPECT_EQ(last_msg_->certificate_bytes[12], 120)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[12])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[12])),
+      120)
       << "incorrect value for certificate_bytes[12], expected 120, is "
       << last_msg_->certificate_bytes[12];
-  EXPECT_EQ(last_msg_->certificate_bytes[13], 73)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[13])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[13])),
+      73)
       << "incorrect value for certificate_bytes[13], expected 73, is "
       << last_msg_->certificate_bytes[13];
-  EXPECT_EQ(last_msg_->certificate_bytes[14], 64)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[14])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[14])),
+      64)
       << "incorrect value for certificate_bytes[14], expected 64, is "
       << last_msg_->certificate_bytes[14];
-  EXPECT_EQ(last_msg_->certificate_bytes[15], 169)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[15])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[15])),
+      169)
       << "incorrect value for certificate_bytes[15], expected 169, is "
       << last_msg_->certificate_bytes[15];
-  EXPECT_EQ(last_msg_->certificate_bytes[16], 148)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[16])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[16])),
+      148)
       << "incorrect value for certificate_bytes[16], expected 148, is "
       << last_msg_->certificate_bytes[16];
-  EXPECT_EQ(last_msg_->certificate_bytes[17], 224)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[17])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[17])),
+      224)
       << "incorrect value for certificate_bytes[17], expected 224, is "
       << last_msg_->certificate_bytes[17];
-  EXPECT_EQ(last_msg_->certificate_bytes[18], 57)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[18])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[18])),
+      57)
       << "incorrect value for certificate_bytes[18], expected 57, is "
       << last_msg_->certificate_bytes[18];
-  EXPECT_EQ(last_msg_->certificate_bytes[19], 95)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[19])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[19])),
+      95)
       << "incorrect value for certificate_bytes[19], expected 95, is "
       << last_msg_->certificate_bytes[19];
-  EXPECT_EQ(last_msg_->certificate_bytes[20], 17)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[20])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[20])),
+      17)
       << "incorrect value for certificate_bytes[20], expected 17, is "
       << last_msg_->certificate_bytes[20];
-  EXPECT_EQ(last_msg_->certificate_bytes[21], 40)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[21])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[21])),
+      40)
       << "incorrect value for certificate_bytes[21], expected 40, is "
       << last_msg_->certificate_bytes[21];
-  EXPECT_EQ(last_msg_->certificate_bytes[22], 213)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[22])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[22])),
+      213)
       << "incorrect value for certificate_bytes[22], expected 213, is "
       << last_msg_->certificate_bytes[22];
-  EXPECT_EQ(last_msg_->certificate_bytes[23], 92)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[23])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[23])),
+      92)
       << "incorrect value for certificate_bytes[23], expected 92, is "
       << last_msg_->certificate_bytes[23];
-  EXPECT_EQ(last_msg_->certificate_bytes[24], 195)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[24])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[24])),
+      195)
       << "incorrect value for certificate_bytes[24], expected 195, is "
       << last_msg_->certificate_bytes[24];
-  EXPECT_EQ(last_msg_->certificate_bytes[25], 146)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[25])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[25])),
+      146)
       << "incorrect value for certificate_bytes[25], expected 146, is "
       << last_msg_->certificate_bytes[25];
-  EXPECT_EQ(last_msg_->certificate_bytes[26], 235)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[26])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[26])),
+      235)
       << "incorrect value for certificate_bytes[26], expected 235, is "
       << last_msg_->certificate_bytes[26];
-  EXPECT_EQ(last_msg_->certificate_bytes[27], 228)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[27])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[27])),
+      228)
       << "incorrect value for certificate_bytes[27], expected 228, is "
       << last_msg_->certificate_bytes[27];
-  EXPECT_EQ(last_msg_->certificate_bytes[28], 177)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[28])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[28])),
+      177)
       << "incorrect value for certificate_bytes[28], expected 177, is "
       << last_msg_->certificate_bytes[28];
-  EXPECT_EQ(last_msg_->certificate_bytes[29], 101)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[29])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[29])),
+      101)
       << "incorrect value for certificate_bytes[29], expected 101, is "
       << last_msg_->certificate_bytes[29];
-  EXPECT_EQ(last_msg_->certificate_bytes[30], 82)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[30])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[30])),
+      82)
       << "incorrect value for certificate_bytes[30], expected 82, is "
       << last_msg_->certificate_bytes[30];
-  EXPECT_EQ(last_msg_->certificate_bytes[31], 182)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[31])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[31])),
+      182)
       << "incorrect value for certificate_bytes[31], expected 182, is "
       << last_msg_->certificate_bytes[31];
-  EXPECT_EQ(last_msg_->certificate_bytes[32], 25)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[32])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[32])),
+      25)
       << "incorrect value for certificate_bytes[32], expected 25, is "
       << last_msg_->certificate_bytes[32];
-  EXPECT_EQ(last_msg_->certificate_bytes[33], 172)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[33])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[33])),
+      172)
       << "incorrect value for certificate_bytes[33], expected 172, is "
       << last_msg_->certificate_bytes[33];
-  EXPECT_EQ(last_msg_->certificate_bytes[34], 170)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[34])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[34])),
+      170)
       << "incorrect value for certificate_bytes[34], expected 170, is "
       << last_msg_->certificate_bytes[34];
-  EXPECT_EQ(last_msg_->certificate_bytes[35], 250)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[35])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[35])),
+      250)
       << "incorrect value for certificate_bytes[35], expected 250, is "
       << last_msg_->certificate_bytes[35];
-  EXPECT_EQ(last_msg_->certificate_bytes[36], 236)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[36])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[36])),
+      236)
       << "incorrect value for certificate_bytes[36], expected 236, is "
       << last_msg_->certificate_bytes[36];
-  EXPECT_EQ(last_msg_->certificate_bytes[37], 7)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[37])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[37])),
+      7)
       << "incorrect value for certificate_bytes[37], expected 7, is "
       << last_msg_->certificate_bytes[37];
-  EXPECT_EQ(last_msg_->certificate_bytes[38], 119)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[38])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[38])),
+      119)
       << "incorrect value for certificate_bytes[38], expected 119, is "
       << last_msg_->certificate_bytes[38];
-  EXPECT_EQ(last_msg_->certificate_bytes[39], 4)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[39])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[39])),
+      4)
       << "incorrect value for certificate_bytes[39], expected 4, is "
       << last_msg_->certificate_bytes[39];
-  EXPECT_EQ(last_msg_->certificate_bytes[40], 201)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[40])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[40])),
+      201)
       << "incorrect value for certificate_bytes[40], expected 201, is "
       << last_msg_->certificate_bytes[40];
-  EXPECT_EQ(last_msg_->certificate_bytes[41], 10)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[41])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[41])),
+      10)
       << "incorrect value for certificate_bytes[41], expected 10, is "
       << last_msg_->certificate_bytes[41];
-  EXPECT_EQ(last_msg_->certificate_bytes[42], 14)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[42])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[42])),
+      14)
       << "incorrect value for certificate_bytes[42], expected 14, is "
       << last_msg_->certificate_bytes[42];
-  EXPECT_EQ(last_msg_->certificate_bytes[43], 208)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[43])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[43])),
+      208)
       << "incorrect value for certificate_bytes[43], expected 208, is "
       << last_msg_->certificate_bytes[43];
-  EXPECT_EQ(last_msg_->certificate_bytes[44], 47)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[44])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[44])),
+      47)
       << "incorrect value for certificate_bytes[44], expected 47, is "
       << last_msg_->certificate_bytes[44];
-  EXPECT_EQ(last_msg_->certificate_bytes[45], 126)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[45])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[45])),
+      126)
       << "incorrect value for certificate_bytes[45], expected 126, is "
       << last_msg_->certificate_bytes[45];
-  EXPECT_EQ(last_msg_->certificate_bytes[46], 49)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[46])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[46])),
+      49)
       << "incorrect value for certificate_bytes[46], expected 49, is "
       << last_msg_->certificate_bytes[46];
-  EXPECT_EQ(last_msg_->certificate_bytes[47], 210)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[47])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[47])),
+      210)
       << "incorrect value for certificate_bytes[47], expected 210, is "
       << last_msg_->certificate_bytes[47];
-  EXPECT_EQ(last_msg_->certificate_bytes[48], 174)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[48])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[48])),
+      174)
       << "incorrect value for certificate_bytes[48], expected 174, is "
       << last_msg_->certificate_bytes[48];
-  EXPECT_EQ(last_msg_->certificate_bytes[49], 75)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[49])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[49])),
+      75)
       << "incorrect value for certificate_bytes[49], expected 75, is "
       << last_msg_->certificate_bytes[49];
-  EXPECT_EQ(last_msg_->certificate_bytes[50], 221)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[50])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[50])),
+      221)
       << "incorrect value for certificate_bytes[50], expected 221, is "
       << last_msg_->certificate_bytes[50];
-  EXPECT_EQ(last_msg_->certificate_bytes[51], 203)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[51])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[51])),
+      203)
       << "incorrect value for certificate_bytes[51], expected 203, is "
       << last_msg_->certificate_bytes[51];
-  EXPECT_EQ(last_msg_->certificate_bytes[52], 24)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[52])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[52])),
+      24)
       << "incorrect value for certificate_bytes[52], expected 24, is "
       << last_msg_->certificate_bytes[52];
-  EXPECT_EQ(last_msg_->certificate_bytes[53], 66)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[53])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[53])),
+      66)
       << "incorrect value for certificate_bytes[53], expected 66, is "
       << last_msg_->certificate_bytes[53];
-  EXPECT_EQ(last_msg_->certificate_bytes[54], 52)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[54])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[54])),
+      52)
       << "incorrect value for certificate_bytes[54], expected 52, is "
       << last_msg_->certificate_bytes[54];
-  EXPECT_EQ(last_msg_->certificate_bytes[55], 35)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[55])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[55])),
+      35)
       << "incorrect value for certificate_bytes[55], expected 35, is "
       << last_msg_->certificate_bytes[55];
-  EXPECT_EQ(last_msg_->certificate_bytes[56], 26)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[56])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[56])),
+      26)
       << "incorrect value for certificate_bytes[56], expected 26, is "
       << last_msg_->certificate_bytes[56];
-  EXPECT_EQ(last_msg_->certificate_bytes[57], 30)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[57])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[57])),
+      30)
       << "incorrect value for certificate_bytes[57], expected 30, is "
       << last_msg_->certificate_bytes[57];
-  EXPECT_EQ(last_msg_->certificate_bytes[58], 140)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[58])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[58])),
+      140)
       << "incorrect value for certificate_bytes[58], expected 140, is "
       << last_msg_->certificate_bytes[58];
-  EXPECT_EQ(last_msg_->certificate_bytes[59], 111)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[59])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[59])),
+      111)
       << "incorrect value for certificate_bytes[59], expected 111, is "
       << last_msg_->certificate_bytes[59];
-  EXPECT_EQ(last_msg_->certificate_bytes[60], 246)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[60])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[60])),
+      246)
       << "incorrect value for certificate_bytes[60], expected 246, is "
       << last_msg_->certificate_bytes[60];
-  EXPECT_EQ(last_msg_->certificate_bytes[61], 39)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[61])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[61])),
+      39)
       << "incorrect value for certificate_bytes[61], expected 39, is "
       << last_msg_->certificate_bytes[61];
-  EXPECT_EQ(last_msg_->certificate_bytes[62], 226)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[62])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[62])),
+      226)
       << "incorrect value for certificate_bytes[62], expected 226, is "
       << last_msg_->certificate_bytes[62];
-  EXPECT_EQ(last_msg_->certificate_bytes[63], 205)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[63])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[63])),
+      205)
       << "incorrect value for certificate_bytes[63], expected 205, is "
       << last_msg_->certificate_bytes[63];
-  EXPECT_EQ(last_msg_->certificate_bytes[64], 198)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[64])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[64])),
+      198)
       << "incorrect value for certificate_bytes[64], expected 198, is "
       << last_msg_->certificate_bytes[64];
-  EXPECT_EQ(last_msg_->certificate_bytes[65], 178)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[65])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[65])),
+      178)
       << "incorrect value for certificate_bytes[65], expected 178, is "
       << last_msg_->certificate_bytes[65];
-  EXPECT_EQ(last_msg_->certificate_bytes[66], 196)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[66])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[66])),
+      196)
       << "incorrect value for certificate_bytes[66], expected 196, is "
       << last_msg_->certificate_bytes[66];
-  EXPECT_EQ(last_msg_->certificate_bytes[67], 5)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[67])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[67])),
+      5)
       << "incorrect value for certificate_bytes[67], expected 5, is "
       << last_msg_->certificate_bytes[67];
-  EXPECT_EQ(last_msg_->certificate_bytes[68], 81)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[68])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[68])),
+      81)
       << "incorrect value for certificate_bytes[68], expected 81, is "
       << last_msg_->certificate_bytes[68];
-  EXPECT_EQ(last_msg_->certificate_bytes[69], 9)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[69])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[69])),
+      9)
       << "incorrect value for certificate_bytes[69], expected 9, is "
       << last_msg_->certificate_bytes[69];
-  EXPECT_EQ(last_msg_->certificate_bytes[70], 44)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[70])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[70])),
+      44)
       << "incorrect value for certificate_bytes[70], expected 44, is "
       << last_msg_->certificate_bytes[70];
-  EXPECT_EQ(last_msg_->certificate_bytes[71], 164)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[71])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[71])),
+      164)
       << "incorrect value for certificate_bytes[71], expected 164, is "
       << last_msg_->certificate_bytes[71];
-  EXPECT_EQ(last_msg_->certificate_bytes[72], 163)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[72])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[72])),
+      163)
       << "incorrect value for certificate_bytes[72], expected 163, is "
       << last_msg_->certificate_bytes[72];
-  EXPECT_EQ(last_msg_->certificate_bytes[73], 214)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[73])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[73])),
+      214)
       << "incorrect value for certificate_bytes[73], expected 214, is "
       << last_msg_->certificate_bytes[73];
-  EXPECT_EQ(last_msg_->certificate_bytes[74], 138)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[74])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[74])),
+      138)
       << "incorrect value for certificate_bytes[74], expected 138, is "
       << last_msg_->certificate_bytes[74];
-  EXPECT_EQ(last_msg_->certificate_bytes[75], 123)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[75])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[75])),
+      123)
       << "incorrect value for certificate_bytes[75], expected 123, is "
       << last_msg_->certificate_bytes[75];
-  EXPECT_EQ(last_msg_->certificate_bytes[76], 76)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[76])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[76])),
+      76)
       << "incorrect value for certificate_bytes[76], expected 76, is "
       << last_msg_->certificate_bytes[76];
-  EXPECT_EQ(last_msg_->certificate_bytes[77], 74)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[77])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[77])),
+      74)
       << "incorrect value for certificate_bytes[77], expected 74, is "
       << last_msg_->certificate_bytes[77];
-  EXPECT_EQ(last_msg_->certificate_bytes[78], 237)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[78])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[78])),
+      237)
       << "incorrect value for certificate_bytes[78], expected 237, is "
       << last_msg_->certificate_bytes[78];
-  EXPECT_EQ(last_msg_->certificate_bytes[79], 121)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[79])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[79])),
+      121)
       << "incorrect value for certificate_bytes[79], expected 121, is "
       << last_msg_->certificate_bytes[79];
-  EXPECT_EQ(last_msg_->certificate_bytes[80], 13)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[80])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[80])),
+      13)
       << "incorrect value for certificate_bytes[80], expected 13, is "
       << last_msg_->certificate_bytes[80];
-  EXPECT_EQ(last_msg_->certificate_bytes[81], 137)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[81])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[81])),
+      137)
       << "incorrect value for certificate_bytes[81], expected 137, is "
       << last_msg_->certificate_bytes[81];
-  EXPECT_EQ(last_msg_->certificate_bytes[82], 186)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[82])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[82])),
+      186)
       << "incorrect value for certificate_bytes[82], expected 186, is "
       << last_msg_->certificate_bytes[82];
-  EXPECT_EQ(last_msg_->certificate_bytes[83], 97)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[83])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[83])),
+      97)
       << "incorrect value for certificate_bytes[83], expected 97, is "
       << last_msg_->certificate_bytes[83];
-  EXPECT_EQ(last_msg_->certificate_bytes[84], 193)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[84])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[84])),
+      193)
       << "incorrect value for certificate_bytes[84], expected 193, is "
       << last_msg_->certificate_bytes[84];
-  EXPECT_EQ(last_msg_->certificate_bytes[85], 189)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[85])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[85])),
+      189)
       << "incorrect value for certificate_bytes[85], expected 189, is "
       << last_msg_->certificate_bytes[85];
-  EXPECT_EQ(last_msg_->certificate_bytes[86], 200)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[86])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[86])),
+      200)
       << "incorrect value for certificate_bytes[86], expected 200, is "
       << last_msg_->certificate_bytes[86];
-  EXPECT_EQ(last_msg_->certificate_bytes[87], 124)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[87])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[87])),
+      124)
       << "incorrect value for certificate_bytes[87], expected 124, is "
       << last_msg_->certificate_bytes[87];
-  EXPECT_EQ(last_msg_->certificate_bytes[88], 69)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[88])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[88])),
+      69)
       << "incorrect value for certificate_bytes[88], expected 69, is "
       << last_msg_->certificate_bytes[88];
-  EXPECT_EQ(last_msg_->certificate_bytes[89], 115)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[89])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[89])),
+      115)
       << "incorrect value for certificate_bytes[89], expected 115, is "
       << last_msg_->certificate_bytes[89];
-  EXPECT_EQ(last_msg_->certificate_bytes[90], 230)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[90])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[90])),
+      230)
       << "incorrect value for certificate_bytes[90], expected 230, is "
       << last_msg_->certificate_bytes[90];
-  EXPECT_EQ(last_msg_->certificate_bytes[91], 159)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[91])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[91])),
+      159)
       << "incorrect value for certificate_bytes[91], expected 159, is "
       << last_msg_->certificate_bytes[91];
-  EXPECT_EQ(last_msg_->certificate_bytes[92], 185)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[92])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[92])),
+      185)
       << "incorrect value for certificate_bytes[92], expected 185, is "
       << last_msg_->certificate_bytes[92];
-  EXPECT_EQ(last_msg_->certificate_bytes[93], 158)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[93])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[93])),
+      158)
       << "incorrect value for certificate_bytes[93], expected 158, is "
       << last_msg_->certificate_bytes[93];
-  EXPECT_EQ(last_msg_->certificate_bytes[94], 51)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[94])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[94])),
+      51)
       << "incorrect value for certificate_bytes[94], expected 51, is "
       << last_msg_->certificate_bytes[94];
-  EXPECT_EQ(last_msg_->certificate_bytes[95], 12)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[95])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[95])),
+      12)
       << "incorrect value for certificate_bytes[95], expected 12, is "
       << last_msg_->certificate_bytes[95];
-  EXPECT_EQ(last_msg_->certificate_bytes[96], 225)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[96])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[96])),
+      225)
       << "incorrect value for certificate_bytes[96], expected 225, is "
       << last_msg_->certificate_bytes[96];
-  EXPECT_EQ(last_msg_->certificate_bytes[97], 65)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[97])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[97])),
+      65)
       << "incorrect value for certificate_bytes[97], expected 65, is "
       << last_msg_->certificate_bytes[97];
-  EXPECT_EQ(last_msg_->certificate_bytes[98], 192)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[98])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[98])),
+      192)
       << "incorrect value for certificate_bytes[98], expected 192, is "
       << last_msg_->certificate_bytes[98];
-  EXPECT_EQ(last_msg_->certificate_bytes[99], 105)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[99])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[99])),
+      105)
       << "incorrect value for certificate_bytes[99], expected 105, is "
       << last_msg_->certificate_bytes[99];
-  EXPECT_EQ(last_msg_->certificate_bytes[100], 56)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[100])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[100])),
+            56)
       << "incorrect value for certificate_bytes[100], expected 56, is "
       << last_msg_->certificate_bytes[100];
-  EXPECT_EQ(last_msg_->certificate_bytes[101], 41)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[101])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[101])),
+            41)
       << "incorrect value for certificate_bytes[101], expected 41, is "
       << last_msg_->certificate_bytes[101];
-  EXPECT_EQ(last_msg_->certificate_bytes[102], 85)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[102])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[102])),
+            85)
       << "incorrect value for certificate_bytes[102], expected 85, is "
       << last_msg_->certificate_bytes[102];
-  EXPECT_EQ(last_msg_->certificate_bytes[103], 133)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[103])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[103])),
+            133)
       << "incorrect value for certificate_bytes[103], expected 133, is "
       << last_msg_->certificate_bytes[103];
-  EXPECT_EQ(last_msg_->certificate_bytes[104], 19)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[104])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[104])),
+            19)
       << "incorrect value for certificate_bytes[104], expected 19, is "
       << last_msg_->certificate_bytes[104];
-  EXPECT_EQ(last_msg_->certificate_bytes[105], 217)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[105])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[105])),
+            217)
       << "incorrect value for certificate_bytes[105], expected 217, is "
       << last_msg_->certificate_bytes[105];
-  EXPECT_EQ(last_msg_->certificate_bytes[106], 166)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[106])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[106])),
+            166)
       << "incorrect value for certificate_bytes[106], expected 166, is "
       << last_msg_->certificate_bytes[106];
-  EXPECT_EQ(last_msg_->certificate_bytes[107], 48)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[107])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[107])),
+            48)
       << "incorrect value for certificate_bytes[107], expected 48, is "
       << last_msg_->certificate_bytes[107];
-  EXPECT_EQ(last_msg_->certificate_bytes[108], 139)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[108])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[108])),
+            139)
       << "incorrect value for certificate_bytes[108], expected 139, is "
       << last_msg_->certificate_bytes[108];
-  EXPECT_EQ(last_msg_->certificate_bytes[109], 131)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[109])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[109])),
+            131)
       << "incorrect value for certificate_bytes[109], expected 131, is "
       << last_msg_->certificate_bytes[109];
-  EXPECT_EQ(last_msg_->certificate_bytes[110], 96)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[110])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[110])),
+            96)
       << "incorrect value for certificate_bytes[110], expected 96, is "
       << last_msg_->certificate_bytes[110];
-  EXPECT_EQ(last_msg_->certificate_bytes[111], 216)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[111])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[111])),
+            216)
       << "incorrect value for certificate_bytes[111], expected 216, is "
       << last_msg_->certificate_bytes[111];
-  EXPECT_EQ(last_msg_->certificate_bytes[112], 98)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[112])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[112])),
+            98)
       << "incorrect value for certificate_bytes[112], expected 98, is "
       << last_msg_->certificate_bytes[112];
-  EXPECT_EQ(last_msg_->certificate_bytes[113], 147)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[113])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[113])),
+            147)
       << "incorrect value for certificate_bytes[113], expected 147, is "
       << last_msg_->certificate_bytes[113];
-  EXPECT_EQ(last_msg_->certificate_bytes[114], 132)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[114])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[114])),
+            132)
       << "incorrect value for certificate_bytes[114], expected 132, is "
       << last_msg_->certificate_bytes[114];
-  EXPECT_EQ(last_msg_->certificate_bytes[115], 234)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[115])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[115])),
+            234)
       << "incorrect value for certificate_bytes[115], expected 234, is "
       << last_msg_->certificate_bytes[115];
-  EXPECT_EQ(last_msg_->certificate_bytes[116], 167)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[116])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[116])),
+            167)
       << "incorrect value for certificate_bytes[116], expected 167, is "
       << last_msg_->certificate_bytes[116];
-  EXPECT_EQ(last_msg_->certificate_bytes[117], 248)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[117])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[117])),
+            248)
       << "incorrect value for certificate_bytes[117], expected 248, is "
       << last_msg_->certificate_bytes[117];
-  EXPECT_EQ(last_msg_->certificate_bytes[118], 247)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[118])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[118])),
+            247)
       << "incorrect value for certificate_bytes[118], expected 247, is "
       << last_msg_->certificate_bytes[118];
-  EXPECT_EQ(last_msg_->certificate_bytes[119], 32)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[119])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[119])),
+            32)
       << "incorrect value for certificate_bytes[119], expected 32, is "
       << last_msg_->certificate_bytes[119];
-  EXPECT_EQ(last_msg_->certificate_bytes[120], 239)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[120])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[120])),
+            239)
       << "incorrect value for certificate_bytes[120], expected 239, is "
       << last_msg_->certificate_bytes[120];
-  EXPECT_EQ(last_msg_->certificate_bytes[121], 194)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[121])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[121])),
+            194)
       << "incorrect value for certificate_bytes[121], expected 194, is "
       << last_msg_->certificate_bytes[121];
-  EXPECT_EQ(last_msg_->certificate_bytes[122], 188)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[122])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[122])),
+            188)
       << "incorrect value for certificate_bytes[122], expected 188, is "
       << last_msg_->certificate_bytes[122];
-  EXPECT_EQ(last_msg_->certificate_bytes[123], 254)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[123])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[123])),
+            254)
       << "incorrect value for certificate_bytes[123], expected 254, is "
       << last_msg_->certificate_bytes[123];
-  EXPECT_EQ(last_msg_->certificate_bytes[124], 114)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[124])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[124])),
+            114)
       << "incorrect value for certificate_bytes[124], expected 114, is "
       << last_msg_->certificate_bytes[124];
-  EXPECT_EQ(last_msg_->certificate_bytes[125], 117)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[125])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[125])),
+            117)
       << "incorrect value for certificate_bytes[125], expected 117, is "
       << last_msg_->certificate_bytes[125];
-  EXPECT_EQ(last_msg_->certificate_bytes[126], 83)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[126])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[126])),
+            83)
       << "incorrect value for certificate_bytes[126], expected 83, is "
       << last_msg_->certificate_bytes[126];
-  EXPECT_EQ(last_msg_->certificate_bytes[127], 25)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[127])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[127])),
+            25)
       << "incorrect value for certificate_bytes[127], expected 25, is "
       << last_msg_->certificate_bytes[127];
-  EXPECT_EQ(last_msg_->certificate_bytes[128], 251)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[128])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[128])),
+            251)
       << "incorrect value for certificate_bytes[128], expected 251, is "
       << last_msg_->certificate_bytes[128];
-  EXPECT_EQ(last_msg_->certificate_bytes[129], 191)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[129])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[129])),
+            191)
       << "incorrect value for certificate_bytes[129], expected 191, is "
       << last_msg_->certificate_bytes[129];
-  EXPECT_EQ(last_msg_->certificate_bytes[130], 104)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[130])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[130])),
+            104)
       << "incorrect value for certificate_bytes[130], expected 104, is "
       << last_msg_->certificate_bytes[130];
-  EXPECT_EQ(last_msg_->certificate_bytes[131], 240)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[131])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[131])),
+            240)
       << "incorrect value for certificate_bytes[131], expected 240, is "
       << last_msg_->certificate_bytes[131];
-  EXPECT_EQ(last_msg_->certificate_bytes[132], 118)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[132])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[132])),
+            118)
       << "incorrect value for certificate_bytes[132], expected 118, is "
       << last_msg_->certificate_bytes[132];
-  EXPECT_EQ(last_msg_->certificate_bytes[133], 68)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[133])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[133])),
+            68)
       << "incorrect value for certificate_bytes[133], expected 68, is "
       << last_msg_->certificate_bytes[133];
-  EXPECT_EQ(last_msg_->certificate_bytes[134], 42)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[134])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[134])),
+            42)
       << "incorrect value for certificate_bytes[134], expected 42, is "
       << last_msg_->certificate_bytes[134];
-  EXPECT_EQ(last_msg_->certificate_bytes[135], 93)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[135])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[135])),
+            93)
       << "incorrect value for certificate_bytes[135], expected 93, is "
       << last_msg_->certificate_bytes[135];
-  EXPECT_EQ(last_msg_->certificate_bytes[136], 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[136])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[136])),
+            18)
       << "incorrect value for certificate_bytes[136], expected 18, is "
       << last_msg_->certificate_bytes[136];
-  EXPECT_EQ(last_msg_->certificate_bytes[137], 16)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[137])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[137])),
+            16)
       << "incorrect value for certificate_bytes[137], expected 16, is "
       << last_msg_->certificate_bytes[137];
-  EXPECT_EQ(last_msg_->certificate_bytes[138], 37)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[138])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[138])),
+            37)
       << "incorrect value for certificate_bytes[138], expected 37, is "
       << last_msg_->certificate_bytes[138];
-  EXPECT_EQ(last_msg_->certificate_bytes[139], 232)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[139])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[139])),
+            232)
       << "incorrect value for certificate_bytes[139], expected 232, is "
       << last_msg_->certificate_bytes[139];
-  EXPECT_EQ(last_msg_->certificate_bytes[140], 99)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[140])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[140])),
+            99)
       << "incorrect value for certificate_bytes[140], expected 99, is "
       << last_msg_->certificate_bytes[140];
-  EXPECT_EQ(last_msg_->certificate_bytes[141], 179)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[141])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[141])),
+            179)
       << "incorrect value for certificate_bytes[141], expected 179, is "
       << last_msg_->certificate_bytes[141];
-  EXPECT_EQ(last_msg_->certificate_bytes[142], 23)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[142])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[142])),
+            23)
       << "incorrect value for certificate_bytes[142], expected 23, is "
       << last_msg_->certificate_bytes[142];
-  EXPECT_EQ(last_msg_->certificate_bytes[143], 90)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[143])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[143])),
+            90)
       << "incorrect value for certificate_bytes[143], expected 90, is "
       << last_msg_->certificate_bytes[143];
-  EXPECT_EQ(last_msg_->certificate_bytes[144], 94)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[144])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[144])),
+            94)
       << "incorrect value for certificate_bytes[144], expected 94, is "
       << last_msg_->certificate_bytes[144];
-  EXPECT_EQ(last_msg_->certificate_bytes[145], 136)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[145])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[145])),
+            136)
       << "incorrect value for certificate_bytes[145], expected 136, is "
       << last_msg_->certificate_bytes[145];
-  EXPECT_EQ(last_msg_->certificate_bytes[146], 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[146])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[146])),
+            6)
       << "incorrect value for certificate_bytes[146], expected 6, is "
       << last_msg_->certificate_bytes[146];
-  EXPECT_EQ(last_msg_->certificate_bytes[147], 125)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[147])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[147])),
+            125)
       << "incorrect value for certificate_bytes[147], expected 125, is "
       << last_msg_->certificate_bytes[147];
-  EXPECT_EQ(last_msg_->certificate_bytes[148], 91)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[148])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[148])),
+            91)
       << "incorrect value for certificate_bytes[148], expected 91, is "
       << last_msg_->certificate_bytes[148];
-  EXPECT_EQ(last_msg_->certificate_bytes[149], 255)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[149])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[149])),
+            255)
       << "incorrect value for certificate_bytes[149], expected 255, is "
       << last_msg_->certificate_bytes[149];
-  EXPECT_EQ(last_msg_->certificate_bytes[150], 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[150])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[150])),
+            15)
       << "incorrect value for certificate_bytes[150], expected 15, is "
       << last_msg_->certificate_bytes[150];
-  EXPECT_EQ(last_msg_->certificate_bytes[151], 71)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[151])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[151])),
+            71)
       << "incorrect value for certificate_bytes[151], expected 71, is "
       << last_msg_->certificate_bytes[151];
-  EXPECT_EQ(last_msg_->certificate_bytes[152], 43)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[152])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[152])),
+            43)
       << "incorrect value for certificate_bytes[152], expected 43, is "
       << last_msg_->certificate_bytes[152];
-  EXPECT_EQ(last_msg_->certificate_bytes[153], 46)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[153])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[153])),
+            46)
       << "incorrect value for certificate_bytes[153], expected 46, is "
       << last_msg_->certificate_bytes[153];
-  EXPECT_EQ(last_msg_->certificate_bytes[154], 25)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[154])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[154])),
+            25)
       << "incorrect value for certificate_bytes[154], expected 25, is "
       << last_msg_->certificate_bytes[154];
-  EXPECT_EQ(last_msg_->certificate_bytes[155], 252)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[155])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[155])),
+            252)
       << "incorrect value for certificate_bytes[155], expected 252, is "
       << last_msg_->certificate_bytes[155];
-  EXPECT_EQ(last_msg_->certificate_bytes[156], 229)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[156])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[156])),
+            229)
       << "incorrect value for certificate_bytes[156], expected 229, is "
       << last_msg_->certificate_bytes[156];
-  EXPECT_EQ(last_msg_->certificate_bytes[157], 80)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[157])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[157])),
+            80)
       << "incorrect value for certificate_bytes[157], expected 80, is "
       << last_msg_->certificate_bytes[157];
-  EXPECT_EQ(last_msg_->certificate_bytes[158], 143)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[158])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[158])),
+            143)
       << "incorrect value for certificate_bytes[158], expected 143, is "
       << last_msg_->certificate_bytes[158];
-  EXPECT_EQ(last_msg_->certificate_bytes[159], 58)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[159])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[159])),
+            58)
       << "incorrect value for certificate_bytes[159], expected 58, is "
       << last_msg_->certificate_bytes[159];
-  EXPECT_EQ(last_msg_->certificate_bytes[160], 241)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[160])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[160])),
+            241)
       << "incorrect value for certificate_bytes[160], expected 241, is "
       << last_msg_->certificate_bytes[160];
-  EXPECT_EQ(last_msg_->certificate_bytes[161], 11)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[161])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[161])),
+            11)
       << "incorrect value for certificate_bytes[161], expected 11, is "
       << last_msg_->certificate_bytes[161];
-  EXPECT_EQ(last_msg_->certificate_bytes[162], 62)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[162])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[162])),
+            62)
       << "incorrect value for certificate_bytes[162], expected 62, is "
       << last_msg_->certificate_bytes[162];
-  EXPECT_EQ(last_msg_->certificate_bytes[163], 181)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[163])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[163])),
+            181)
       << "incorrect value for certificate_bytes[163], expected 181, is "
       << last_msg_->certificate_bytes[163];
-  EXPECT_EQ(last_msg_->certificate_bytes[164], 155)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[164])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[164])),
+            155)
       << "incorrect value for certificate_bytes[164], expected 155, is "
       << last_msg_->certificate_bytes[164];
-  EXPECT_EQ(last_msg_->certificate_bytes[165], 53)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[165])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[165])),
+            53)
       << "incorrect value for certificate_bytes[165], expected 53, is "
       << last_msg_->certificate_bytes[165];
-  EXPECT_EQ(last_msg_->certificate_bytes[166], 153)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[166])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[166])),
+            153)
       << "incorrect value for certificate_bytes[166], expected 153, is "
       << last_msg_->certificate_bytes[166];
-  EXPECT_EQ(last_msg_->certificate_bytes[167], 149)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[167])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[167])),
+            149)
       << "incorrect value for certificate_bytes[167], expected 149, is "
       << last_msg_->certificate_bytes[167];
-  EXPECT_EQ(last_msg_->certificate_bytes[168], 152)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[168])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[168])),
+            152)
       << "incorrect value for certificate_bytes[168], expected 152, is "
       << last_msg_->certificate_bytes[168];
-  EXPECT_EQ(last_msg_->certificate_bytes[169], 227)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[169])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[169])),
+            227)
       << "incorrect value for certificate_bytes[169], expected 227, is "
       << last_msg_->certificate_bytes[169];
-  EXPECT_EQ(last_msg_->certificate_bytes[170], 150)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[170])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[170])),
+            150)
       << "incorrect value for certificate_bytes[170], expected 150, is "
       << last_msg_->certificate_bytes[170];
-  EXPECT_EQ(last_msg_->certificate_bytes[171], 87)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[171])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[171])),
+            87)
       << "incorrect value for certificate_bytes[171], expected 87, is "
       << last_msg_->certificate_bytes[171];
-  EXPECT_EQ(last_msg_->certificate_bytes[172], 112)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[172])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[172])),
+            112)
       << "incorrect value for certificate_bytes[172], expected 112, is "
       << last_msg_->certificate_bytes[172];
-  EXPECT_EQ(last_msg_->certificate_bytes[173], 165)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[173])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[173])),
+            165)
       << "incorrect value for certificate_bytes[173], expected 165, is "
       << last_msg_->certificate_bytes[173];
-  EXPECT_EQ(last_msg_->certificate_bytes[174], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[174])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[174])),
+            2)
       << "incorrect value for certificate_bytes[174], expected 2, is "
       << last_msg_->certificate_bytes[174];
-  EXPECT_EQ(last_msg_->certificate_bytes[175], 128)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[175])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[175])),
+            128)
       << "incorrect value for certificate_bytes[175], expected 128, is "
       << last_msg_->certificate_bytes[175];
-  EXPECT_EQ(last_msg_->certificate_bytes[176], 231)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[176])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[176])),
+            231)
       << "incorrect value for certificate_bytes[176], expected 231, is "
       << last_msg_->certificate_bytes[176];
-  EXPECT_EQ(last_msg_->certificate_bytes[177], 25)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[177])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[177])),
+            25)
       << "incorrect value for certificate_bytes[177], expected 25, is "
       << last_msg_->certificate_bytes[177];
-  EXPECT_EQ(last_msg_->certificate_bytes[178], 157)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[178])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[178])),
+            157)
       << "incorrect value for certificate_bytes[178], expected 157, is "
       << last_msg_->certificate_bytes[178];
-  EXPECT_EQ(last_msg_->certificate_bytes[179], 244)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[179])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[179])),
+            244)
       << "incorrect value for certificate_bytes[179], expected 244, is "
       << last_msg_->certificate_bytes[179];
-  EXPECT_EQ(last_msg_->certificate_bytes[180], 204)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[180])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[180])),
+            204)
       << "incorrect value for certificate_bytes[180], expected 204, is "
       << last_msg_->certificate_bytes[180];
-  EXPECT_EQ(last_msg_->certificate_bytes[181], 108)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[181])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[181])),
+            108)
       << "incorrect value for certificate_bytes[181], expected 108, is "
       << last_msg_->certificate_bytes[181];
-  EXPECT_EQ(last_msg_->certificate_bytes[182], 253)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[182])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[182])),
+            253)
       << "incorrect value for certificate_bytes[182], expected 253, is "
       << last_msg_->certificate_bytes[182];
-  EXPECT_EQ(last_msg_->certificate_bytes[183], 127)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[183])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[183])),
+            127)
       << "incorrect value for certificate_bytes[183], expected 127, is "
       << last_msg_->certificate_bytes[183];
-  EXPECT_EQ(last_msg_->certificate_bytes[184], 122)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[184])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[184])),
+            122)
       << "incorrect value for certificate_bytes[184], expected 122, is "
       << last_msg_->certificate_bytes[184];
-  EXPECT_EQ(last_msg_->certificate_bytes[185], 145)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[185])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[185])),
+            145)
       << "incorrect value for certificate_bytes[185], expected 145, is "
       << last_msg_->certificate_bytes[185];
-  EXPECT_EQ(last_msg_->certificate_bytes[186], 113)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[186])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[186])),
+            113)
       << "incorrect value for certificate_bytes[186], expected 113, is "
       << last_msg_->certificate_bytes[186];
-  EXPECT_EQ(last_msg_->certificate_bytes[187], 162)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[187])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[187])),
+            162)
       << "incorrect value for certificate_bytes[187], expected 162, is "
       << last_msg_->certificate_bytes[187];
-  EXPECT_EQ(last_msg_->certificate_bytes[188], 197)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[188])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[188])),
+            197)
       << "incorrect value for certificate_bytes[188], expected 197, is "
       << last_msg_->certificate_bytes[188];
-  EXPECT_EQ(last_msg_->certificate_bytes[189], 171)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[189])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[189])),
+            171)
       << "incorrect value for certificate_bytes[189], expected 171, is "
       << last_msg_->certificate_bytes[189];
-  EXPECT_EQ(last_msg_->certificate_bytes[190], 199)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[190])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[190])),
+            199)
       << "incorrect value for certificate_bytes[190], expected 199, is "
       << last_msg_->certificate_bytes[190];
-  EXPECT_EQ(last_msg_->certificate_bytes[191], 54)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[191])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[191])),
+            54)
       << "incorrect value for certificate_bytes[191], expected 54, is "
       << last_msg_->certificate_bytes[191];
-  EXPECT_EQ(last_msg_->certificate_bytes[192], 184)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[192])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[192])),
+            184)
       << "incorrect value for certificate_bytes[192], expected 184, is "
       << last_msg_->certificate_bytes[192];
-  EXPECT_EQ(last_msg_->certificate_bytes[193], 222)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[193])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[193])),
+            222)
       << "incorrect value for certificate_bytes[193], expected 222, is "
       << last_msg_->certificate_bytes[193];
-  EXPECT_EQ(last_msg_->certificate_bytes[194], 206)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[194])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[194])),
+            206)
       << "incorrect value for certificate_bytes[194], expected 206, is "
       << last_msg_->certificate_bytes[194];
-  EXPECT_EQ(last_msg_->certificate_bytes[195], 67)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[195])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[195])),
+            67)
       << "incorrect value for certificate_bytes[195], expected 67, is "
       << last_msg_->certificate_bytes[195];
-  EXPECT_EQ(last_msg_->certificate_bytes[196], 144)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[196])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[196])),
+            144)
       << "incorrect value for certificate_bytes[196], expected 144, is "
       << last_msg_->certificate_bytes[196];
-  EXPECT_EQ(last_msg_->certificate_bytes[197], 78)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[197])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[197])),
+            78)
       << "incorrect value for certificate_bytes[197], expected 78, is "
       << last_msg_->certificate_bytes[197];
-  EXPECT_EQ(last_msg_->certificate_bytes[198], 187)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[198])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[198])),
+            187)
       << "incorrect value for certificate_bytes[198], expected 187, is "
       << last_msg_->certificate_bytes[198];
-  EXPECT_EQ(last_msg_->certificate_bytes[199], 207)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[199])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[199])),
+            207)
       << "incorrect value for certificate_bytes[199], expected 207, is "
       << last_msg_->certificate_bytes[199];
-  EXPECT_EQ(last_msg_->certificate_bytes[200], 60)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[200])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[200])),
+            60)
       << "incorrect value for certificate_bytes[200], expected 60, is "
       << last_msg_->certificate_bytes[200];
-  EXPECT_EQ(last_msg_->certificate_bytes[201], 211)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[201])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[201])),
+            211)
       << "incorrect value for certificate_bytes[201], expected 211, is "
       << last_msg_->certificate_bytes[201];
-  EXPECT_EQ(last_msg_->certificate_bytes[202], 141)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[202])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[202])),
+            141)
       << "incorrect value for certificate_bytes[202], expected 141, is "
       << last_msg_->certificate_bytes[202];
-  EXPECT_EQ(last_msg_->certificate_bytes[203], 135)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[203])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[203])),
+            135)
       << "incorrect value for certificate_bytes[203], expected 135, is "
       << last_msg_->certificate_bytes[203];
-  EXPECT_EQ(last_msg_->certificate_bytes[204], 106)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[204])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[204])),
+            106)
       << "incorrect value for certificate_bytes[204], expected 106, is "
       << last_msg_->certificate_bytes[204];
-  EXPECT_EQ(last_msg_->certificate_bytes[205], 220)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[205])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[205])),
+            220)
       << "incorrect value for certificate_bytes[205], expected 220, is "
       << last_msg_->certificate_bytes[205];
-  EXPECT_EQ(last_msg_->certificate_bytes[206], 79)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[206])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[206])),
+            79)
       << "incorrect value for certificate_bytes[206], expected 79, is "
       << last_msg_->certificate_bytes[206];
-  EXPECT_EQ(last_msg_->certificate_bytes[207], 183)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[207])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[207])),
+            183)
       << "incorrect value for certificate_bytes[207], expected 183, is "
       << last_msg_->certificate_bytes[207];
-  EXPECT_EQ(last_msg_->certificate_bytes[208], 245)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[208])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[208])),
+            245)
       << "incorrect value for certificate_bytes[208], expected 245, is "
       << last_msg_->certificate_bytes[208];
-  EXPECT_EQ(last_msg_->certificate_bytes[209], 21)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[209])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[209])),
+            21)
       << "incorrect value for certificate_bytes[209], expected 21, is "
       << last_msg_->certificate_bytes[209];
-  EXPECT_EQ(last_msg_->certificate_bytes[210], 161)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[210])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[210])),
+            161)
       << "incorrect value for certificate_bytes[210], expected 161, is "
       << last_msg_->certificate_bytes[210];
-  EXPECT_EQ(last_msg_->certificate_bytes[211], 168)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[211])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[211])),
+            168)
       << "incorrect value for certificate_bytes[211], expected 168, is "
       << last_msg_->certificate_bytes[211];
-  EXPECT_EQ(last_msg_->certificate_bytes[212], 34)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[212])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[212])),
+            34)
       << "incorrect value for certificate_bytes[212], expected 34, is "
       << last_msg_->certificate_bytes[212];
-  EXPECT_EQ(last_msg_->certificate_bytes[213], 129)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[213])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[213])),
+            129)
       << "incorrect value for certificate_bytes[213], expected 129, is "
       << last_msg_->certificate_bytes[213];
-  EXPECT_EQ(last_msg_->certificate_bytes[214], 50)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[214])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[214])),
+            50)
       << "incorrect value for certificate_bytes[214], expected 50, is "
       << last_msg_->certificate_bytes[214];
-  EXPECT_EQ(last_msg_->certificate_bytes[215], 176)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[215])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[215])),
+            176)
       << "incorrect value for certificate_bytes[215], expected 176, is "
       << last_msg_->certificate_bytes[215];
-  EXPECT_EQ(last_msg_->certificate_bytes[216], 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[216])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[216])),
+            1)
       << "incorrect value for certificate_bytes[216], expected 1, is "
       << last_msg_->certificate_bytes[216];
-  EXPECT_EQ(last_msg_->certificate_bytes[217], 218)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[217])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[217])),
+            218)
       << "incorrect value for certificate_bytes[217], expected 218, is "
       << last_msg_->certificate_bytes[217];
-  EXPECT_EQ(last_msg_->certificate_bytes[218], 20)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[218])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[218])),
+            20)
       << "incorrect value for certificate_bytes[218], expected 20, is "
       << last_msg_->certificate_bytes[218];
-  EXPECT_EQ(last_msg_->certificate_bytes[219], 130)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[219])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[219])),
+            130)
       << "incorrect value for certificate_bytes[219], expected 130, is "
       << last_msg_->certificate_bytes[219];
-  EXPECT_EQ(last_msg_->certificate_bytes[220], 59)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[220])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[220])),
+            59)
       << "incorrect value for certificate_bytes[220], expected 59, is "
       << last_msg_->certificate_bytes[220];
-  EXPECT_EQ(last_msg_->certificate_bytes[221], 249)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[221])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[221])),
+            249)
       << "incorrect value for certificate_bytes[221], expected 249, is "
       << last_msg_->certificate_bytes[221];
-  EXPECT_EQ(last_msg_->certificate_bytes[222], 109)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[222])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[222])),
+            109)
       << "incorrect value for certificate_bytes[222], expected 109, is "
       << last_msg_->certificate_bytes[222];
-  EXPECT_EQ(last_msg_->certificate_bytes[223], 219)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[223])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[223])),
+            219)
       << "incorrect value for certificate_bytes[223], expected 219, is "
       << last_msg_->certificate_bytes[223];
-  EXPECT_EQ(last_msg_->certificate_bytes[224], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[224])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[224])),
+            0)
       << "incorrect value for certificate_bytes[224], expected 0, is "
       << last_msg_->certificate_bytes[224];
-  EXPECT_EQ(last_msg_->certificate_bytes[225], 100)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[225])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[225])),
+            100)
       << "incorrect value for certificate_bytes[225], expected 100, is "
       << last_msg_->certificate_bytes[225];
-  EXPECT_EQ(last_msg_->certificate_bytes[226], 103)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[226])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[226])),
+            103)
       << "incorrect value for certificate_bytes[226], expected 103, is "
       << last_msg_->certificate_bytes[226];
-  EXPECT_EQ(last_msg_->certificate_bytes[227], 55)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[227])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[227])),
+            55)
       << "incorrect value for certificate_bytes[227], expected 55, is "
       << last_msg_->certificate_bytes[227];
-  EXPECT_EQ(last_msg_->certificate_bytes[228], 29)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[228])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[228])),
+            29)
       << "incorrect value for certificate_bytes[228], expected 29, is "
       << last_msg_->certificate_bytes[228];
-  EXPECT_EQ(last_msg_->certificate_bytes[229], 242)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[229])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[229])),
+            242)
       << "incorrect value for certificate_bytes[229], expected 242, is "
       << last_msg_->certificate_bytes[229];
-  EXPECT_EQ(last_msg_->certificate_bytes[230], 110)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[230])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[230])),
+            110)
       << "incorrect value for certificate_bytes[230], expected 110, is "
       << last_msg_->certificate_bytes[230];
-  EXPECT_EQ(last_msg_->certificate_bytes[231], 154)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[231])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[231])),
+            154)
       << "incorrect value for certificate_bytes[231], expected 154, is "
       << last_msg_->certificate_bytes[231];
-  EXPECT_EQ(last_msg_->certificate_bytes[232], 190)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[232])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[232])),
+            190)
       << "incorrect value for certificate_bytes[232], expected 190, is "
       << last_msg_->certificate_bytes[232];
-  EXPECT_EQ(last_msg_->certificate_bytes[233], 233)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[233])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[233])),
+            233)
       << "incorrect value for certificate_bytes[233], expected 233, is "
       << last_msg_->certificate_bytes[233];
-  EXPECT_EQ(last_msg_->certificate_bytes[234], 142)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[234])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[234])),
+            142)
       << "incorrect value for certificate_bytes[234], expected 142, is "
       << last_msg_->certificate_bytes[234];
-  EXPECT_EQ(last_msg_->certificate_bytes[235], 45)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[235])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[235])),
+            45)
       << "incorrect value for certificate_bytes[235], expected 45, is "
       << last_msg_->certificate_bytes[235];
-  EXPECT_EQ(last_msg_->certificate_bytes[236], 61)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[236])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[236])),
+            61)
       << "incorrect value for certificate_bytes[236], expected 61, is "
       << last_msg_->certificate_bytes[236];
-  EXPECT_EQ(last_msg_->certificate_bytes[237], 215)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[237])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[237])),
+            215)
       << "incorrect value for certificate_bytes[237], expected 215, is "
       << last_msg_->certificate_bytes[237];
-  EXPECT_EQ(last_msg_->certificate_bytes[238], 202)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[238])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[238])),
+            202)
       << "incorrect value for certificate_bytes[238], expected 202, is "
       << last_msg_->certificate_bytes[238];
-  EXPECT_EQ(last_msg_->certificate_bytes[239], 238)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[239])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[239])),
+            238)
       << "incorrect value for certificate_bytes[239], expected 238, is "
       << last_msg_->certificate_bytes[239];
-  EXPECT_EQ(last_msg_->certificate_bytes[240], 88)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[240])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[240])),
+            88)
       << "incorrect value for certificate_bytes[240], expected 88, is "
       << last_msg_->certificate_bytes[240];
-  EXPECT_EQ(last_msg_->certificate_bytes[241], 209)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[241])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[241])),
+            209)
       << "incorrect value for certificate_bytes[241], expected 209, is "
       << last_msg_->certificate_bytes[241];
-  EXPECT_EQ(last_msg_->certificate_bytes[242], 70)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[242])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[242])),
+            70)
       << "incorrect value for certificate_bytes[242], expected 70, is "
       << last_msg_->certificate_bytes[242];
-  EXPECT_EQ(last_msg_->certificate_bytes[243], 63)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[243])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[243])),
+            63)
       << "incorrect value for certificate_bytes[243], expected 63, is "
       << last_msg_->certificate_bytes[243];
-  EXPECT_EQ(last_msg_->certificate_bytes[244], 151)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[244])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[244])),
+            151)
       << "incorrect value for certificate_bytes[244], expected 151, is "
       << last_msg_->certificate_bytes[244];
-  EXPECT_EQ(last_msg_->certificate_bytes[245], 27)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[245])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[245])),
+            27)
       << "incorrect value for certificate_bytes[245], expected 27, is "
       << last_msg_->certificate_bytes[245];
-  EXPECT_EQ(last_msg_->certificate_bytes[246], 102)
+  EXPECT_EQ(get_as<decltype(last_msg_->certificate_bytes[246])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->certificate_bytes[246])),
+            102)
       << "incorrect value for certificate_bytes[246], expected 102, is "
       << last_msg_->certificate_bytes[246];
-  EXPECT_EQ(last_msg_->certificate_id[0], 10)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_id[0])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_id[0])),
+      10)
       << "incorrect value for certificate_id[0], expected 10, is "
       << last_msg_->certificate_id[0];
-  EXPECT_EQ(last_msg_->certificate_id[1], 11)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_id[1])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_id[1])),
+      11)
       << "incorrect value for certificate_id[1], expected 11, is "
       << last_msg_->certificate_id[1];
-  EXPECT_EQ(last_msg_->certificate_id[2], 12)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_id[2])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_id[2])),
+      12)
       << "incorrect value for certificate_id[2], expected 12, is "
       << last_msg_->certificate_id[2];
-  EXPECT_EQ(last_msg_->certificate_id[3], 13)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_id[3])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_id[3])),
+      13)
       << "incorrect value for certificate_id[3], expected 13, is "
       << last_msg_->certificate_id[3];
-  EXPECT_EQ(last_msg_->flags, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            2)
       << "incorrect value for flags, expected 2, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_msg, 48)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_msg)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_msg)),
+            48)
       << "incorrect value for n_msg, expected 48, is " << last_msg_->n_msg;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_signing_MsgEcdsaSignature.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_signing_MsgEcdsaSignature.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/signing.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_signing_MsgEcdsaSignature0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -592,252 +599,498 @@ TEST_F(Test_legacy_auto_check_sbp_signing_MsgEcdsaSignature0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->certificate_id[0], 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_id[0])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_id[0])),
+      1)
       << "incorrect value for certificate_id[0], expected 1, is "
       << last_msg_->certificate_id[0];
-  EXPECT_EQ(last_msg_->certificate_id[1], 2)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_id[1])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_id[1])),
+      2)
       << "incorrect value for certificate_id[1], expected 2, is "
       << last_msg_->certificate_id[1];
-  EXPECT_EQ(last_msg_->certificate_id[2], 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_id[2])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_id[2])),
+      3)
       << "incorrect value for certificate_id[2], expected 3, is "
       << last_msg_->certificate_id[2];
-  EXPECT_EQ(last_msg_->certificate_id[3], 4)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_id[3])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_id[3])),
+      4)
       << "incorrect value for certificate_id[3], expected 4, is "
       << last_msg_->certificate_id[3];
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->on_demand_counter, 2)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->on_demand_counter)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->on_demand_counter)),
+      2)
       << "incorrect value for on_demand_counter, expected 2, is "
       << last_msg_->on_demand_counter;
-  EXPECT_EQ(last_msg_->signature.data[0], 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[0])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[0])),
+      0)
       << "incorrect value for signature.data[0], expected 0, is "
       << last_msg_->signature.data[0];
-  EXPECT_EQ(last_msg_->signature.data[1], 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[1])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[1])),
+      1)
       << "incorrect value for signature.data[1], expected 1, is "
       << last_msg_->signature.data[1];
-  EXPECT_EQ(last_msg_->signature.data[2], 2)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[2])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[2])),
+      2)
       << "incorrect value for signature.data[2], expected 2, is "
       << last_msg_->signature.data[2];
-  EXPECT_EQ(last_msg_->signature.data[3], 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[3])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[3])),
+      3)
       << "incorrect value for signature.data[3], expected 3, is "
       << last_msg_->signature.data[3];
-  EXPECT_EQ(last_msg_->signature.data[4], 4)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[4])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[4])),
+      4)
       << "incorrect value for signature.data[4], expected 4, is "
       << last_msg_->signature.data[4];
-  EXPECT_EQ(last_msg_->signature.data[5], 5)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[5])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[5])),
+      5)
       << "incorrect value for signature.data[5], expected 5, is "
       << last_msg_->signature.data[5];
-  EXPECT_EQ(last_msg_->signature.data[6], 6)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[6])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[6])),
+      6)
       << "incorrect value for signature.data[6], expected 6, is "
       << last_msg_->signature.data[6];
-  EXPECT_EQ(last_msg_->signature.data[7], 7)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[7])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[7])),
+      7)
       << "incorrect value for signature.data[7], expected 7, is "
       << last_msg_->signature.data[7];
-  EXPECT_EQ(last_msg_->signature.data[8], 8)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[8])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[8])),
+      8)
       << "incorrect value for signature.data[8], expected 8, is "
       << last_msg_->signature.data[8];
-  EXPECT_EQ(last_msg_->signature.data[9], 9)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[9])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[9])),
+      9)
       << "incorrect value for signature.data[9], expected 9, is "
       << last_msg_->signature.data[9];
-  EXPECT_EQ(last_msg_->signature.data[10], 10)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[10])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[10])),
+      10)
       << "incorrect value for signature.data[10], expected 10, is "
       << last_msg_->signature.data[10];
-  EXPECT_EQ(last_msg_->signature.data[11], 11)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[11])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[11])),
+      11)
       << "incorrect value for signature.data[11], expected 11, is "
       << last_msg_->signature.data[11];
-  EXPECT_EQ(last_msg_->signature.data[12], 12)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[12])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[12])),
+      12)
       << "incorrect value for signature.data[12], expected 12, is "
       << last_msg_->signature.data[12];
-  EXPECT_EQ(last_msg_->signature.data[13], 13)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[13])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[13])),
+      13)
       << "incorrect value for signature.data[13], expected 13, is "
       << last_msg_->signature.data[13];
-  EXPECT_EQ(last_msg_->signature.data[14], 14)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[14])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[14])),
+      14)
       << "incorrect value for signature.data[14], expected 14, is "
       << last_msg_->signature.data[14];
-  EXPECT_EQ(last_msg_->signature.data[15], 15)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[15])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[15])),
+      15)
       << "incorrect value for signature.data[15], expected 15, is "
       << last_msg_->signature.data[15];
-  EXPECT_EQ(last_msg_->signature.data[16], 16)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[16])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[16])),
+      16)
       << "incorrect value for signature.data[16], expected 16, is "
       << last_msg_->signature.data[16];
-  EXPECT_EQ(last_msg_->signature.data[17], 17)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[17])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[17])),
+      17)
       << "incorrect value for signature.data[17], expected 17, is "
       << last_msg_->signature.data[17];
-  EXPECT_EQ(last_msg_->signature.data[18], 18)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[18])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[18])),
+      18)
       << "incorrect value for signature.data[18], expected 18, is "
       << last_msg_->signature.data[18];
-  EXPECT_EQ(last_msg_->signature.data[19], 19)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[19])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[19])),
+      19)
       << "incorrect value for signature.data[19], expected 19, is "
       << last_msg_->signature.data[19];
-  EXPECT_EQ(last_msg_->signature.data[20], 20)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[20])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[20])),
+      20)
       << "incorrect value for signature.data[20], expected 20, is "
       << last_msg_->signature.data[20];
-  EXPECT_EQ(last_msg_->signature.data[21], 21)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[21])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[21])),
+      21)
       << "incorrect value for signature.data[21], expected 21, is "
       << last_msg_->signature.data[21];
-  EXPECT_EQ(last_msg_->signature.data[22], 22)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[22])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[22])),
+      22)
       << "incorrect value for signature.data[22], expected 22, is "
       << last_msg_->signature.data[22];
-  EXPECT_EQ(last_msg_->signature.data[23], 23)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[23])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[23])),
+      23)
       << "incorrect value for signature.data[23], expected 23, is "
       << last_msg_->signature.data[23];
-  EXPECT_EQ(last_msg_->signature.data[24], 24)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[24])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[24])),
+      24)
       << "incorrect value for signature.data[24], expected 24, is "
       << last_msg_->signature.data[24];
-  EXPECT_EQ(last_msg_->signature.data[25], 25)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[25])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[25])),
+      25)
       << "incorrect value for signature.data[25], expected 25, is "
       << last_msg_->signature.data[25];
-  EXPECT_EQ(last_msg_->signature.data[26], 26)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[26])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[26])),
+      26)
       << "incorrect value for signature.data[26], expected 26, is "
       << last_msg_->signature.data[26];
-  EXPECT_EQ(last_msg_->signature.data[27], 27)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[27])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[27])),
+      27)
       << "incorrect value for signature.data[27], expected 27, is "
       << last_msg_->signature.data[27];
-  EXPECT_EQ(last_msg_->signature.data[28], 28)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[28])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[28])),
+      28)
       << "incorrect value for signature.data[28], expected 28, is "
       << last_msg_->signature.data[28];
-  EXPECT_EQ(last_msg_->signature.data[29], 29)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[29])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[29])),
+      29)
       << "incorrect value for signature.data[29], expected 29, is "
       << last_msg_->signature.data[29];
-  EXPECT_EQ(last_msg_->signature.data[30], 30)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[30])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[30])),
+      30)
       << "incorrect value for signature.data[30], expected 30, is "
       << last_msg_->signature.data[30];
-  EXPECT_EQ(last_msg_->signature.data[31], 31)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[31])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[31])),
+      31)
       << "incorrect value for signature.data[31], expected 31, is "
       << last_msg_->signature.data[31];
-  EXPECT_EQ(last_msg_->signature.data[32], 32)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[32])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[32])),
+      32)
       << "incorrect value for signature.data[32], expected 32, is "
       << last_msg_->signature.data[32];
-  EXPECT_EQ(last_msg_->signature.data[33], 33)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[33])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[33])),
+      33)
       << "incorrect value for signature.data[33], expected 33, is "
       << last_msg_->signature.data[33];
-  EXPECT_EQ(last_msg_->signature.data[34], 34)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[34])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[34])),
+      34)
       << "incorrect value for signature.data[34], expected 34, is "
       << last_msg_->signature.data[34];
-  EXPECT_EQ(last_msg_->signature.data[35], 35)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[35])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[35])),
+      35)
       << "incorrect value for signature.data[35], expected 35, is "
       << last_msg_->signature.data[35];
-  EXPECT_EQ(last_msg_->signature.data[36], 36)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[36])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[36])),
+      36)
       << "incorrect value for signature.data[36], expected 36, is "
       << last_msg_->signature.data[36];
-  EXPECT_EQ(last_msg_->signature.data[37], 37)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[37])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[37])),
+      37)
       << "incorrect value for signature.data[37], expected 37, is "
       << last_msg_->signature.data[37];
-  EXPECT_EQ(last_msg_->signature.data[38], 38)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[38])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[38])),
+      38)
       << "incorrect value for signature.data[38], expected 38, is "
       << last_msg_->signature.data[38];
-  EXPECT_EQ(last_msg_->signature.data[39], 39)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[39])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[39])),
+      39)
       << "incorrect value for signature.data[39], expected 39, is "
       << last_msg_->signature.data[39];
-  EXPECT_EQ(last_msg_->signature.data[40], 40)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[40])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[40])),
+      40)
       << "incorrect value for signature.data[40], expected 40, is "
       << last_msg_->signature.data[40];
-  EXPECT_EQ(last_msg_->signature.data[41], 41)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[41])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[41])),
+      41)
       << "incorrect value for signature.data[41], expected 41, is "
       << last_msg_->signature.data[41];
-  EXPECT_EQ(last_msg_->signature.data[42], 42)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[42])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[42])),
+      42)
       << "incorrect value for signature.data[42], expected 42, is "
       << last_msg_->signature.data[42];
-  EXPECT_EQ(last_msg_->signature.data[43], 43)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[43])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[43])),
+      43)
       << "incorrect value for signature.data[43], expected 43, is "
       << last_msg_->signature.data[43];
-  EXPECT_EQ(last_msg_->signature.data[44], 44)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[44])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[44])),
+      44)
       << "incorrect value for signature.data[44], expected 44, is "
       << last_msg_->signature.data[44];
-  EXPECT_EQ(last_msg_->signature.data[45], 45)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[45])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[45])),
+      45)
       << "incorrect value for signature.data[45], expected 45, is "
       << last_msg_->signature.data[45];
-  EXPECT_EQ(last_msg_->signature.data[46], 46)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[46])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[46])),
+      46)
       << "incorrect value for signature.data[46], expected 46, is "
       << last_msg_->signature.data[46];
-  EXPECT_EQ(last_msg_->signature.data[47], 47)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[47])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[47])),
+      47)
       << "incorrect value for signature.data[47], expected 47, is "
       << last_msg_->signature.data[47];
-  EXPECT_EQ(last_msg_->signature.data[48], 48)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[48])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[48])),
+      48)
       << "incorrect value for signature.data[48], expected 48, is "
       << last_msg_->signature.data[48];
-  EXPECT_EQ(last_msg_->signature.data[49], 49)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[49])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[49])),
+      49)
       << "incorrect value for signature.data[49], expected 49, is "
       << last_msg_->signature.data[49];
-  EXPECT_EQ(last_msg_->signature.data[50], 50)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[50])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[50])),
+      50)
       << "incorrect value for signature.data[50], expected 50, is "
       << last_msg_->signature.data[50];
-  EXPECT_EQ(last_msg_->signature.data[51], 51)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[51])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[51])),
+      51)
       << "incorrect value for signature.data[51], expected 51, is "
       << last_msg_->signature.data[51];
-  EXPECT_EQ(last_msg_->signature.data[52], 52)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[52])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[52])),
+      52)
       << "incorrect value for signature.data[52], expected 52, is "
       << last_msg_->signature.data[52];
-  EXPECT_EQ(last_msg_->signature.data[53], 53)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[53])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[53])),
+      53)
       << "incorrect value for signature.data[53], expected 53, is "
       << last_msg_->signature.data[53];
-  EXPECT_EQ(last_msg_->signature.data[54], 54)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[54])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[54])),
+      54)
       << "incorrect value for signature.data[54], expected 54, is "
       << last_msg_->signature.data[54];
-  EXPECT_EQ(last_msg_->signature.data[55], 55)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[55])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[55])),
+      55)
       << "incorrect value for signature.data[55], expected 55, is "
       << last_msg_->signature.data[55];
-  EXPECT_EQ(last_msg_->signature.data[56], 56)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[56])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[56])),
+      56)
       << "incorrect value for signature.data[56], expected 56, is "
       << last_msg_->signature.data[56];
-  EXPECT_EQ(last_msg_->signature.data[57], 57)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[57])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[57])),
+      57)
       << "incorrect value for signature.data[57], expected 57, is "
       << last_msg_->signature.data[57];
-  EXPECT_EQ(last_msg_->signature.data[58], 58)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[58])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[58])),
+      58)
       << "incorrect value for signature.data[58], expected 58, is "
       << last_msg_->signature.data[58];
-  EXPECT_EQ(last_msg_->signature.data[59], 59)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[59])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[59])),
+      59)
       << "incorrect value for signature.data[59], expected 59, is "
       << last_msg_->signature.data[59];
-  EXPECT_EQ(last_msg_->signature.data[60], 60)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[60])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[60])),
+      60)
       << "incorrect value for signature.data[60], expected 60, is "
       << last_msg_->signature.data[60];
-  EXPECT_EQ(last_msg_->signature.data[61], 61)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[61])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[61])),
+      61)
       << "incorrect value for signature.data[61], expected 61, is "
       << last_msg_->signature.data[61];
-  EXPECT_EQ(last_msg_->signature.data[62], 62)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[62])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[62])),
+      62)
       << "incorrect value for signature.data[62], expected 62, is "
       << last_msg_->signature.data[62];
-  EXPECT_EQ(last_msg_->signature.data[63], 63)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[63])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[63])),
+      63)
       << "incorrect value for signature.data[63], expected 63, is "
       << last_msg_->signature.data[63];
-  EXPECT_EQ(last_msg_->signature.data[64], 64)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[64])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[64])),
+      64)
       << "incorrect value for signature.data[64], expected 64, is "
       << last_msg_->signature.data[64];
-  EXPECT_EQ(last_msg_->signature.data[65], 65)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[65])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[65])),
+      65)
       << "incorrect value for signature.data[65], expected 65, is "
       << last_msg_->signature.data[65];
-  EXPECT_EQ(last_msg_->signature.data[66], 66)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[66])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[66])),
+      66)
       << "incorrect value for signature.data[66], expected 66, is "
       << last_msg_->signature.data[66];
-  EXPECT_EQ(last_msg_->signature.data[67], 67)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[67])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[67])),
+      67)
       << "incorrect value for signature.data[67], expected 67, is "
       << last_msg_->signature.data[67];
-  EXPECT_EQ(last_msg_->signature.data[68], 68)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[68])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[68])),
+      68)
       << "incorrect value for signature.data[68], expected 68, is "
       << last_msg_->signature.data[68];
-  EXPECT_EQ(last_msg_->signature.data[69], 69)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[69])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[69])),
+      69)
       << "incorrect value for signature.data[69], expected 69, is "
       << last_msg_->signature.data[69];
-  EXPECT_EQ(last_msg_->signature.data[70], 70)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[70])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[70])),
+      70)
       << "incorrect value for signature.data[70], expected 70, is "
       << last_msg_->signature.data[70];
-  EXPECT_EQ(last_msg_->signature.data[71], 71)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signature.data[71])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signature.data[71])),
+      71)
       << "incorrect value for signature.data[71], expected 71, is "
       << last_msg_->signature.data[71];
-  EXPECT_EQ(last_msg_->signature.len, 72)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature.len)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature.len)),
+            72)
       << "incorrect value for signature.len, expected 72, is "
       << last_msg_->signature.len;
-  EXPECT_EQ(last_msg_->signed_messages[0], 10)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[0])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[0])),
+      10)
       << "incorrect value for signed_messages[0], expected 10, is "
       << last_msg_->signed_messages[0];
-  EXPECT_EQ(last_msg_->signed_messages[1], 21)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[1])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[1])),
+      21)
       << "incorrect value for signed_messages[1], expected 21, is "
       << last_msg_->signed_messages[1];
-  EXPECT_EQ(last_msg_->signed_messages[2], 23)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[2])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[2])),
+      23)
       << "incorrect value for signed_messages[2], expected 23, is "
       << last_msg_->signed_messages[2];
-  EXPECT_EQ(last_msg_->stream_counter, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->stream_counter)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->stream_counter)),
+            1)
       << "incorrect value for stream_counter, expected 1, is "
       << last_msg_->stream_counter;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_signing_MsgEcdsaSignatureDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_signing_MsgEcdsaSignatureDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/signing.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_signing_MsgEcdsaSignatureDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -1579,768 +1586,1467 @@ TEST_F(Test_legacy_auto_check_sbp_signing_MsgEcdsaSignatureDepA0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->certificate_id[0], 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_id[0])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_id[0])),
+      1)
       << "incorrect value for certificate_id[0], expected 1, is "
       << last_msg_->certificate_id[0];
-  EXPECT_EQ(last_msg_->certificate_id[1], 2)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_id[1])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_id[1])),
+      2)
       << "incorrect value for certificate_id[1], expected 2, is "
       << last_msg_->certificate_id[1];
-  EXPECT_EQ(last_msg_->certificate_id[2], 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_id[2])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_id[2])),
+      3)
       << "incorrect value for certificate_id[2], expected 3, is "
       << last_msg_->certificate_id[2];
-  EXPECT_EQ(last_msg_->certificate_id[3], 4)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_id[3])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_id[3])),
+      4)
       << "incorrect value for certificate_id[3], expected 4, is "
       << last_msg_->certificate_id[3];
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->on_demand_counter, 2)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->on_demand_counter)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->on_demand_counter)),
+      2)
       << "incorrect value for on_demand_counter, expected 2, is "
       << last_msg_->on_demand_counter;
-  EXPECT_EQ(last_msg_->signature[0], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[0])),
+            0)
       << "incorrect value for signature[0], expected 0, is "
       << last_msg_->signature[0];
-  EXPECT_EQ(last_msg_->signature[1], 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[1])),
+            1)
       << "incorrect value for signature[1], expected 1, is "
       << last_msg_->signature[1];
-  EXPECT_EQ(last_msg_->signature[2], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[2])),
+            2)
       << "incorrect value for signature[2], expected 2, is "
       << last_msg_->signature[2];
-  EXPECT_EQ(last_msg_->signature[3], 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[3])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[3])),
+            3)
       << "incorrect value for signature[3], expected 3, is "
       << last_msg_->signature[3];
-  EXPECT_EQ(last_msg_->signature[4], 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[4])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[4])),
+            4)
       << "incorrect value for signature[4], expected 4, is "
       << last_msg_->signature[4];
-  EXPECT_EQ(last_msg_->signature[5], 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[5])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[5])),
+            5)
       << "incorrect value for signature[5], expected 5, is "
       << last_msg_->signature[5];
-  EXPECT_EQ(last_msg_->signature[6], 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[6])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[6])),
+            6)
       << "incorrect value for signature[6], expected 6, is "
       << last_msg_->signature[6];
-  EXPECT_EQ(last_msg_->signature[7], 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[7])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[7])),
+            7)
       << "incorrect value for signature[7], expected 7, is "
       << last_msg_->signature[7];
-  EXPECT_EQ(last_msg_->signature[8], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[8])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[8])),
+            0)
       << "incorrect value for signature[8], expected 0, is "
       << last_msg_->signature[8];
-  EXPECT_EQ(last_msg_->signature[9], 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[9])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[9])),
+            1)
       << "incorrect value for signature[9], expected 1, is "
       << last_msg_->signature[9];
-  EXPECT_EQ(last_msg_->signature[10], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[10])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[10])),
+            2)
       << "incorrect value for signature[10], expected 2, is "
       << last_msg_->signature[10];
-  EXPECT_EQ(last_msg_->signature[11], 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[11])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[11])),
+            3)
       << "incorrect value for signature[11], expected 3, is "
       << last_msg_->signature[11];
-  EXPECT_EQ(last_msg_->signature[12], 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[12])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[12])),
+            4)
       << "incorrect value for signature[12], expected 4, is "
       << last_msg_->signature[12];
-  EXPECT_EQ(last_msg_->signature[13], 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[13])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[13])),
+            5)
       << "incorrect value for signature[13], expected 5, is "
       << last_msg_->signature[13];
-  EXPECT_EQ(last_msg_->signature[14], 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[14])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[14])),
+            6)
       << "incorrect value for signature[14], expected 6, is "
       << last_msg_->signature[14];
-  EXPECT_EQ(last_msg_->signature[15], 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[15])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[15])),
+            7)
       << "incorrect value for signature[15], expected 7, is "
       << last_msg_->signature[15];
-  EXPECT_EQ(last_msg_->signature[16], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[16])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[16])),
+            0)
       << "incorrect value for signature[16], expected 0, is "
       << last_msg_->signature[16];
-  EXPECT_EQ(last_msg_->signature[17], 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[17])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[17])),
+            1)
       << "incorrect value for signature[17], expected 1, is "
       << last_msg_->signature[17];
-  EXPECT_EQ(last_msg_->signature[18], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[18])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[18])),
+            2)
       << "incorrect value for signature[18], expected 2, is "
       << last_msg_->signature[18];
-  EXPECT_EQ(last_msg_->signature[19], 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[19])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[19])),
+            3)
       << "incorrect value for signature[19], expected 3, is "
       << last_msg_->signature[19];
-  EXPECT_EQ(last_msg_->signature[20], 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[20])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[20])),
+            4)
       << "incorrect value for signature[20], expected 4, is "
       << last_msg_->signature[20];
-  EXPECT_EQ(last_msg_->signature[21], 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[21])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[21])),
+            5)
       << "incorrect value for signature[21], expected 5, is "
       << last_msg_->signature[21];
-  EXPECT_EQ(last_msg_->signature[22], 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[22])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[22])),
+            6)
       << "incorrect value for signature[22], expected 6, is "
       << last_msg_->signature[22];
-  EXPECT_EQ(last_msg_->signature[23], 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[23])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[23])),
+            7)
       << "incorrect value for signature[23], expected 7, is "
       << last_msg_->signature[23];
-  EXPECT_EQ(last_msg_->signature[24], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[24])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[24])),
+            0)
       << "incorrect value for signature[24], expected 0, is "
       << last_msg_->signature[24];
-  EXPECT_EQ(last_msg_->signature[25], 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[25])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[25])),
+            1)
       << "incorrect value for signature[25], expected 1, is "
       << last_msg_->signature[25];
-  EXPECT_EQ(last_msg_->signature[26], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[26])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[26])),
+            2)
       << "incorrect value for signature[26], expected 2, is "
       << last_msg_->signature[26];
-  EXPECT_EQ(last_msg_->signature[27], 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[27])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[27])),
+            3)
       << "incorrect value for signature[27], expected 3, is "
       << last_msg_->signature[27];
-  EXPECT_EQ(last_msg_->signature[28], 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[28])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[28])),
+            4)
       << "incorrect value for signature[28], expected 4, is "
       << last_msg_->signature[28];
-  EXPECT_EQ(last_msg_->signature[29], 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[29])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[29])),
+            5)
       << "incorrect value for signature[29], expected 5, is "
       << last_msg_->signature[29];
-  EXPECT_EQ(last_msg_->signature[30], 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[30])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[30])),
+            6)
       << "incorrect value for signature[30], expected 6, is "
       << last_msg_->signature[30];
-  EXPECT_EQ(last_msg_->signature[31], 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[31])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[31])),
+            7)
       << "incorrect value for signature[31], expected 7, is "
       << last_msg_->signature[31];
-  EXPECT_EQ(last_msg_->signature[32], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[32])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[32])),
+            0)
       << "incorrect value for signature[32], expected 0, is "
       << last_msg_->signature[32];
-  EXPECT_EQ(last_msg_->signature[33], 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[33])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[33])),
+            1)
       << "incorrect value for signature[33], expected 1, is "
       << last_msg_->signature[33];
-  EXPECT_EQ(last_msg_->signature[34], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[34])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[34])),
+            2)
       << "incorrect value for signature[34], expected 2, is "
       << last_msg_->signature[34];
-  EXPECT_EQ(last_msg_->signature[35], 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[35])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[35])),
+            3)
       << "incorrect value for signature[35], expected 3, is "
       << last_msg_->signature[35];
-  EXPECT_EQ(last_msg_->signature[36], 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[36])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[36])),
+            4)
       << "incorrect value for signature[36], expected 4, is "
       << last_msg_->signature[36];
-  EXPECT_EQ(last_msg_->signature[37], 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[37])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[37])),
+            5)
       << "incorrect value for signature[37], expected 5, is "
       << last_msg_->signature[37];
-  EXPECT_EQ(last_msg_->signature[38], 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[38])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[38])),
+            6)
       << "incorrect value for signature[38], expected 6, is "
       << last_msg_->signature[38];
-  EXPECT_EQ(last_msg_->signature[39], 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[39])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[39])),
+            7)
       << "incorrect value for signature[39], expected 7, is "
       << last_msg_->signature[39];
-  EXPECT_EQ(last_msg_->signature[40], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[40])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[40])),
+            0)
       << "incorrect value for signature[40], expected 0, is "
       << last_msg_->signature[40];
-  EXPECT_EQ(last_msg_->signature[41], 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[41])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[41])),
+            1)
       << "incorrect value for signature[41], expected 1, is "
       << last_msg_->signature[41];
-  EXPECT_EQ(last_msg_->signature[42], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[42])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[42])),
+            2)
       << "incorrect value for signature[42], expected 2, is "
       << last_msg_->signature[42];
-  EXPECT_EQ(last_msg_->signature[43], 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[43])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[43])),
+            3)
       << "incorrect value for signature[43], expected 3, is "
       << last_msg_->signature[43];
-  EXPECT_EQ(last_msg_->signature[44], 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[44])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[44])),
+            4)
       << "incorrect value for signature[44], expected 4, is "
       << last_msg_->signature[44];
-  EXPECT_EQ(last_msg_->signature[45], 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[45])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[45])),
+            5)
       << "incorrect value for signature[45], expected 5, is "
       << last_msg_->signature[45];
-  EXPECT_EQ(last_msg_->signature[46], 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[46])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[46])),
+            6)
       << "incorrect value for signature[46], expected 6, is "
       << last_msg_->signature[46];
-  EXPECT_EQ(last_msg_->signature[47], 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[47])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[47])),
+            7)
       << "incorrect value for signature[47], expected 7, is "
       << last_msg_->signature[47];
-  EXPECT_EQ(last_msg_->signature[48], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[48])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[48])),
+            0)
       << "incorrect value for signature[48], expected 0, is "
       << last_msg_->signature[48];
-  EXPECT_EQ(last_msg_->signature[49], 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[49])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[49])),
+            1)
       << "incorrect value for signature[49], expected 1, is "
       << last_msg_->signature[49];
-  EXPECT_EQ(last_msg_->signature[50], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[50])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[50])),
+            2)
       << "incorrect value for signature[50], expected 2, is "
       << last_msg_->signature[50];
-  EXPECT_EQ(last_msg_->signature[51], 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[51])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[51])),
+            3)
       << "incorrect value for signature[51], expected 3, is "
       << last_msg_->signature[51];
-  EXPECT_EQ(last_msg_->signature[52], 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[52])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[52])),
+            4)
       << "incorrect value for signature[52], expected 4, is "
       << last_msg_->signature[52];
-  EXPECT_EQ(last_msg_->signature[53], 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[53])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[53])),
+            5)
       << "incorrect value for signature[53], expected 5, is "
       << last_msg_->signature[53];
-  EXPECT_EQ(last_msg_->signature[54], 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[54])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[54])),
+            6)
       << "incorrect value for signature[54], expected 6, is "
       << last_msg_->signature[54];
-  EXPECT_EQ(last_msg_->signature[55], 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[55])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[55])),
+            7)
       << "incorrect value for signature[55], expected 7, is "
       << last_msg_->signature[55];
-  EXPECT_EQ(last_msg_->signature[56], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[56])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[56])),
+            0)
       << "incorrect value for signature[56], expected 0, is "
       << last_msg_->signature[56];
-  EXPECT_EQ(last_msg_->signature[57], 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[57])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[57])),
+            1)
       << "incorrect value for signature[57], expected 1, is "
       << last_msg_->signature[57];
-  EXPECT_EQ(last_msg_->signature[58], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[58])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[58])),
+            2)
       << "incorrect value for signature[58], expected 2, is "
       << last_msg_->signature[58];
-  EXPECT_EQ(last_msg_->signature[59], 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[59])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[59])),
+            3)
       << "incorrect value for signature[59], expected 3, is "
       << last_msg_->signature[59];
-  EXPECT_EQ(last_msg_->signature[60], 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[60])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[60])),
+            4)
       << "incorrect value for signature[60], expected 4, is "
       << last_msg_->signature[60];
-  EXPECT_EQ(last_msg_->signature[61], 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[61])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[61])),
+            5)
       << "incorrect value for signature[61], expected 5, is "
       << last_msg_->signature[61];
-  EXPECT_EQ(last_msg_->signature[62], 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[62])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[62])),
+            6)
       << "incorrect value for signature[62], expected 6, is "
       << last_msg_->signature[62];
-  EXPECT_EQ(last_msg_->signature[63], 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[63])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[63])),
+            7)
       << "incorrect value for signature[63], expected 7, is "
       << last_msg_->signature[63];
-  EXPECT_EQ(last_msg_->signed_messages[0], 10)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[0])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[0])),
+      10)
       << "incorrect value for signed_messages[0], expected 10, is "
       << last_msg_->signed_messages[0];
-  EXPECT_EQ(last_msg_->signed_messages[1], 21)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[1])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[1])),
+      21)
       << "incorrect value for signed_messages[1], expected 21, is "
       << last_msg_->signed_messages[1];
-  EXPECT_EQ(last_msg_->signed_messages[2], 23)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[2])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[2])),
+      23)
       << "incorrect value for signed_messages[2], expected 23, is "
       << last_msg_->signed_messages[2];
-  EXPECT_EQ(last_msg_->signed_messages[3], 63)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[3])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[3])),
+      63)
       << "incorrect value for signed_messages[3], expected 63, is "
       << last_msg_->signed_messages[3];
-  EXPECT_EQ(last_msg_->signed_messages[4], 140)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[4])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[4])),
+      140)
       << "incorrect value for signed_messages[4], expected 140, is "
       << last_msg_->signed_messages[4];
-  EXPECT_EQ(last_msg_->signed_messages[5], 37)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[5])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[5])),
+      37)
       << "incorrect value for signed_messages[5], expected 37, is "
       << last_msg_->signed_messages[5];
-  EXPECT_EQ(last_msg_->signed_messages[6], 130)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[6])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[6])),
+      130)
       << "incorrect value for signed_messages[6], expected 130, is "
       << last_msg_->signed_messages[6];
-  EXPECT_EQ(last_msg_->signed_messages[7], 106)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[7])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[7])),
+      106)
       << "incorrect value for signed_messages[7], expected 106, is "
       << last_msg_->signed_messages[7];
-  EXPECT_EQ(last_msg_->signed_messages[8], 28)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[8])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[8])),
+      28)
       << "incorrect value for signed_messages[8], expected 28, is "
       << last_msg_->signed_messages[8];
-  EXPECT_EQ(last_msg_->signed_messages[9], 40)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[9])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[9])),
+      40)
       << "incorrect value for signed_messages[9], expected 40, is "
       << last_msg_->signed_messages[9];
-  EXPECT_EQ(last_msg_->signed_messages[10], 165)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[10])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[10])),
+      165)
       << "incorrect value for signed_messages[10], expected 165, is "
       << last_msg_->signed_messages[10];
-  EXPECT_EQ(last_msg_->signed_messages[11], 179)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[11])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[11])),
+      179)
       << "incorrect value for signed_messages[11], expected 179, is "
       << last_msg_->signed_messages[11];
-  EXPECT_EQ(last_msg_->signed_messages[12], 73)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[12])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[12])),
+      73)
       << "incorrect value for signed_messages[12], expected 73, is "
       << last_msg_->signed_messages[12];
-  EXPECT_EQ(last_msg_->signed_messages[13], 178)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[13])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[13])),
+      178)
       << "incorrect value for signed_messages[13], expected 178, is "
       << last_msg_->signed_messages[13];
-  EXPECT_EQ(last_msg_->signed_messages[14], 60)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[14])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[14])),
+      60)
       << "incorrect value for signed_messages[14], expected 60, is "
       << last_msg_->signed_messages[14];
-  EXPECT_EQ(last_msg_->signed_messages[15], 126)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[15])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[15])),
+      126)
       << "incorrect value for signed_messages[15], expected 126, is "
       << last_msg_->signed_messages[15];
-  EXPECT_EQ(last_msg_->signed_messages[16], 114)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[16])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[16])),
+      114)
       << "incorrect value for signed_messages[16], expected 114, is "
       << last_msg_->signed_messages[16];
-  EXPECT_EQ(last_msg_->signed_messages[17], 78)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[17])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[17])),
+      78)
       << "incorrect value for signed_messages[17], expected 78, is "
       << last_msg_->signed_messages[17];
-  EXPECT_EQ(last_msg_->signed_messages[18], 113)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[18])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[18])),
+      113)
       << "incorrect value for signed_messages[18], expected 113, is "
       << last_msg_->signed_messages[18];
-  EXPECT_EQ(last_msg_->signed_messages[19], 27)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[19])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[19])),
+      27)
       << "incorrect value for signed_messages[19], expected 27, is "
       << last_msg_->signed_messages[19];
-  EXPECT_EQ(last_msg_->signed_messages[20], 95)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[20])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[20])),
+      95)
       << "incorrect value for signed_messages[20], expected 95, is "
       << last_msg_->signed_messages[20];
-  EXPECT_EQ(last_msg_->signed_messages[21], 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[21])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[21])),
+      3)
       << "incorrect value for signed_messages[21], expected 3, is "
       << last_msg_->signed_messages[21];
-  EXPECT_EQ(last_msg_->signed_messages[22], 62)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[22])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[22])),
+      62)
       << "incorrect value for signed_messages[22], expected 62, is "
       << last_msg_->signed_messages[22];
-  EXPECT_EQ(last_msg_->signed_messages[23], 104)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[23])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[23])),
+      104)
       << "incorrect value for signed_messages[23], expected 104, is "
       << last_msg_->signed_messages[23];
-  EXPECT_EQ(last_msg_->signed_messages[24], 145)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[24])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[24])),
+      145)
       << "incorrect value for signed_messages[24], expected 145, is "
       << last_msg_->signed_messages[24];
-  EXPECT_EQ(last_msg_->signed_messages[25], 96)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[25])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[25])),
+      96)
       << "incorrect value for signed_messages[25], expected 96, is "
       << last_msg_->signed_messages[25];
-  EXPECT_EQ(last_msg_->signed_messages[26], 19)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[26])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[26])),
+      19)
       << "incorrect value for signed_messages[26], expected 19, is "
       << last_msg_->signed_messages[26];
-  EXPECT_EQ(last_msg_->signed_messages[27], 92)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[27])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[27])),
+      92)
       << "incorrect value for signed_messages[27], expected 92, is "
       << last_msg_->signed_messages[27];
-  EXPECT_EQ(last_msg_->signed_messages[28], 123)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[28])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[28])),
+      123)
       << "incorrect value for signed_messages[28], expected 123, is "
       << last_msg_->signed_messages[28];
-  EXPECT_EQ(last_msg_->signed_messages[29], 14)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[29])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[29])),
+      14)
       << "incorrect value for signed_messages[29], expected 14, is "
       << last_msg_->signed_messages[29];
-  EXPECT_EQ(last_msg_->signed_messages[30], 90)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[30])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[30])),
+      90)
       << "incorrect value for signed_messages[30], expected 90, is "
       << last_msg_->signed_messages[30];
-  EXPECT_EQ(last_msg_->signed_messages[31], 153)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[31])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[31])),
+      153)
       << "incorrect value for signed_messages[31], expected 153, is "
       << last_msg_->signed_messages[31];
-  EXPECT_EQ(last_msg_->signed_messages[32], 183)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[32])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[32])),
+      183)
       << "incorrect value for signed_messages[32], expected 183, is "
       << last_msg_->signed_messages[32];
-  EXPECT_EQ(last_msg_->signed_messages[33], 9)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[33])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[33])),
+      9)
       << "incorrect value for signed_messages[33], expected 9, is "
       << last_msg_->signed_messages[33];
-  EXPECT_EQ(last_msg_->signed_messages[34], 72)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[34])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[34])),
+      72)
       << "incorrect value for signed_messages[34], expected 72, is "
       << last_msg_->signed_messages[34];
-  EXPECT_EQ(last_msg_->signed_messages[35], 81)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[35])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[35])),
+      81)
       << "incorrect value for signed_messages[35], expected 81, is "
       << last_msg_->signed_messages[35];
-  EXPECT_EQ(last_msg_->signed_messages[36], 118)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[36])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[36])),
+      118)
       << "incorrect value for signed_messages[36], expected 118, is "
       << last_msg_->signed_messages[36];
-  EXPECT_EQ(last_msg_->signed_messages[37], 112)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[37])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[37])),
+      112)
       << "incorrect value for signed_messages[37], expected 112, is "
       << last_msg_->signed_messages[37];
-  EXPECT_EQ(last_msg_->signed_messages[38], 124)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[38])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[38])),
+      124)
       << "incorrect value for signed_messages[38], expected 124, is "
       << last_msg_->signed_messages[38];
-  EXPECT_EQ(last_msg_->signed_messages[39], 16)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[39])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[39])),
+      16)
       << "incorrect value for signed_messages[39], expected 16, is "
       << last_msg_->signed_messages[39];
-  EXPECT_EQ(last_msg_->signed_messages[40], 182)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[40])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[40])),
+      182)
       << "incorrect value for signed_messages[40], expected 182, is "
       << last_msg_->signed_messages[40];
-  EXPECT_EQ(last_msg_->signed_messages[41], 76)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[41])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[41])),
+      76)
       << "incorrect value for signed_messages[41], expected 76, is "
       << last_msg_->signed_messages[41];
-  EXPECT_EQ(last_msg_->signed_messages[42], 146)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[42])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[42])),
+      146)
       << "incorrect value for signed_messages[42], expected 146, is "
       << last_msg_->signed_messages[42];
-  EXPECT_EQ(last_msg_->signed_messages[43], 115)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[43])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[43])),
+      115)
       << "incorrect value for signed_messages[43], expected 115, is "
       << last_msg_->signed_messages[43];
-  EXPECT_EQ(last_msg_->signed_messages[44], 58)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[44])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[44])),
+      58)
       << "incorrect value for signed_messages[44], expected 58, is "
       << last_msg_->signed_messages[44];
-  EXPECT_EQ(last_msg_->signed_messages[45], 144)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[45])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[45])),
+      144)
       << "incorrect value for signed_messages[45], expected 144, is "
       << last_msg_->signed_messages[45];
-  EXPECT_EQ(last_msg_->signed_messages[46], 17)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[46])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[46])),
+      17)
       << "incorrect value for signed_messages[46], expected 17, is "
       << last_msg_->signed_messages[46];
-  EXPECT_EQ(last_msg_->signed_messages[47], 105)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[47])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[47])),
+      105)
       << "incorrect value for signed_messages[47], expected 105, is "
       << last_msg_->signed_messages[47];
-  EXPECT_EQ(last_msg_->signed_messages[48], 66)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[48])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[48])),
+      66)
       << "incorrect value for signed_messages[48], expected 66, is "
       << last_msg_->signed_messages[48];
-  EXPECT_EQ(last_msg_->signed_messages[49], 31)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[49])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[49])),
+      31)
       << "incorrect value for signed_messages[49], expected 31, is "
       << last_msg_->signed_messages[49];
-  EXPECT_EQ(last_msg_->signed_messages[50], 135)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[50])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[50])),
+      135)
       << "incorrect value for signed_messages[50], expected 135, is "
       << last_msg_->signed_messages[50];
-  EXPECT_EQ(last_msg_->signed_messages[51], 54)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[51])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[51])),
+      54)
       << "incorrect value for signed_messages[51], expected 54, is "
       << last_msg_->signed_messages[51];
-  EXPECT_EQ(last_msg_->signed_messages[52], 100)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[52])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[52])),
+      100)
       << "incorrect value for signed_messages[52], expected 100, is "
       << last_msg_->signed_messages[52];
-  EXPECT_EQ(last_msg_->signed_messages[53], 84)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[53])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[53])),
+      84)
       << "incorrect value for signed_messages[53], expected 84, is "
       << last_msg_->signed_messages[53];
-  EXPECT_EQ(last_msg_->signed_messages[54], 181)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[54])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[54])),
+      181)
       << "incorrect value for signed_messages[54], expected 181, is "
       << last_msg_->signed_messages[54];
-  EXPECT_EQ(last_msg_->signed_messages[55], 103)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[55])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[55])),
+      103)
       << "incorrect value for signed_messages[55], expected 103, is "
       << last_msg_->signed_messages[55];
-  EXPECT_EQ(last_msg_->signed_messages[56], 11)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[56])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[56])),
+      11)
       << "incorrect value for signed_messages[56], expected 11, is "
       << last_msg_->signed_messages[56];
-  EXPECT_EQ(last_msg_->signed_messages[57], 88)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[57])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[57])),
+      88)
       << "incorrect value for signed_messages[57], expected 88, is "
       << last_msg_->signed_messages[57];
-  EXPECT_EQ(last_msg_->signed_messages[58], 133)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[58])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[58])),
+      133)
       << "incorrect value for signed_messages[58], expected 133, is "
       << last_msg_->signed_messages[58];
-  EXPECT_EQ(last_msg_->signed_messages[59], 155)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[59])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[59])),
+      155)
       << "incorrect value for signed_messages[59], expected 155, is "
       << last_msg_->signed_messages[59];
-  EXPECT_EQ(last_msg_->signed_messages[60], 167)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[60])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[60])),
+      167)
       << "incorrect value for signed_messages[60], expected 167, is "
       << last_msg_->signed_messages[60];
-  EXPECT_EQ(last_msg_->signed_messages[61], 173)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[61])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[61])),
+      173)
       << "incorrect value for signed_messages[61], expected 173, is "
       << last_msg_->signed_messages[61];
-  EXPECT_EQ(last_msg_->signed_messages[62], 143)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[62])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[62])),
+      143)
       << "incorrect value for signed_messages[62], expected 143, is "
       << last_msg_->signed_messages[62];
-  EXPECT_EQ(last_msg_->signed_messages[63], 86)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[63])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[63])),
+      86)
       << "incorrect value for signed_messages[63], expected 86, is "
       << last_msg_->signed_messages[63];
-  EXPECT_EQ(last_msg_->signed_messages[64], 158)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[64])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[64])),
+      158)
       << "incorrect value for signed_messages[64], expected 158, is "
       << last_msg_->signed_messages[64];
-  EXPECT_EQ(last_msg_->signed_messages[65], 20)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[65])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[65])),
+      20)
       << "incorrect value for signed_messages[65], expected 20, is "
       << last_msg_->signed_messages[65];
-  EXPECT_EQ(last_msg_->signed_messages[66], 168)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[66])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[66])),
+      168)
       << "incorrect value for signed_messages[66], expected 168, is "
       << last_msg_->signed_messages[66];
-  EXPECT_EQ(last_msg_->signed_messages[67], 132)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[67])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[67])),
+      132)
       << "incorrect value for signed_messages[67], expected 132, is "
       << last_msg_->signed_messages[67];
-  EXPECT_EQ(last_msg_->signed_messages[68], 141)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[68])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[68])),
+      141)
       << "incorrect value for signed_messages[68], expected 141, is "
       << last_msg_->signed_messages[68];
-  EXPECT_EQ(last_msg_->signed_messages[69], 102)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[69])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[69])),
+      102)
       << "incorrect value for signed_messages[69], expected 102, is "
       << last_msg_->signed_messages[69];
-  EXPECT_EQ(last_msg_->signed_messages[70], 50)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[70])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[70])),
+      50)
       << "incorrect value for signed_messages[70], expected 50, is "
       << last_msg_->signed_messages[70];
-  EXPECT_EQ(last_msg_->signed_messages[71], 48)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[71])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[71])),
+      48)
       << "incorrect value for signed_messages[71], expected 48, is "
       << last_msg_->signed_messages[71];
-  EXPECT_EQ(last_msg_->signed_messages[72], 71)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[72])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[72])),
+      71)
       << "incorrect value for signed_messages[72], expected 71, is "
       << last_msg_->signed_messages[72];
-  EXPECT_EQ(last_msg_->signed_messages[73], 147)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[73])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[73])),
+      147)
       << "incorrect value for signed_messages[73], expected 147, is "
       << last_msg_->signed_messages[73];
-  EXPECT_EQ(last_msg_->signed_messages[74], 53)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[74])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[74])),
+      53)
       << "incorrect value for signed_messages[74], expected 53, is "
       << last_msg_->signed_messages[74];
-  EXPECT_EQ(last_msg_->signed_messages[75], 87)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[75])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[75])),
+      87)
       << "incorrect value for signed_messages[75], expected 87, is "
       << last_msg_->signed_messages[75];
-  EXPECT_EQ(last_msg_->signed_messages[76], 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[76])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[76])),
+      1)
       << "incorrect value for signed_messages[76], expected 1, is "
       << last_msg_->signed_messages[76];
-  EXPECT_EQ(last_msg_->signed_messages[77], 108)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[77])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[77])),
+      108)
       << "incorrect value for signed_messages[77], expected 108, is "
       << last_msg_->signed_messages[77];
-  EXPECT_EQ(last_msg_->signed_messages[78], 138)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[78])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[78])),
+      138)
       << "incorrect value for signed_messages[78], expected 138, is "
       << last_msg_->signed_messages[78];
-  EXPECT_EQ(last_msg_->signed_messages[79], 36)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[79])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[79])),
+      36)
       << "incorrect value for signed_messages[79], expected 36, is "
       << last_msg_->signed_messages[79];
-  EXPECT_EQ(last_msg_->signed_messages[80], 134)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[80])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[80])),
+      134)
       << "incorrect value for signed_messages[80], expected 134, is "
       << last_msg_->signed_messages[80];
-  EXPECT_EQ(last_msg_->signed_messages[81], 139)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[81])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[81])),
+      139)
       << "incorrect value for signed_messages[81], expected 139, is "
       << last_msg_->signed_messages[81];
-  EXPECT_EQ(last_msg_->signed_messages[82], 163)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[82])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[82])),
+      163)
       << "incorrect value for signed_messages[82], expected 163, is "
       << last_msg_->signed_messages[82];
-  EXPECT_EQ(last_msg_->signed_messages[83], 82)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[83])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[83])),
+      82)
       << "incorrect value for signed_messages[83], expected 82, is "
       << last_msg_->signed_messages[83];
-  EXPECT_EQ(last_msg_->signed_messages[84], 43)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[84])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[84])),
+      43)
       << "incorrect value for signed_messages[84], expected 43, is "
       << last_msg_->signed_messages[84];
-  EXPECT_EQ(last_msg_->signed_messages[85], 52)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[85])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[85])),
+      52)
       << "incorrect value for signed_messages[85], expected 52, is "
       << last_msg_->signed_messages[85];
-  EXPECT_EQ(last_msg_->signed_messages[86], 150)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[86])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[86])),
+      150)
       << "incorrect value for signed_messages[86], expected 150, is "
       << last_msg_->signed_messages[86];
-  EXPECT_EQ(last_msg_->signed_messages[87], 12)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[87])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[87])),
+      12)
       << "incorrect value for signed_messages[87], expected 12, is "
       << last_msg_->signed_messages[87];
-  EXPECT_EQ(last_msg_->signed_messages[88], 30)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[88])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[88])),
+      30)
       << "incorrect value for signed_messages[88], expected 30, is "
       << last_msg_->signed_messages[88];
-  EXPECT_EQ(last_msg_->signed_messages[89], 110)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[89])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[89])),
+      110)
       << "incorrect value for signed_messages[89], expected 110, is "
       << last_msg_->signed_messages[89];
-  EXPECT_EQ(last_msg_->signed_messages[90], 156)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[90])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[90])),
+      156)
       << "incorrect value for signed_messages[90], expected 156, is "
       << last_msg_->signed_messages[90];
-  EXPECT_EQ(last_msg_->signed_messages[91], 107)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[91])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[91])),
+      107)
       << "incorrect value for signed_messages[91], expected 107, is "
       << last_msg_->signed_messages[91];
-  EXPECT_EQ(last_msg_->signed_messages[92], 120)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[92])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[92])),
+      120)
       << "incorrect value for signed_messages[92], expected 120, is "
       << last_msg_->signed_messages[92];
-  EXPECT_EQ(last_msg_->signed_messages[93], 91)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[93])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[93])),
+      91)
       << "incorrect value for signed_messages[93], expected 91, is "
       << last_msg_->signed_messages[93];
-  EXPECT_EQ(last_msg_->signed_messages[94], 122)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[94])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[94])),
+      122)
       << "incorrect value for signed_messages[94], expected 122, is "
       << last_msg_->signed_messages[94];
-  EXPECT_EQ(last_msg_->signed_messages[95], 69)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[95])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[95])),
+      69)
       << "incorrect value for signed_messages[95], expected 69, is "
       << last_msg_->signed_messages[95];
-  EXPECT_EQ(last_msg_->signed_messages[96], 164)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[96])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[96])),
+      164)
       << "incorrect value for signed_messages[96], expected 164, is "
       << last_msg_->signed_messages[96];
-  EXPECT_EQ(last_msg_->signed_messages[97], 170)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[97])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[97])),
+      170)
       << "incorrect value for signed_messages[97], expected 170, is "
       << last_msg_->signed_messages[97];
-  EXPECT_EQ(last_msg_->signed_messages[98], 116)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[98])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[98])),
+      116)
       << "incorrect value for signed_messages[98], expected 116, is "
       << last_msg_->signed_messages[98];
-  EXPECT_EQ(last_msg_->signed_messages[99], 25)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[99])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[99])),
+      25)
       << "incorrect value for signed_messages[99], expected 25, is "
       << last_msg_->signed_messages[99];
-  EXPECT_EQ(last_msg_->signed_messages[100], 94)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[100])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[100])),
+      94)
       << "incorrect value for signed_messages[100], expected 94, is "
       << last_msg_->signed_messages[100];
-  EXPECT_EQ(last_msg_->signed_messages[101], 5)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[101])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[101])),
+      5)
       << "incorrect value for signed_messages[101], expected 5, is "
       << last_msg_->signed_messages[101];
-  EXPECT_EQ(last_msg_->signed_messages[102], 22)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[102])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[102])),
+      22)
       << "incorrect value for signed_messages[102], expected 22, is "
       << last_msg_->signed_messages[102];
-  EXPECT_EQ(last_msg_->signed_messages[103], 24)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[103])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[103])),
+      24)
       << "incorrect value for signed_messages[103], expected 24, is "
       << last_msg_->signed_messages[103];
-  EXPECT_EQ(last_msg_->signed_messages[104], 162)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[104])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[104])),
+      162)
       << "incorrect value for signed_messages[104], expected 162, is "
       << last_msg_->signed_messages[104];
-  EXPECT_EQ(last_msg_->signed_messages[105], 175)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[105])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[105])),
+      175)
       << "incorrect value for signed_messages[105], expected 175, is "
       << last_msg_->signed_messages[105];
-  EXPECT_EQ(last_msg_->signed_messages[106], 38)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[106])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[106])),
+      38)
       << "incorrect value for signed_messages[106], expected 38, is "
       << last_msg_->signed_messages[106];
-  EXPECT_EQ(last_msg_->signed_messages[107], 157)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[107])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[107])),
+      157)
       << "incorrect value for signed_messages[107], expected 157, is "
       << last_msg_->signed_messages[107];
-  EXPECT_EQ(last_msg_->signed_messages[108], 98)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[108])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[108])),
+      98)
       << "incorrect value for signed_messages[108], expected 98, is "
       << last_msg_->signed_messages[108];
-  EXPECT_EQ(last_msg_->signed_messages[109], 44)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[109])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[109])),
+      44)
       << "incorrect value for signed_messages[109], expected 44, is "
       << last_msg_->signed_messages[109];
-  EXPECT_EQ(last_msg_->signed_messages[110], 160)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[110])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[110])),
+      160)
       << "incorrect value for signed_messages[110], expected 160, is "
       << last_msg_->signed_messages[110];
-  EXPECT_EQ(last_msg_->signed_messages[111], 47)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[111])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[111])),
+      47)
       << "incorrect value for signed_messages[111], expected 47, is "
       << last_msg_->signed_messages[111];
-  EXPECT_EQ(last_msg_->signed_messages[112], 97)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[112])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[112])),
+      97)
       << "incorrect value for signed_messages[112], expected 97, is "
       << last_msg_->signed_messages[112];
-  EXPECT_EQ(last_msg_->signed_messages[113], 142)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[113])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[113])),
+      142)
       << "incorrect value for signed_messages[113], expected 142, is "
       << last_msg_->signed_messages[113];
-  EXPECT_EQ(last_msg_->signed_messages[114], 8)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[114])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[114])),
+      8)
       << "incorrect value for signed_messages[114], expected 8, is "
       << last_msg_->signed_messages[114];
-  EXPECT_EQ(last_msg_->signed_messages[115], 74)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[115])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[115])),
+      74)
       << "incorrect value for signed_messages[115], expected 74, is "
       << last_msg_->signed_messages[115];
-  EXPECT_EQ(last_msg_->signed_messages[116], 13)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[116])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[116])),
+      13)
       << "incorrect value for signed_messages[116], expected 13, is "
       << last_msg_->signed_messages[116];
-  EXPECT_EQ(last_msg_->signed_messages[117], 177)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[117])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[117])),
+      177)
       << "incorrect value for signed_messages[117], expected 177, is "
       << last_msg_->signed_messages[117];
-  EXPECT_EQ(last_msg_->signed_messages[118], 15)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[118])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[118])),
+      15)
       << "incorrect value for signed_messages[118], expected 15, is "
       << last_msg_->signed_messages[118];
-  EXPECT_EQ(last_msg_->signed_messages[119], 128)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[119])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[119])),
+      128)
       << "incorrect value for signed_messages[119], expected 128, is "
       << last_msg_->signed_messages[119];
-  EXPECT_EQ(last_msg_->signed_messages[120], 26)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[120])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[120])),
+      26)
       << "incorrect value for signed_messages[120], expected 26, is "
       << last_msg_->signed_messages[120];
-  EXPECT_EQ(last_msg_->signed_messages[121], 131)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[121])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[121])),
+      131)
       << "incorrect value for signed_messages[121], expected 131, is "
       << last_msg_->signed_messages[121];
-  EXPECT_EQ(last_msg_->signed_messages[122], 154)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[122])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[122])),
+      154)
       << "incorrect value for signed_messages[122], expected 154, is "
       << last_msg_->signed_messages[122];
-  EXPECT_EQ(last_msg_->signed_messages[123], 65)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[123])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[123])),
+      65)
       << "incorrect value for signed_messages[123], expected 65, is "
       << last_msg_->signed_messages[123];
-  EXPECT_EQ(last_msg_->signed_messages[124], 169)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[124])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[124])),
+      169)
       << "incorrect value for signed_messages[124], expected 169, is "
       << last_msg_->signed_messages[124];
-  EXPECT_EQ(last_msg_->signed_messages[125], 55)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[125])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[125])),
+      55)
       << "incorrect value for signed_messages[125], expected 55, is "
       << last_msg_->signed_messages[125];
-  EXPECT_EQ(last_msg_->signed_messages[126], 136)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[126])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[126])),
+      136)
       << "incorrect value for signed_messages[126], expected 136, is "
       << last_msg_->signed_messages[126];
-  EXPECT_EQ(last_msg_->signed_messages[127], 125)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[127])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[127])),
+      125)
       << "incorrect value for signed_messages[127], expected 125, is "
       << last_msg_->signed_messages[127];
-  EXPECT_EQ(last_msg_->signed_messages[128], 171)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[128])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[128])),
+      171)
       << "incorrect value for signed_messages[128], expected 171, is "
       << last_msg_->signed_messages[128];
-  EXPECT_EQ(last_msg_->signed_messages[129], 161)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[129])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[129])),
+      161)
       << "incorrect value for signed_messages[129], expected 161, is "
       << last_msg_->signed_messages[129];
-  EXPECT_EQ(last_msg_->signed_messages[130], 29)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[130])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[130])),
+      29)
       << "incorrect value for signed_messages[130], expected 29, is "
       << last_msg_->signed_messages[130];
-  EXPECT_EQ(last_msg_->signed_messages[131], 129)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[131])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[131])),
+      129)
       << "incorrect value for signed_messages[131], expected 129, is "
       << last_msg_->signed_messages[131];
-  EXPECT_EQ(last_msg_->signed_messages[132], 151)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[132])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[132])),
+      151)
       << "incorrect value for signed_messages[132], expected 151, is "
       << last_msg_->signed_messages[132];
-  EXPECT_EQ(last_msg_->signed_messages[133], 68)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[133])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[133])),
+      68)
       << "incorrect value for signed_messages[133], expected 68, is "
       << last_msg_->signed_messages[133];
-  EXPECT_EQ(last_msg_->signed_messages[134], 166)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[134])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[134])),
+      166)
       << "incorrect value for signed_messages[134], expected 166, is "
       << last_msg_->signed_messages[134];
-  EXPECT_EQ(last_msg_->signed_messages[135], 51)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[135])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[135])),
+      51)
       << "incorrect value for signed_messages[135], expected 51, is "
       << last_msg_->signed_messages[135];
-  EXPECT_EQ(last_msg_->signed_messages[136], 70)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[136])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[136])),
+      70)
       << "incorrect value for signed_messages[136], expected 70, is "
       << last_msg_->signed_messages[136];
-  EXPECT_EQ(last_msg_->signed_messages[137], 45)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[137])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[137])),
+      45)
       << "incorrect value for signed_messages[137], expected 45, is "
       << last_msg_->signed_messages[137];
-  EXPECT_EQ(last_msg_->signed_messages[138], 56)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[138])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[138])),
+      56)
       << "incorrect value for signed_messages[138], expected 56, is "
       << last_msg_->signed_messages[138];
-  EXPECT_EQ(last_msg_->signed_messages[139], 79)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[139])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[139])),
+      79)
       << "incorrect value for signed_messages[139], expected 79, is "
       << last_msg_->signed_messages[139];
-  EXPECT_EQ(last_msg_->signed_messages[140], 149)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[140])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[140])),
+      149)
       << "incorrect value for signed_messages[140], expected 149, is "
       << last_msg_->signed_messages[140];
-  EXPECT_EQ(last_msg_->signed_messages[141], 99)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[141])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[141])),
+      99)
       << "incorrect value for signed_messages[141], expected 99, is "
       << last_msg_->signed_messages[141];
-  EXPECT_EQ(last_msg_->signed_messages[142], 42)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[142])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[142])),
+      42)
       << "incorrect value for signed_messages[142], expected 42, is "
       << last_msg_->signed_messages[142];
-  EXPECT_EQ(last_msg_->signed_messages[143], 101)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[143])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[143])),
+      101)
       << "incorrect value for signed_messages[143], expected 101, is "
       << last_msg_->signed_messages[143];
-  EXPECT_EQ(last_msg_->signed_messages[144], 152)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[144])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[144])),
+      152)
       << "incorrect value for signed_messages[144], expected 152, is "
       << last_msg_->signed_messages[144];
-  EXPECT_EQ(last_msg_->signed_messages[145], 39)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[145])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[145])),
+      39)
       << "incorrect value for signed_messages[145], expected 39, is "
       << last_msg_->signed_messages[145];
-  EXPECT_EQ(last_msg_->signed_messages[146], 89)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[146])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[146])),
+      89)
       << "incorrect value for signed_messages[146], expected 89, is "
       << last_msg_->signed_messages[146];
-  EXPECT_EQ(last_msg_->signed_messages[147], 180)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[147])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[147])),
+      180)
       << "incorrect value for signed_messages[147], expected 180, is "
       << last_msg_->signed_messages[147];
-  EXPECT_EQ(last_msg_->signed_messages[148], 64)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[148])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[148])),
+      64)
       << "incorrect value for signed_messages[148], expected 64, is "
       << last_msg_->signed_messages[148];
-  EXPECT_EQ(last_msg_->signed_messages[149], 49)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[149])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[149])),
+      49)
       << "incorrect value for signed_messages[149], expected 49, is "
       << last_msg_->signed_messages[149];
-  EXPECT_EQ(last_msg_->signed_messages[150], 6)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[150])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[150])),
+      6)
       << "incorrect value for signed_messages[150], expected 6, is "
       << last_msg_->signed_messages[150];
-  EXPECT_EQ(last_msg_->signed_messages[151], 80)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[151])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[151])),
+      80)
       << "incorrect value for signed_messages[151], expected 80, is "
       << last_msg_->signed_messages[151];
-  EXPECT_EQ(last_msg_->signed_messages[152], 172)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[152])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[152])),
+      172)
       << "incorrect value for signed_messages[152], expected 172, is "
       << last_msg_->signed_messages[152];
-  EXPECT_EQ(last_msg_->signed_messages[153], 32)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[153])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[153])),
+      32)
       << "incorrect value for signed_messages[153], expected 32, is "
       << last_msg_->signed_messages[153];
-  EXPECT_EQ(last_msg_->signed_messages[154], 109)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[154])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[154])),
+      109)
       << "incorrect value for signed_messages[154], expected 109, is "
       << last_msg_->signed_messages[154];
-  EXPECT_EQ(last_msg_->signed_messages[155], 2)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[155])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[155])),
+      2)
       << "incorrect value for signed_messages[155], expected 2, is "
       << last_msg_->signed_messages[155];
-  EXPECT_EQ(last_msg_->signed_messages[156], 119)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[156])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[156])),
+      119)
       << "incorrect value for signed_messages[156], expected 119, is "
       << last_msg_->signed_messages[156];
-  EXPECT_EQ(last_msg_->signed_messages[157], 93)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[157])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[157])),
+      93)
       << "incorrect value for signed_messages[157], expected 93, is "
       << last_msg_->signed_messages[157];
-  EXPECT_EQ(last_msg_->signed_messages[158], 176)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[158])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[158])),
+      176)
       << "incorrect value for signed_messages[158], expected 176, is "
       << last_msg_->signed_messages[158];
-  EXPECT_EQ(last_msg_->signed_messages[159], 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[159])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[159])),
+      0)
       << "incorrect value for signed_messages[159], expected 0, is "
       << last_msg_->signed_messages[159];
-  EXPECT_EQ(last_msg_->signed_messages[160], 33)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[160])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[160])),
+      33)
       << "incorrect value for signed_messages[160], expected 33, is "
       << last_msg_->signed_messages[160];
-  EXPECT_EQ(last_msg_->signed_messages[161], 57)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[161])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[161])),
+      57)
       << "incorrect value for signed_messages[161], expected 57, is "
       << last_msg_->signed_messages[161];
-  EXPECT_EQ(last_msg_->signed_messages[162], 34)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[162])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[162])),
+      34)
       << "incorrect value for signed_messages[162], expected 34, is "
       << last_msg_->signed_messages[162];
-  EXPECT_EQ(last_msg_->signed_messages[163], 18)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[163])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[163])),
+      18)
       << "incorrect value for signed_messages[163], expected 18, is "
       << last_msg_->signed_messages[163];
-  EXPECT_EQ(last_msg_->signed_messages[164], 85)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[164])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[164])),
+      85)
       << "incorrect value for signed_messages[164], expected 85, is "
       << last_msg_->signed_messages[164];
-  EXPECT_EQ(last_msg_->signed_messages[165], 121)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[165])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[165])),
+      121)
       << "incorrect value for signed_messages[165], expected 121, is "
       << last_msg_->signed_messages[165];
-  EXPECT_EQ(last_msg_->signed_messages[166], 137)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[166])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[166])),
+      137)
       << "incorrect value for signed_messages[166], expected 137, is "
       << last_msg_->signed_messages[166];
-  EXPECT_EQ(last_msg_->signed_messages[167], 83)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[167])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[167])),
+      83)
       << "incorrect value for signed_messages[167], expected 83, is "
       << last_msg_->signed_messages[167];
-  EXPECT_EQ(last_msg_->signed_messages[168], 111)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[168])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[168])),
+      111)
       << "incorrect value for signed_messages[168], expected 111, is "
       << last_msg_->signed_messages[168];
-  EXPECT_EQ(last_msg_->signed_messages[169], 59)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[169])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[169])),
+      59)
       << "incorrect value for signed_messages[169], expected 59, is "
       << last_msg_->signed_messages[169];
-  EXPECT_EQ(last_msg_->signed_messages[170], 7)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[170])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[170])),
+      7)
       << "incorrect value for signed_messages[170], expected 7, is "
       << last_msg_->signed_messages[170];
-  EXPECT_EQ(last_msg_->signed_messages[171], 77)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[171])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[171])),
+      77)
       << "incorrect value for signed_messages[171], expected 77, is "
       << last_msg_->signed_messages[171];
-  EXPECT_EQ(last_msg_->signed_messages[172], 4)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[172])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[172])),
+      4)
       << "incorrect value for signed_messages[172], expected 4, is "
       << last_msg_->signed_messages[172];
-  EXPECT_EQ(last_msg_->signed_messages[173], 117)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[173])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[173])),
+      117)
       << "incorrect value for signed_messages[173], expected 117, is "
       << last_msg_->signed_messages[173];
-  EXPECT_EQ(last_msg_->signed_messages[174], 159)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[174])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[174])),
+      159)
       << "incorrect value for signed_messages[174], expected 159, is "
       << last_msg_->signed_messages[174];
-  EXPECT_EQ(last_msg_->signed_messages[175], 148)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[175])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[175])),
+      148)
       << "incorrect value for signed_messages[175], expected 148, is "
       << last_msg_->signed_messages[175];
-  EXPECT_EQ(last_msg_->signed_messages[176], 35)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[176])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[176])),
+      35)
       << "incorrect value for signed_messages[176], expected 35, is "
       << last_msg_->signed_messages[176];
-  EXPECT_EQ(last_msg_->signed_messages[177], 61)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[177])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[177])),
+      61)
       << "incorrect value for signed_messages[177], expected 61, is "
       << last_msg_->signed_messages[177];
-  EXPECT_EQ(last_msg_->signed_messages[178], 41)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[178])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[178])),
+      41)
       << "incorrect value for signed_messages[178], expected 41, is "
       << last_msg_->signed_messages[178];
-  EXPECT_EQ(last_msg_->signed_messages[179], 67)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[179])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[179])),
+      67)
       << "incorrect value for signed_messages[179], expected 67, is "
       << last_msg_->signed_messages[179];
-  EXPECT_EQ(last_msg_->signed_messages[180], 46)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[180])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[180])),
+      46)
       << "incorrect value for signed_messages[180], expected 46, is "
       << last_msg_->signed_messages[180];
-  EXPECT_EQ(last_msg_->signed_messages[181], 127)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[181])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[181])),
+      127)
       << "incorrect value for signed_messages[181], expected 127, is "
       << last_msg_->signed_messages[181];
-  EXPECT_EQ(last_msg_->signed_messages[182], 75)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[182])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[182])),
+      75)
       << "incorrect value for signed_messages[182], expected 75, is "
       << last_msg_->signed_messages[182];
-  EXPECT_EQ(last_msg_->signed_messages[183], 174)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[183])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[183])),
+      174)
       << "incorrect value for signed_messages[183], expected 174, is "
       << last_msg_->signed_messages[183];
-  EXPECT_EQ(last_msg_->stream_counter, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->stream_counter)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->stream_counter)),
+            1)
       << "incorrect value for stream_counter, expected 1, is "
       << last_msg_->stream_counter;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_signing_MsgEcdsaSignatureDepB.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_signing_MsgEcdsaSignatureDepB.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/signing.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_signing_MsgEcdsaSignatureDepB0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -522,252 +529,427 @@ TEST_F(Test_legacy_auto_check_sbp_signing_MsgEcdsaSignatureDepB0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->certificate_id[0], 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_id[0])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_id[0])),
+      1)
       << "incorrect value for certificate_id[0], expected 1, is "
       << last_msg_->certificate_id[0];
-  EXPECT_EQ(last_msg_->certificate_id[1], 2)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_id[1])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_id[1])),
+      2)
       << "incorrect value for certificate_id[1], expected 2, is "
       << last_msg_->certificate_id[1];
-  EXPECT_EQ(last_msg_->certificate_id[2], 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_id[2])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_id[2])),
+      3)
       << "incorrect value for certificate_id[2], expected 3, is "
       << last_msg_->certificate_id[2];
-  EXPECT_EQ(last_msg_->certificate_id[3], 4)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_id[3])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_id[3])),
+      4)
       << "incorrect value for certificate_id[3], expected 4, is "
       << last_msg_->certificate_id[3];
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_signature_bytes, 72)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->n_signature_bytes)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->n_signature_bytes)),
+      72)
       << "incorrect value for n_signature_bytes, expected 72, is "
       << last_msg_->n_signature_bytes;
-  EXPECT_EQ(last_msg_->on_demand_counter, 2)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->on_demand_counter)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->on_demand_counter)),
+      2)
       << "incorrect value for on_demand_counter, expected 2, is "
       << last_msg_->on_demand_counter;
-  EXPECT_EQ(last_msg_->signature[0], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[0])),
+            0)
       << "incorrect value for signature[0], expected 0, is "
       << last_msg_->signature[0];
-  EXPECT_EQ(last_msg_->signature[1], 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[1])),
+            1)
       << "incorrect value for signature[1], expected 1, is "
       << last_msg_->signature[1];
-  EXPECT_EQ(last_msg_->signature[2], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[2])),
+            2)
       << "incorrect value for signature[2], expected 2, is "
       << last_msg_->signature[2];
-  EXPECT_EQ(last_msg_->signature[3], 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[3])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[3])),
+            3)
       << "incorrect value for signature[3], expected 3, is "
       << last_msg_->signature[3];
-  EXPECT_EQ(last_msg_->signature[4], 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[4])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[4])),
+            4)
       << "incorrect value for signature[4], expected 4, is "
       << last_msg_->signature[4];
-  EXPECT_EQ(last_msg_->signature[5], 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[5])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[5])),
+            5)
       << "incorrect value for signature[5], expected 5, is "
       << last_msg_->signature[5];
-  EXPECT_EQ(last_msg_->signature[6], 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[6])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[6])),
+            6)
       << "incorrect value for signature[6], expected 6, is "
       << last_msg_->signature[6];
-  EXPECT_EQ(last_msg_->signature[7], 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[7])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[7])),
+            7)
       << "incorrect value for signature[7], expected 7, is "
       << last_msg_->signature[7];
-  EXPECT_EQ(last_msg_->signature[8], 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[8])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[8])),
+            8)
       << "incorrect value for signature[8], expected 8, is "
       << last_msg_->signature[8];
-  EXPECT_EQ(last_msg_->signature[9], 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[9])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[9])),
+            9)
       << "incorrect value for signature[9], expected 9, is "
       << last_msg_->signature[9];
-  EXPECT_EQ(last_msg_->signature[10], 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[10])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[10])),
+            10)
       << "incorrect value for signature[10], expected 10, is "
       << last_msg_->signature[10];
-  EXPECT_EQ(last_msg_->signature[11], 11)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[11])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[11])),
+            11)
       << "incorrect value for signature[11], expected 11, is "
       << last_msg_->signature[11];
-  EXPECT_EQ(last_msg_->signature[12], 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[12])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[12])),
+            12)
       << "incorrect value for signature[12], expected 12, is "
       << last_msg_->signature[12];
-  EXPECT_EQ(last_msg_->signature[13], 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[13])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[13])),
+            13)
       << "incorrect value for signature[13], expected 13, is "
       << last_msg_->signature[13];
-  EXPECT_EQ(last_msg_->signature[14], 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[14])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[14])),
+            14)
       << "incorrect value for signature[14], expected 14, is "
       << last_msg_->signature[14];
-  EXPECT_EQ(last_msg_->signature[15], 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[15])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[15])),
+            15)
       << "incorrect value for signature[15], expected 15, is "
       << last_msg_->signature[15];
-  EXPECT_EQ(last_msg_->signature[16], 16)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[16])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[16])),
+            16)
       << "incorrect value for signature[16], expected 16, is "
       << last_msg_->signature[16];
-  EXPECT_EQ(last_msg_->signature[17], 17)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[17])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[17])),
+            17)
       << "incorrect value for signature[17], expected 17, is "
       << last_msg_->signature[17];
-  EXPECT_EQ(last_msg_->signature[18], 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[18])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[18])),
+            18)
       << "incorrect value for signature[18], expected 18, is "
       << last_msg_->signature[18];
-  EXPECT_EQ(last_msg_->signature[19], 19)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[19])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[19])),
+            19)
       << "incorrect value for signature[19], expected 19, is "
       << last_msg_->signature[19];
-  EXPECT_EQ(last_msg_->signature[20], 20)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[20])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[20])),
+            20)
       << "incorrect value for signature[20], expected 20, is "
       << last_msg_->signature[20];
-  EXPECT_EQ(last_msg_->signature[21], 21)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[21])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[21])),
+            21)
       << "incorrect value for signature[21], expected 21, is "
       << last_msg_->signature[21];
-  EXPECT_EQ(last_msg_->signature[22], 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[22])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[22])),
+            22)
       << "incorrect value for signature[22], expected 22, is "
       << last_msg_->signature[22];
-  EXPECT_EQ(last_msg_->signature[23], 23)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[23])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[23])),
+            23)
       << "incorrect value for signature[23], expected 23, is "
       << last_msg_->signature[23];
-  EXPECT_EQ(last_msg_->signature[24], 24)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[24])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[24])),
+            24)
       << "incorrect value for signature[24], expected 24, is "
       << last_msg_->signature[24];
-  EXPECT_EQ(last_msg_->signature[25], 25)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[25])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[25])),
+            25)
       << "incorrect value for signature[25], expected 25, is "
       << last_msg_->signature[25];
-  EXPECT_EQ(last_msg_->signature[26], 26)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[26])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[26])),
+            26)
       << "incorrect value for signature[26], expected 26, is "
       << last_msg_->signature[26];
-  EXPECT_EQ(last_msg_->signature[27], 27)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[27])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[27])),
+            27)
       << "incorrect value for signature[27], expected 27, is "
       << last_msg_->signature[27];
-  EXPECT_EQ(last_msg_->signature[28], 28)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[28])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[28])),
+            28)
       << "incorrect value for signature[28], expected 28, is "
       << last_msg_->signature[28];
-  EXPECT_EQ(last_msg_->signature[29], 29)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[29])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[29])),
+            29)
       << "incorrect value for signature[29], expected 29, is "
       << last_msg_->signature[29];
-  EXPECT_EQ(last_msg_->signature[30], 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[30])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[30])),
+            30)
       << "incorrect value for signature[30], expected 30, is "
       << last_msg_->signature[30];
-  EXPECT_EQ(last_msg_->signature[31], 31)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[31])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[31])),
+            31)
       << "incorrect value for signature[31], expected 31, is "
       << last_msg_->signature[31];
-  EXPECT_EQ(last_msg_->signature[32], 32)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[32])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[32])),
+            32)
       << "incorrect value for signature[32], expected 32, is "
       << last_msg_->signature[32];
-  EXPECT_EQ(last_msg_->signature[33], 33)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[33])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[33])),
+            33)
       << "incorrect value for signature[33], expected 33, is "
       << last_msg_->signature[33];
-  EXPECT_EQ(last_msg_->signature[34], 34)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[34])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[34])),
+            34)
       << "incorrect value for signature[34], expected 34, is "
       << last_msg_->signature[34];
-  EXPECT_EQ(last_msg_->signature[35], 35)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[35])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[35])),
+            35)
       << "incorrect value for signature[35], expected 35, is "
       << last_msg_->signature[35];
-  EXPECT_EQ(last_msg_->signature[36], 36)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[36])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[36])),
+            36)
       << "incorrect value for signature[36], expected 36, is "
       << last_msg_->signature[36];
-  EXPECT_EQ(last_msg_->signature[37], 37)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[37])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[37])),
+            37)
       << "incorrect value for signature[37], expected 37, is "
       << last_msg_->signature[37];
-  EXPECT_EQ(last_msg_->signature[38], 38)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[38])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[38])),
+            38)
       << "incorrect value for signature[38], expected 38, is "
       << last_msg_->signature[38];
-  EXPECT_EQ(last_msg_->signature[39], 39)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[39])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[39])),
+            39)
       << "incorrect value for signature[39], expected 39, is "
       << last_msg_->signature[39];
-  EXPECT_EQ(last_msg_->signature[40], 40)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[40])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[40])),
+            40)
       << "incorrect value for signature[40], expected 40, is "
       << last_msg_->signature[40];
-  EXPECT_EQ(last_msg_->signature[41], 41)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[41])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[41])),
+            41)
       << "incorrect value for signature[41], expected 41, is "
       << last_msg_->signature[41];
-  EXPECT_EQ(last_msg_->signature[42], 42)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[42])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[42])),
+            42)
       << "incorrect value for signature[42], expected 42, is "
       << last_msg_->signature[42];
-  EXPECT_EQ(last_msg_->signature[43], 43)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[43])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[43])),
+            43)
       << "incorrect value for signature[43], expected 43, is "
       << last_msg_->signature[43];
-  EXPECT_EQ(last_msg_->signature[44], 44)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[44])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[44])),
+            44)
       << "incorrect value for signature[44], expected 44, is "
       << last_msg_->signature[44];
-  EXPECT_EQ(last_msg_->signature[45], 45)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[45])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[45])),
+            45)
       << "incorrect value for signature[45], expected 45, is "
       << last_msg_->signature[45];
-  EXPECT_EQ(last_msg_->signature[46], 46)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[46])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[46])),
+            46)
       << "incorrect value for signature[46], expected 46, is "
       << last_msg_->signature[46];
-  EXPECT_EQ(last_msg_->signature[47], 47)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[47])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[47])),
+            47)
       << "incorrect value for signature[47], expected 47, is "
       << last_msg_->signature[47];
-  EXPECT_EQ(last_msg_->signature[48], 48)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[48])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[48])),
+            48)
       << "incorrect value for signature[48], expected 48, is "
       << last_msg_->signature[48];
-  EXPECT_EQ(last_msg_->signature[49], 49)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[49])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[49])),
+            49)
       << "incorrect value for signature[49], expected 49, is "
       << last_msg_->signature[49];
-  EXPECT_EQ(last_msg_->signature[50], 50)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[50])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[50])),
+            50)
       << "incorrect value for signature[50], expected 50, is "
       << last_msg_->signature[50];
-  EXPECT_EQ(last_msg_->signature[51], 51)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[51])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[51])),
+            51)
       << "incorrect value for signature[51], expected 51, is "
       << last_msg_->signature[51];
-  EXPECT_EQ(last_msg_->signature[52], 52)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[52])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[52])),
+            52)
       << "incorrect value for signature[52], expected 52, is "
       << last_msg_->signature[52];
-  EXPECT_EQ(last_msg_->signature[53], 53)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[53])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[53])),
+            53)
       << "incorrect value for signature[53], expected 53, is "
       << last_msg_->signature[53];
-  EXPECT_EQ(last_msg_->signature[54], 54)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[54])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[54])),
+            54)
       << "incorrect value for signature[54], expected 54, is "
       << last_msg_->signature[54];
-  EXPECT_EQ(last_msg_->signature[55], 55)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[55])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[55])),
+            55)
       << "incorrect value for signature[55], expected 55, is "
       << last_msg_->signature[55];
-  EXPECT_EQ(last_msg_->signature[56], 56)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[56])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[56])),
+            56)
       << "incorrect value for signature[56], expected 56, is "
       << last_msg_->signature[56];
-  EXPECT_EQ(last_msg_->signature[57], 57)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[57])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[57])),
+            57)
       << "incorrect value for signature[57], expected 57, is "
       << last_msg_->signature[57];
-  EXPECT_EQ(last_msg_->signature[58], 58)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[58])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[58])),
+            58)
       << "incorrect value for signature[58], expected 58, is "
       << last_msg_->signature[58];
-  EXPECT_EQ(last_msg_->signature[59], 59)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[59])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[59])),
+            59)
       << "incorrect value for signature[59], expected 59, is "
       << last_msg_->signature[59];
-  EXPECT_EQ(last_msg_->signature[60], 60)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[60])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[60])),
+            60)
       << "incorrect value for signature[60], expected 60, is "
       << last_msg_->signature[60];
-  EXPECT_EQ(last_msg_->signature[61], 61)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[61])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[61])),
+            61)
       << "incorrect value for signature[61], expected 61, is "
       << last_msg_->signature[61];
-  EXPECT_EQ(last_msg_->signature[62], 62)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[62])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[62])),
+            62)
       << "incorrect value for signature[62], expected 62, is "
       << last_msg_->signature[62];
-  EXPECT_EQ(last_msg_->signature[63], 63)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[63])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[63])),
+            63)
       << "incorrect value for signature[63], expected 63, is "
       << last_msg_->signature[63];
-  EXPECT_EQ(last_msg_->signature[64], 64)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[64])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[64])),
+            64)
       << "incorrect value for signature[64], expected 64, is "
       << last_msg_->signature[64];
-  EXPECT_EQ(last_msg_->signature[65], 65)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[65])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[65])),
+            65)
       << "incorrect value for signature[65], expected 65, is "
       << last_msg_->signature[65];
-  EXPECT_EQ(last_msg_->signature[66], 66)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[66])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[66])),
+            66)
       << "incorrect value for signature[66], expected 66, is "
       << last_msg_->signature[66];
-  EXPECT_EQ(last_msg_->signature[67], 67)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[67])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[67])),
+            67)
       << "incorrect value for signature[67], expected 67, is "
       << last_msg_->signature[67];
-  EXPECT_EQ(last_msg_->signature[68], 68)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[68])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[68])),
+            68)
       << "incorrect value for signature[68], expected 68, is "
       << last_msg_->signature[68];
-  EXPECT_EQ(last_msg_->signature[69], 69)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[69])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[69])),
+            69)
       << "incorrect value for signature[69], expected 69, is "
       << last_msg_->signature[69];
-  EXPECT_EQ(last_msg_->signature[70], 70)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[70])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[70])),
+            70)
       << "incorrect value for signature[70], expected 70, is "
       << last_msg_->signature[70];
-  EXPECT_EQ(last_msg_->signature[71], 71)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[71])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[71])),
+            71)
       << "incorrect value for signature[71], expected 71, is "
       << last_msg_->signature[71];
-  EXPECT_EQ(last_msg_->signed_messages[0], 10)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[0])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[0])),
+      10)
       << "incorrect value for signed_messages[0], expected 10, is "
       << last_msg_->signed_messages[0];
-  EXPECT_EQ(last_msg_->signed_messages[1], 21)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[1])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[1])),
+      21)
       << "incorrect value for signed_messages[1], expected 21, is "
       << last_msg_->signed_messages[1];
-  EXPECT_EQ(last_msg_->signed_messages[2], 23)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[2])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[2])),
+      23)
       << "incorrect value for signed_messages[2], expected 23, is "
       << last_msg_->signed_messages[2];
-  EXPECT_EQ(last_msg_->stream_counter, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->stream_counter)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->stream_counter)),
+            1)
       << "incorrect value for stream_counter, expected 1, is "
       << last_msg_->stream_counter;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_signing_MsgEd25519CertificateDep.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_signing_MsgEd25519CertificateDep.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/signing.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_signing_MsgEd25519CertificateDep0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -729,321 +736,618 @@ TEST_F(Test_legacy_auto_check_sbp_signing_MsgEd25519CertificateDep0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->certificate_bytes[0], 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[0])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[0])),
+      0)
       << "incorrect value for certificate_bytes[0], expected 0, is "
       << last_msg_->certificate_bytes[0];
-  EXPECT_EQ(last_msg_->certificate_bytes[1], 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[1])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[1])),
+      3)
       << "incorrect value for certificate_bytes[1], expected 3, is "
       << last_msg_->certificate_bytes[1];
-  EXPECT_EQ(last_msg_->certificate_bytes[2], 6)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[2])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[2])),
+      6)
       << "incorrect value for certificate_bytes[2], expected 6, is "
       << last_msg_->certificate_bytes[2];
-  EXPECT_EQ(last_msg_->certificate_bytes[3], 9)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[3])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[3])),
+      9)
       << "incorrect value for certificate_bytes[3], expected 9, is "
       << last_msg_->certificate_bytes[3];
-  EXPECT_EQ(last_msg_->certificate_bytes[4], 12)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[4])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[4])),
+      12)
       << "incorrect value for certificate_bytes[4], expected 12, is "
       << last_msg_->certificate_bytes[4];
-  EXPECT_EQ(last_msg_->certificate_bytes[5], 15)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[5])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[5])),
+      15)
       << "incorrect value for certificate_bytes[5], expected 15, is "
       << last_msg_->certificate_bytes[5];
-  EXPECT_EQ(last_msg_->certificate_bytes[6], 18)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[6])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[6])),
+      18)
       << "incorrect value for certificate_bytes[6], expected 18, is "
       << last_msg_->certificate_bytes[6];
-  EXPECT_EQ(last_msg_->certificate_bytes[7], 21)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[7])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[7])),
+      21)
       << "incorrect value for certificate_bytes[7], expected 21, is "
       << last_msg_->certificate_bytes[7];
-  EXPECT_EQ(last_msg_->certificate_bytes[8], 24)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[8])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[8])),
+      24)
       << "incorrect value for certificate_bytes[8], expected 24, is "
       << last_msg_->certificate_bytes[8];
-  EXPECT_EQ(last_msg_->certificate_bytes[9], 27)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[9])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[9])),
+      27)
       << "incorrect value for certificate_bytes[9], expected 27, is "
       << last_msg_->certificate_bytes[9];
-  EXPECT_EQ(last_msg_->certificate_bytes[10], 30)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[10])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[10])),
+      30)
       << "incorrect value for certificate_bytes[10], expected 30, is "
       << last_msg_->certificate_bytes[10];
-  EXPECT_EQ(last_msg_->certificate_bytes[11], 33)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[11])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[11])),
+      33)
       << "incorrect value for certificate_bytes[11], expected 33, is "
       << last_msg_->certificate_bytes[11];
-  EXPECT_EQ(last_msg_->certificate_bytes[12], 36)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[12])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[12])),
+      36)
       << "incorrect value for certificate_bytes[12], expected 36, is "
       << last_msg_->certificate_bytes[12];
-  EXPECT_EQ(last_msg_->certificate_bytes[13], 39)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[13])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[13])),
+      39)
       << "incorrect value for certificate_bytes[13], expected 39, is "
       << last_msg_->certificate_bytes[13];
-  EXPECT_EQ(last_msg_->certificate_bytes[14], 42)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[14])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[14])),
+      42)
       << "incorrect value for certificate_bytes[14], expected 42, is "
       << last_msg_->certificate_bytes[14];
-  EXPECT_EQ(last_msg_->certificate_bytes[15], 45)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[15])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[15])),
+      45)
       << "incorrect value for certificate_bytes[15], expected 45, is "
       << last_msg_->certificate_bytes[15];
-  EXPECT_EQ(last_msg_->certificate_bytes[16], 48)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[16])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[16])),
+      48)
       << "incorrect value for certificate_bytes[16], expected 48, is "
       << last_msg_->certificate_bytes[16];
-  EXPECT_EQ(last_msg_->certificate_bytes[17], 51)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[17])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[17])),
+      51)
       << "incorrect value for certificate_bytes[17], expected 51, is "
       << last_msg_->certificate_bytes[17];
-  EXPECT_EQ(last_msg_->certificate_bytes[18], 54)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[18])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[18])),
+      54)
       << "incorrect value for certificate_bytes[18], expected 54, is "
       << last_msg_->certificate_bytes[18];
-  EXPECT_EQ(last_msg_->certificate_bytes[19], 57)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[19])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[19])),
+      57)
       << "incorrect value for certificate_bytes[19], expected 57, is "
       << last_msg_->certificate_bytes[19];
-  EXPECT_EQ(last_msg_->certificate_bytes[20], 60)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[20])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[20])),
+      60)
       << "incorrect value for certificate_bytes[20], expected 60, is "
       << last_msg_->certificate_bytes[20];
-  EXPECT_EQ(last_msg_->certificate_bytes[21], 63)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[21])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[21])),
+      63)
       << "incorrect value for certificate_bytes[21], expected 63, is "
       << last_msg_->certificate_bytes[21];
-  EXPECT_EQ(last_msg_->certificate_bytes[22], 66)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[22])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[22])),
+      66)
       << "incorrect value for certificate_bytes[22], expected 66, is "
       << last_msg_->certificate_bytes[22];
-  EXPECT_EQ(last_msg_->certificate_bytes[23], 69)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[23])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[23])),
+      69)
       << "incorrect value for certificate_bytes[23], expected 69, is "
       << last_msg_->certificate_bytes[23];
-  EXPECT_EQ(last_msg_->certificate_bytes[24], 72)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[24])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[24])),
+      72)
       << "incorrect value for certificate_bytes[24], expected 72, is "
       << last_msg_->certificate_bytes[24];
-  EXPECT_EQ(last_msg_->certificate_bytes[25], 75)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[25])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[25])),
+      75)
       << "incorrect value for certificate_bytes[25], expected 75, is "
       << last_msg_->certificate_bytes[25];
-  EXPECT_EQ(last_msg_->certificate_bytes[26], 78)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[26])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[26])),
+      78)
       << "incorrect value for certificate_bytes[26], expected 78, is "
       << last_msg_->certificate_bytes[26];
-  EXPECT_EQ(last_msg_->certificate_bytes[27], 81)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[27])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[27])),
+      81)
       << "incorrect value for certificate_bytes[27], expected 81, is "
       << last_msg_->certificate_bytes[27];
-  EXPECT_EQ(last_msg_->certificate_bytes[28], 84)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[28])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[28])),
+      84)
       << "incorrect value for certificate_bytes[28], expected 84, is "
       << last_msg_->certificate_bytes[28];
-  EXPECT_EQ(last_msg_->certificate_bytes[29], 87)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[29])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[29])),
+      87)
       << "incorrect value for certificate_bytes[29], expected 87, is "
       << last_msg_->certificate_bytes[29];
-  EXPECT_EQ(last_msg_->certificate_bytes[30], 90)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[30])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[30])),
+      90)
       << "incorrect value for certificate_bytes[30], expected 90, is "
       << last_msg_->certificate_bytes[30];
-  EXPECT_EQ(last_msg_->certificate_bytes[31], 93)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[31])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[31])),
+      93)
       << "incorrect value for certificate_bytes[31], expected 93, is "
       << last_msg_->certificate_bytes[31];
-  EXPECT_EQ(last_msg_->certificate_bytes[32], 96)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[32])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[32])),
+      96)
       << "incorrect value for certificate_bytes[32], expected 96, is "
       << last_msg_->certificate_bytes[32];
-  EXPECT_EQ(last_msg_->certificate_bytes[33], 99)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[33])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[33])),
+      99)
       << "incorrect value for certificate_bytes[33], expected 99, is "
       << last_msg_->certificate_bytes[33];
-  EXPECT_EQ(last_msg_->certificate_bytes[34], 102)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[34])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[34])),
+      102)
       << "incorrect value for certificate_bytes[34], expected 102, is "
       << last_msg_->certificate_bytes[34];
-  EXPECT_EQ(last_msg_->certificate_bytes[35], 105)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[35])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[35])),
+      105)
       << "incorrect value for certificate_bytes[35], expected 105, is "
       << last_msg_->certificate_bytes[35];
-  EXPECT_EQ(last_msg_->certificate_bytes[36], 108)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[36])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[36])),
+      108)
       << "incorrect value for certificate_bytes[36], expected 108, is "
       << last_msg_->certificate_bytes[36];
-  EXPECT_EQ(last_msg_->certificate_bytes[37], 111)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[37])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[37])),
+      111)
       << "incorrect value for certificate_bytes[37], expected 111, is "
       << last_msg_->certificate_bytes[37];
-  EXPECT_EQ(last_msg_->certificate_bytes[38], 114)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[38])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[38])),
+      114)
       << "incorrect value for certificate_bytes[38], expected 114, is "
       << last_msg_->certificate_bytes[38];
-  EXPECT_EQ(last_msg_->certificate_bytes[39], 117)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[39])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[39])),
+      117)
       << "incorrect value for certificate_bytes[39], expected 117, is "
       << last_msg_->certificate_bytes[39];
-  EXPECT_EQ(last_msg_->certificate_bytes[40], 120)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[40])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[40])),
+      120)
       << "incorrect value for certificate_bytes[40], expected 120, is "
       << last_msg_->certificate_bytes[40];
-  EXPECT_EQ(last_msg_->certificate_bytes[41], 123)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[41])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[41])),
+      123)
       << "incorrect value for certificate_bytes[41], expected 123, is "
       << last_msg_->certificate_bytes[41];
-  EXPECT_EQ(last_msg_->certificate_bytes[42], 126)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[42])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[42])),
+      126)
       << "incorrect value for certificate_bytes[42], expected 126, is "
       << last_msg_->certificate_bytes[42];
-  EXPECT_EQ(last_msg_->certificate_bytes[43], 129)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[43])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[43])),
+      129)
       << "incorrect value for certificate_bytes[43], expected 129, is "
       << last_msg_->certificate_bytes[43];
-  EXPECT_EQ(last_msg_->certificate_bytes[44], 132)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[44])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[44])),
+      132)
       << "incorrect value for certificate_bytes[44], expected 132, is "
       << last_msg_->certificate_bytes[44];
-  EXPECT_EQ(last_msg_->certificate_bytes[45], 135)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[45])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[45])),
+      135)
       << "incorrect value for certificate_bytes[45], expected 135, is "
       << last_msg_->certificate_bytes[45];
-  EXPECT_EQ(last_msg_->certificate_bytes[46], 138)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[46])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[46])),
+      138)
       << "incorrect value for certificate_bytes[46], expected 138, is "
       << last_msg_->certificate_bytes[46];
-  EXPECT_EQ(last_msg_->certificate_bytes[47], 141)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[47])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[47])),
+      141)
       << "incorrect value for certificate_bytes[47], expected 141, is "
       << last_msg_->certificate_bytes[47];
-  EXPECT_EQ(last_msg_->certificate_bytes[48], 144)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[48])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[48])),
+      144)
       << "incorrect value for certificate_bytes[48], expected 144, is "
       << last_msg_->certificate_bytes[48];
-  EXPECT_EQ(last_msg_->certificate_bytes[49], 147)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[49])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[49])),
+      147)
       << "incorrect value for certificate_bytes[49], expected 147, is "
       << last_msg_->certificate_bytes[49];
-  EXPECT_EQ(last_msg_->certificate_bytes[50], 150)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[50])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[50])),
+      150)
       << "incorrect value for certificate_bytes[50], expected 150, is "
       << last_msg_->certificate_bytes[50];
-  EXPECT_EQ(last_msg_->certificate_bytes[51], 153)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[51])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[51])),
+      153)
       << "incorrect value for certificate_bytes[51], expected 153, is "
       << last_msg_->certificate_bytes[51];
-  EXPECT_EQ(last_msg_->certificate_bytes[52], 156)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[52])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[52])),
+      156)
       << "incorrect value for certificate_bytes[52], expected 156, is "
       << last_msg_->certificate_bytes[52];
-  EXPECT_EQ(last_msg_->certificate_bytes[53], 159)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[53])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[53])),
+      159)
       << "incorrect value for certificate_bytes[53], expected 159, is "
       << last_msg_->certificate_bytes[53];
-  EXPECT_EQ(last_msg_->certificate_bytes[54], 162)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[54])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[54])),
+      162)
       << "incorrect value for certificate_bytes[54], expected 162, is "
       << last_msg_->certificate_bytes[54];
-  EXPECT_EQ(last_msg_->certificate_bytes[55], 165)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[55])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[55])),
+      165)
       << "incorrect value for certificate_bytes[55], expected 165, is "
       << last_msg_->certificate_bytes[55];
-  EXPECT_EQ(last_msg_->certificate_bytes[56], 168)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[56])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[56])),
+      168)
       << "incorrect value for certificate_bytes[56], expected 168, is "
       << last_msg_->certificate_bytes[56];
-  EXPECT_EQ(last_msg_->certificate_bytes[57], 171)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[57])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[57])),
+      171)
       << "incorrect value for certificate_bytes[57], expected 171, is "
       << last_msg_->certificate_bytes[57];
-  EXPECT_EQ(last_msg_->certificate_bytes[58], 174)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[58])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[58])),
+      174)
       << "incorrect value for certificate_bytes[58], expected 174, is "
       << last_msg_->certificate_bytes[58];
-  EXPECT_EQ(last_msg_->certificate_bytes[59], 177)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[59])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[59])),
+      177)
       << "incorrect value for certificate_bytes[59], expected 177, is "
       << last_msg_->certificate_bytes[59];
-  EXPECT_EQ(last_msg_->certificate_bytes[60], 180)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[60])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[60])),
+      180)
       << "incorrect value for certificate_bytes[60], expected 180, is "
       << last_msg_->certificate_bytes[60];
-  EXPECT_EQ(last_msg_->certificate_bytes[61], 183)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[61])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[61])),
+      183)
       << "incorrect value for certificate_bytes[61], expected 183, is "
       << last_msg_->certificate_bytes[61];
-  EXPECT_EQ(last_msg_->certificate_bytes[62], 186)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[62])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[62])),
+      186)
       << "incorrect value for certificate_bytes[62], expected 186, is "
       << last_msg_->certificate_bytes[62];
-  EXPECT_EQ(last_msg_->certificate_bytes[63], 189)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[63])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[63])),
+      189)
       << "incorrect value for certificate_bytes[63], expected 189, is "
       << last_msg_->certificate_bytes[63];
-  EXPECT_EQ(last_msg_->certificate_bytes[64], 192)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[64])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[64])),
+      192)
       << "incorrect value for certificate_bytes[64], expected 192, is "
       << last_msg_->certificate_bytes[64];
-  EXPECT_EQ(last_msg_->certificate_bytes[65], 195)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[65])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[65])),
+      195)
       << "incorrect value for certificate_bytes[65], expected 195, is "
       << last_msg_->certificate_bytes[65];
-  EXPECT_EQ(last_msg_->certificate_bytes[66], 198)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[66])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[66])),
+      198)
       << "incorrect value for certificate_bytes[66], expected 198, is "
       << last_msg_->certificate_bytes[66];
-  EXPECT_EQ(last_msg_->certificate_bytes[67], 201)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[67])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[67])),
+      201)
       << "incorrect value for certificate_bytes[67], expected 201, is "
       << last_msg_->certificate_bytes[67];
-  EXPECT_EQ(last_msg_->certificate_bytes[68], 204)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[68])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[68])),
+      204)
       << "incorrect value for certificate_bytes[68], expected 204, is "
       << last_msg_->certificate_bytes[68];
-  EXPECT_EQ(last_msg_->certificate_bytes[69], 207)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[69])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[69])),
+      207)
       << "incorrect value for certificate_bytes[69], expected 207, is "
       << last_msg_->certificate_bytes[69];
-  EXPECT_EQ(last_msg_->certificate_bytes[70], 210)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[70])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[70])),
+      210)
       << "incorrect value for certificate_bytes[70], expected 210, is "
       << last_msg_->certificate_bytes[70];
-  EXPECT_EQ(last_msg_->certificate_bytes[71], 213)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[71])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[71])),
+      213)
       << "incorrect value for certificate_bytes[71], expected 213, is "
       << last_msg_->certificate_bytes[71];
-  EXPECT_EQ(last_msg_->certificate_bytes[72], 216)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[72])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[72])),
+      216)
       << "incorrect value for certificate_bytes[72], expected 216, is "
       << last_msg_->certificate_bytes[72];
-  EXPECT_EQ(last_msg_->certificate_bytes[73], 219)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[73])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[73])),
+      219)
       << "incorrect value for certificate_bytes[73], expected 219, is "
       << last_msg_->certificate_bytes[73];
-  EXPECT_EQ(last_msg_->certificate_bytes[74], 222)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[74])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[74])),
+      222)
       << "incorrect value for certificate_bytes[74], expected 222, is "
       << last_msg_->certificate_bytes[74];
-  EXPECT_EQ(last_msg_->certificate_bytes[75], 225)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[75])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[75])),
+      225)
       << "incorrect value for certificate_bytes[75], expected 225, is "
       << last_msg_->certificate_bytes[75];
-  EXPECT_EQ(last_msg_->certificate_bytes[76], 228)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[76])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[76])),
+      228)
       << "incorrect value for certificate_bytes[76], expected 228, is "
       << last_msg_->certificate_bytes[76];
-  EXPECT_EQ(last_msg_->certificate_bytes[77], 231)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[77])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[77])),
+      231)
       << "incorrect value for certificate_bytes[77], expected 231, is "
       << last_msg_->certificate_bytes[77];
-  EXPECT_EQ(last_msg_->certificate_bytes[78], 234)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[78])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[78])),
+      234)
       << "incorrect value for certificate_bytes[78], expected 234, is "
       << last_msg_->certificate_bytes[78];
-  EXPECT_EQ(last_msg_->certificate_bytes[79], 237)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[79])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[79])),
+      237)
       << "incorrect value for certificate_bytes[79], expected 237, is "
       << last_msg_->certificate_bytes[79];
-  EXPECT_EQ(last_msg_->certificate_bytes[80], 240)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[80])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[80])),
+      240)
       << "incorrect value for certificate_bytes[80], expected 240, is "
       << last_msg_->certificate_bytes[80];
-  EXPECT_EQ(last_msg_->certificate_bytes[81], 243)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[81])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[81])),
+      243)
       << "incorrect value for certificate_bytes[81], expected 243, is "
       << last_msg_->certificate_bytes[81];
-  EXPECT_EQ(last_msg_->certificate_bytes[82], 246)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[82])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[82])),
+      246)
       << "incorrect value for certificate_bytes[82], expected 246, is "
       << last_msg_->certificate_bytes[82];
-  EXPECT_EQ(last_msg_->certificate_bytes[83], 249)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[83])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[83])),
+      249)
       << "incorrect value for certificate_bytes[83], expected 249, is "
       << last_msg_->certificate_bytes[83];
-  EXPECT_EQ(last_msg_->certificate_bytes[84], 252)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->certificate_bytes[84])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->certificate_bytes[84])),
+      252)
       << "incorrect value for certificate_bytes[84], expected 252, is "
       << last_msg_->certificate_bytes[84];
-  EXPECT_EQ(last_msg_->fingerprint[0], 100)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[0])),
+            100)
       << "incorrect value for fingerprint[0], expected 100, is "
       << last_msg_->fingerprint[0];
-  EXPECT_EQ(last_msg_->fingerprint[1], 101)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[1])),
+            101)
       << "incorrect value for fingerprint[1], expected 101, is "
       << last_msg_->fingerprint[1];
-  EXPECT_EQ(last_msg_->fingerprint[2], 102)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[2])),
+            102)
       << "incorrect value for fingerprint[2], expected 102, is "
       << last_msg_->fingerprint[2];
-  EXPECT_EQ(last_msg_->fingerprint[3], 103)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[3])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[3])),
+            103)
       << "incorrect value for fingerprint[3], expected 103, is "
       << last_msg_->fingerprint[3];
-  EXPECT_EQ(last_msg_->fingerprint[4], 104)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[4])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[4])),
+            104)
       << "incorrect value for fingerprint[4], expected 104, is "
       << last_msg_->fingerprint[4];
-  EXPECT_EQ(last_msg_->fingerprint[5], 105)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[5])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[5])),
+            105)
       << "incorrect value for fingerprint[5], expected 105, is "
       << last_msg_->fingerprint[5];
-  EXPECT_EQ(last_msg_->fingerprint[6], 106)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[6])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[6])),
+            106)
       << "incorrect value for fingerprint[6], expected 106, is "
       << last_msg_->fingerprint[6];
-  EXPECT_EQ(last_msg_->fingerprint[7], 107)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[7])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[7])),
+            107)
       << "incorrect value for fingerprint[7], expected 107, is "
       << last_msg_->fingerprint[7];
-  EXPECT_EQ(last_msg_->fingerprint[8], 108)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[8])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[8])),
+            108)
       << "incorrect value for fingerprint[8], expected 108, is "
       << last_msg_->fingerprint[8];
-  EXPECT_EQ(last_msg_->fingerprint[9], 109)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[9])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[9])),
+            109)
       << "incorrect value for fingerprint[9], expected 109, is "
       << last_msg_->fingerprint[9];
-  EXPECT_EQ(last_msg_->fingerprint[10], 110)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[10])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[10])),
+            110)
       << "incorrect value for fingerprint[10], expected 110, is "
       << last_msg_->fingerprint[10];
-  EXPECT_EQ(last_msg_->fingerprint[11], 111)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[11])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[11])),
+            111)
       << "incorrect value for fingerprint[11], expected 111, is "
       << last_msg_->fingerprint[11];
-  EXPECT_EQ(last_msg_->fingerprint[12], 112)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[12])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[12])),
+            112)
       << "incorrect value for fingerprint[12], expected 112, is "
       << last_msg_->fingerprint[12];
-  EXPECT_EQ(last_msg_->fingerprint[13], 113)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[13])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[13])),
+            113)
       << "incorrect value for fingerprint[13], expected 113, is "
       << last_msg_->fingerprint[13];
-  EXPECT_EQ(last_msg_->fingerprint[14], 114)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[14])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[14])),
+            114)
       << "incorrect value for fingerprint[14], expected 114, is "
       << last_msg_->fingerprint[14];
-  EXPECT_EQ(last_msg_->fingerprint[15], 115)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[15])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[15])),
+            115)
       << "incorrect value for fingerprint[15], expected 115, is "
       << last_msg_->fingerprint[15];
-  EXPECT_EQ(last_msg_->fingerprint[16], 116)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[16])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[16])),
+            116)
       << "incorrect value for fingerprint[16], expected 116, is "
       << last_msg_->fingerprint[16];
-  EXPECT_EQ(last_msg_->fingerprint[17], 117)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[17])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[17])),
+            117)
       << "incorrect value for fingerprint[17], expected 117, is "
       << last_msg_->fingerprint[17];
-  EXPECT_EQ(last_msg_->fingerprint[18], 118)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[18])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[18])),
+            118)
       << "incorrect value for fingerprint[18], expected 118, is "
       << last_msg_->fingerprint[18];
-  EXPECT_EQ(last_msg_->fingerprint[19], 119)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[19])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[19])),
+            119)
       << "incorrect value for fingerprint[19], expected 119, is "
       << last_msg_->fingerprint[19];
-  EXPECT_EQ(last_msg_->n_msg, 16)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_msg)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_msg)),
+            16)
       << "incorrect value for n_msg, expected 16, is " << last_msg_->n_msg;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_signing_MsgEd25519SignatureDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_signing_MsgEd25519SignatureDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/signing.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_signing_MsgEd25519SignatureDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -693,331 +700,574 @@ TEST_F(Test_legacy_auto_check_sbp_signing_MsgEd25519SignatureDepA0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->fingerprint[0], 100)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[0])),
+            100)
       << "incorrect value for fingerprint[0], expected 100, is "
       << last_msg_->fingerprint[0];
-  EXPECT_EQ(last_msg_->fingerprint[1], 101)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[1])),
+            101)
       << "incorrect value for fingerprint[1], expected 101, is "
       << last_msg_->fingerprint[1];
-  EXPECT_EQ(last_msg_->fingerprint[2], 102)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[2])),
+            102)
       << "incorrect value for fingerprint[2], expected 102, is "
       << last_msg_->fingerprint[2];
-  EXPECT_EQ(last_msg_->fingerprint[3], 103)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[3])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[3])),
+            103)
       << "incorrect value for fingerprint[3], expected 103, is "
       << last_msg_->fingerprint[3];
-  EXPECT_EQ(last_msg_->fingerprint[4], 104)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[4])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[4])),
+            104)
       << "incorrect value for fingerprint[4], expected 104, is "
       << last_msg_->fingerprint[4];
-  EXPECT_EQ(last_msg_->fingerprint[5], 105)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[5])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[5])),
+            105)
       << "incorrect value for fingerprint[5], expected 105, is "
       << last_msg_->fingerprint[5];
-  EXPECT_EQ(last_msg_->fingerprint[6], 106)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[6])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[6])),
+            106)
       << "incorrect value for fingerprint[6], expected 106, is "
       << last_msg_->fingerprint[6];
-  EXPECT_EQ(last_msg_->fingerprint[7], 107)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[7])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[7])),
+            107)
       << "incorrect value for fingerprint[7], expected 107, is "
       << last_msg_->fingerprint[7];
-  EXPECT_EQ(last_msg_->fingerprint[8], 108)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[8])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[8])),
+            108)
       << "incorrect value for fingerprint[8], expected 108, is "
       << last_msg_->fingerprint[8];
-  EXPECT_EQ(last_msg_->fingerprint[9], 109)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[9])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[9])),
+            109)
       << "incorrect value for fingerprint[9], expected 109, is "
       << last_msg_->fingerprint[9];
-  EXPECT_EQ(last_msg_->fingerprint[10], 110)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[10])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[10])),
+            110)
       << "incorrect value for fingerprint[10], expected 110, is "
       << last_msg_->fingerprint[10];
-  EXPECT_EQ(last_msg_->fingerprint[11], 111)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[11])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[11])),
+            111)
       << "incorrect value for fingerprint[11], expected 111, is "
       << last_msg_->fingerprint[11];
-  EXPECT_EQ(last_msg_->fingerprint[12], 112)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[12])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[12])),
+            112)
       << "incorrect value for fingerprint[12], expected 112, is "
       << last_msg_->fingerprint[12];
-  EXPECT_EQ(last_msg_->fingerprint[13], 113)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[13])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[13])),
+            113)
       << "incorrect value for fingerprint[13], expected 113, is "
       << last_msg_->fingerprint[13];
-  EXPECT_EQ(last_msg_->fingerprint[14], 114)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[14])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[14])),
+            114)
       << "incorrect value for fingerprint[14], expected 114, is "
       << last_msg_->fingerprint[14];
-  EXPECT_EQ(last_msg_->fingerprint[15], 115)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[15])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[15])),
+            115)
       << "incorrect value for fingerprint[15], expected 115, is "
       << last_msg_->fingerprint[15];
-  EXPECT_EQ(last_msg_->fingerprint[16], 116)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[16])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[16])),
+            116)
       << "incorrect value for fingerprint[16], expected 116, is "
       << last_msg_->fingerprint[16];
-  EXPECT_EQ(last_msg_->fingerprint[17], 117)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[17])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[17])),
+            117)
       << "incorrect value for fingerprint[17], expected 117, is "
       << last_msg_->fingerprint[17];
-  EXPECT_EQ(last_msg_->fingerprint[18], 118)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[18])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[18])),
+            118)
       << "incorrect value for fingerprint[18], expected 118, is "
       << last_msg_->fingerprint[18];
-  EXPECT_EQ(last_msg_->fingerprint[19], 119)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[19])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[19])),
+            119)
       << "incorrect value for fingerprint[19], expected 119, is "
       << last_msg_->fingerprint[19];
-  EXPECT_EQ(last_msg_->signature[0], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[0])),
+            0)
       << "incorrect value for signature[0], expected 0, is "
       << last_msg_->signature[0];
-  EXPECT_EQ(last_msg_->signature[1], 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[1])),
+            1)
       << "incorrect value for signature[1], expected 1, is "
       << last_msg_->signature[1];
-  EXPECT_EQ(last_msg_->signature[2], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[2])),
+            2)
       << "incorrect value for signature[2], expected 2, is "
       << last_msg_->signature[2];
-  EXPECT_EQ(last_msg_->signature[3], 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[3])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[3])),
+            3)
       << "incorrect value for signature[3], expected 3, is "
       << last_msg_->signature[3];
-  EXPECT_EQ(last_msg_->signature[4], 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[4])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[4])),
+            4)
       << "incorrect value for signature[4], expected 4, is "
       << last_msg_->signature[4];
-  EXPECT_EQ(last_msg_->signature[5], 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[5])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[5])),
+            5)
       << "incorrect value for signature[5], expected 5, is "
       << last_msg_->signature[5];
-  EXPECT_EQ(last_msg_->signature[6], 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[6])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[6])),
+            6)
       << "incorrect value for signature[6], expected 6, is "
       << last_msg_->signature[6];
-  EXPECT_EQ(last_msg_->signature[7], 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[7])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[7])),
+            7)
       << "incorrect value for signature[7], expected 7, is "
       << last_msg_->signature[7];
-  EXPECT_EQ(last_msg_->signature[8], 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[8])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[8])),
+            8)
       << "incorrect value for signature[8], expected 8, is "
       << last_msg_->signature[8];
-  EXPECT_EQ(last_msg_->signature[9], 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[9])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[9])),
+            9)
       << "incorrect value for signature[9], expected 9, is "
       << last_msg_->signature[9];
-  EXPECT_EQ(last_msg_->signature[10], 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[10])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[10])),
+            10)
       << "incorrect value for signature[10], expected 10, is "
       << last_msg_->signature[10];
-  EXPECT_EQ(last_msg_->signature[11], 11)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[11])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[11])),
+            11)
       << "incorrect value for signature[11], expected 11, is "
       << last_msg_->signature[11];
-  EXPECT_EQ(last_msg_->signature[12], 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[12])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[12])),
+            12)
       << "incorrect value for signature[12], expected 12, is "
       << last_msg_->signature[12];
-  EXPECT_EQ(last_msg_->signature[13], 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[13])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[13])),
+            13)
       << "incorrect value for signature[13], expected 13, is "
       << last_msg_->signature[13];
-  EXPECT_EQ(last_msg_->signature[14], 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[14])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[14])),
+            14)
       << "incorrect value for signature[14], expected 14, is "
       << last_msg_->signature[14];
-  EXPECT_EQ(last_msg_->signature[15], 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[15])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[15])),
+            15)
       << "incorrect value for signature[15], expected 15, is "
       << last_msg_->signature[15];
-  EXPECT_EQ(last_msg_->signature[16], 16)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[16])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[16])),
+            16)
       << "incorrect value for signature[16], expected 16, is "
       << last_msg_->signature[16];
-  EXPECT_EQ(last_msg_->signature[17], 17)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[17])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[17])),
+            17)
       << "incorrect value for signature[17], expected 17, is "
       << last_msg_->signature[17];
-  EXPECT_EQ(last_msg_->signature[18], 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[18])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[18])),
+            18)
       << "incorrect value for signature[18], expected 18, is "
       << last_msg_->signature[18];
-  EXPECT_EQ(last_msg_->signature[19], 19)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[19])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[19])),
+            19)
       << "incorrect value for signature[19], expected 19, is "
       << last_msg_->signature[19];
-  EXPECT_EQ(last_msg_->signature[20], 20)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[20])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[20])),
+            20)
       << "incorrect value for signature[20], expected 20, is "
       << last_msg_->signature[20];
-  EXPECT_EQ(last_msg_->signature[21], 21)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[21])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[21])),
+            21)
       << "incorrect value for signature[21], expected 21, is "
       << last_msg_->signature[21];
-  EXPECT_EQ(last_msg_->signature[22], 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[22])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[22])),
+            22)
       << "incorrect value for signature[22], expected 22, is "
       << last_msg_->signature[22];
-  EXPECT_EQ(last_msg_->signature[23], 23)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[23])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[23])),
+            23)
       << "incorrect value for signature[23], expected 23, is "
       << last_msg_->signature[23];
-  EXPECT_EQ(last_msg_->signature[24], 24)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[24])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[24])),
+            24)
       << "incorrect value for signature[24], expected 24, is "
       << last_msg_->signature[24];
-  EXPECT_EQ(last_msg_->signature[25], 25)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[25])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[25])),
+            25)
       << "incorrect value for signature[25], expected 25, is "
       << last_msg_->signature[25];
-  EXPECT_EQ(last_msg_->signature[26], 26)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[26])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[26])),
+            26)
       << "incorrect value for signature[26], expected 26, is "
       << last_msg_->signature[26];
-  EXPECT_EQ(last_msg_->signature[27], 27)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[27])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[27])),
+            27)
       << "incorrect value for signature[27], expected 27, is "
       << last_msg_->signature[27];
-  EXPECT_EQ(last_msg_->signature[28], 28)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[28])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[28])),
+            28)
       << "incorrect value for signature[28], expected 28, is "
       << last_msg_->signature[28];
-  EXPECT_EQ(last_msg_->signature[29], 29)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[29])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[29])),
+            29)
       << "incorrect value for signature[29], expected 29, is "
       << last_msg_->signature[29];
-  EXPECT_EQ(last_msg_->signature[30], 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[30])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[30])),
+            30)
       << "incorrect value for signature[30], expected 30, is "
       << last_msg_->signature[30];
-  EXPECT_EQ(last_msg_->signature[31], 31)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[31])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[31])),
+            31)
       << "incorrect value for signature[31], expected 31, is "
       << last_msg_->signature[31];
-  EXPECT_EQ(last_msg_->signature[32], 32)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[32])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[32])),
+            32)
       << "incorrect value for signature[32], expected 32, is "
       << last_msg_->signature[32];
-  EXPECT_EQ(last_msg_->signature[33], 33)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[33])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[33])),
+            33)
       << "incorrect value for signature[33], expected 33, is "
       << last_msg_->signature[33];
-  EXPECT_EQ(last_msg_->signature[34], 34)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[34])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[34])),
+            34)
       << "incorrect value for signature[34], expected 34, is "
       << last_msg_->signature[34];
-  EXPECT_EQ(last_msg_->signature[35], 35)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[35])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[35])),
+            35)
       << "incorrect value for signature[35], expected 35, is "
       << last_msg_->signature[35];
-  EXPECT_EQ(last_msg_->signature[36], 36)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[36])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[36])),
+            36)
       << "incorrect value for signature[36], expected 36, is "
       << last_msg_->signature[36];
-  EXPECT_EQ(last_msg_->signature[37], 37)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[37])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[37])),
+            37)
       << "incorrect value for signature[37], expected 37, is "
       << last_msg_->signature[37];
-  EXPECT_EQ(last_msg_->signature[38], 38)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[38])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[38])),
+            38)
       << "incorrect value for signature[38], expected 38, is "
       << last_msg_->signature[38];
-  EXPECT_EQ(last_msg_->signature[39], 39)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[39])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[39])),
+            39)
       << "incorrect value for signature[39], expected 39, is "
       << last_msg_->signature[39];
-  EXPECT_EQ(last_msg_->signature[40], 40)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[40])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[40])),
+            40)
       << "incorrect value for signature[40], expected 40, is "
       << last_msg_->signature[40];
-  EXPECT_EQ(last_msg_->signature[41], 41)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[41])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[41])),
+            41)
       << "incorrect value for signature[41], expected 41, is "
       << last_msg_->signature[41];
-  EXPECT_EQ(last_msg_->signature[42], 42)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[42])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[42])),
+            42)
       << "incorrect value for signature[42], expected 42, is "
       << last_msg_->signature[42];
-  EXPECT_EQ(last_msg_->signature[43], 43)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[43])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[43])),
+            43)
       << "incorrect value for signature[43], expected 43, is "
       << last_msg_->signature[43];
-  EXPECT_EQ(last_msg_->signature[44], 44)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[44])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[44])),
+            44)
       << "incorrect value for signature[44], expected 44, is "
       << last_msg_->signature[44];
-  EXPECT_EQ(last_msg_->signature[45], 45)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[45])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[45])),
+            45)
       << "incorrect value for signature[45], expected 45, is "
       << last_msg_->signature[45];
-  EXPECT_EQ(last_msg_->signature[46], 46)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[46])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[46])),
+            46)
       << "incorrect value for signature[46], expected 46, is "
       << last_msg_->signature[46];
-  EXPECT_EQ(last_msg_->signature[47], 47)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[47])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[47])),
+            47)
       << "incorrect value for signature[47], expected 47, is "
       << last_msg_->signature[47];
-  EXPECT_EQ(last_msg_->signature[48], 48)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[48])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[48])),
+            48)
       << "incorrect value for signature[48], expected 48, is "
       << last_msg_->signature[48];
-  EXPECT_EQ(last_msg_->signature[49], 49)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[49])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[49])),
+            49)
       << "incorrect value for signature[49], expected 49, is "
       << last_msg_->signature[49];
-  EXPECT_EQ(last_msg_->signature[50], 50)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[50])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[50])),
+            50)
       << "incorrect value for signature[50], expected 50, is "
       << last_msg_->signature[50];
-  EXPECT_EQ(last_msg_->signature[51], 51)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[51])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[51])),
+            51)
       << "incorrect value for signature[51], expected 51, is "
       << last_msg_->signature[51];
-  EXPECT_EQ(last_msg_->signature[52], 52)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[52])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[52])),
+            52)
       << "incorrect value for signature[52], expected 52, is "
       << last_msg_->signature[52];
-  EXPECT_EQ(last_msg_->signature[53], 53)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[53])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[53])),
+            53)
       << "incorrect value for signature[53], expected 53, is "
       << last_msg_->signature[53];
-  EXPECT_EQ(last_msg_->signature[54], 54)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[54])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[54])),
+            54)
       << "incorrect value for signature[54], expected 54, is "
       << last_msg_->signature[54];
-  EXPECT_EQ(last_msg_->signature[55], 55)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[55])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[55])),
+            55)
       << "incorrect value for signature[55], expected 55, is "
       << last_msg_->signature[55];
-  EXPECT_EQ(last_msg_->signature[56], 56)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[56])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[56])),
+            56)
       << "incorrect value for signature[56], expected 56, is "
       << last_msg_->signature[56];
-  EXPECT_EQ(last_msg_->signature[57], 57)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[57])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[57])),
+            57)
       << "incorrect value for signature[57], expected 57, is "
       << last_msg_->signature[57];
-  EXPECT_EQ(last_msg_->signature[58], 58)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[58])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[58])),
+            58)
       << "incorrect value for signature[58], expected 58, is "
       << last_msg_->signature[58];
-  EXPECT_EQ(last_msg_->signature[59], 59)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[59])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[59])),
+            59)
       << "incorrect value for signature[59], expected 59, is "
       << last_msg_->signature[59];
-  EXPECT_EQ(last_msg_->signature[60], 60)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[60])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[60])),
+            60)
       << "incorrect value for signature[60], expected 60, is "
       << last_msg_->signature[60];
-  EXPECT_EQ(last_msg_->signature[61], 61)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[61])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[61])),
+            61)
       << "incorrect value for signature[61], expected 61, is "
       << last_msg_->signature[61];
-  EXPECT_EQ(last_msg_->signature[62], 62)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[62])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[62])),
+            62)
       << "incorrect value for signature[62], expected 62, is "
       << last_msg_->signature[62];
-  EXPECT_EQ(last_msg_->signature[63], 63)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[63])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[63])),
+            63)
       << "incorrect value for signature[63], expected 63, is "
       << last_msg_->signature[63];
-  EXPECT_EQ(last_msg_->signed_messages[0], 5000)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[0])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[0])),
+      5000)
       << "incorrect value for signed_messages[0], expected 5000, is "
       << last_msg_->signed_messages[0];
-  EXPECT_EQ(last_msg_->signed_messages[1], 5234)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[1])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[1])),
+      5234)
       << "incorrect value for signed_messages[1], expected 5234, is "
       << last_msg_->signed_messages[1];
-  EXPECT_EQ(last_msg_->signed_messages[2], 5468)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[2])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[2])),
+      5468)
       << "incorrect value for signed_messages[2], expected 5468, is "
       << last_msg_->signed_messages[2];
-  EXPECT_EQ(last_msg_->signed_messages[3], 5702)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[3])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[3])),
+      5702)
       << "incorrect value for signed_messages[3], expected 5702, is "
       << last_msg_->signed_messages[3];
-  EXPECT_EQ(last_msg_->signed_messages[4], 5936)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[4])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[4])),
+      5936)
       << "incorrect value for signed_messages[4], expected 5936, is "
       << last_msg_->signed_messages[4];
-  EXPECT_EQ(last_msg_->signed_messages[5], 6170)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[5])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[5])),
+      6170)
       << "incorrect value for signed_messages[5], expected 6170, is "
       << last_msg_->signed_messages[5];
-  EXPECT_EQ(last_msg_->signed_messages[6], 6404)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[6])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[6])),
+      6404)
       << "incorrect value for signed_messages[6], expected 6404, is "
       << last_msg_->signed_messages[6];
-  EXPECT_EQ(last_msg_->signed_messages[7], 6638)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[7])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[7])),
+      6638)
       << "incorrect value for signed_messages[7], expected 6638, is "
       << last_msg_->signed_messages[7];
-  EXPECT_EQ(last_msg_->signed_messages[8], 6872)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[8])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[8])),
+      6872)
       << "incorrect value for signed_messages[8], expected 6872, is "
       << last_msg_->signed_messages[8];
-  EXPECT_EQ(last_msg_->signed_messages[9], 7106)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[9])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[9])),
+      7106)
       << "incorrect value for signed_messages[9], expected 7106, is "
       << last_msg_->signed_messages[9];
-  EXPECT_EQ(last_msg_->signed_messages[10], 7340)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[10])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[10])),
+      7340)
       << "incorrect value for signed_messages[10], expected 7340, is "
       << last_msg_->signed_messages[10];
-  EXPECT_EQ(last_msg_->signed_messages[11], 7574)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[11])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[11])),
+      7574)
       << "incorrect value for signed_messages[11], expected 7574, is "
       << last_msg_->signed_messages[11];
-  EXPECT_EQ(last_msg_->signed_messages[12], 7808)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[12])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[12])),
+      7808)
       << "incorrect value for signed_messages[12], expected 7808, is "
       << last_msg_->signed_messages[12];
-  EXPECT_EQ(last_msg_->signed_messages[13], 8042)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[13])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[13])),
+      8042)
       << "incorrect value for signed_messages[13], expected 8042, is "
       << last_msg_->signed_messages[13];
-  EXPECT_EQ(last_msg_->signed_messages[14], 8276)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[14])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[14])),
+      8276)
       << "incorrect value for signed_messages[14], expected 8276, is "
       << last_msg_->signed_messages[14];
-  EXPECT_EQ(last_msg_->signed_messages[15], 8510)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[15])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[15])),
+      8510)
       << "incorrect value for signed_messages[15], expected 8510, is "
       << last_msg_->signed_messages[15];
-  EXPECT_EQ(last_msg_->signed_messages[16], 8744)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[16])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[16])),
+      8744)
       << "incorrect value for signed_messages[16], expected 8744, is "
       << last_msg_->signed_messages[16];
-  EXPECT_EQ(last_msg_->signed_messages[17], 8978)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[17])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[17])),
+      8978)
       << "incorrect value for signed_messages[17], expected 8978, is "
       << last_msg_->signed_messages[17];
-  EXPECT_EQ(last_msg_->signed_messages[18], 9212)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[18])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[18])),
+      9212)
       << "incorrect value for signed_messages[18], expected 9212, is "
       << last_msg_->signed_messages[18];
-  EXPECT_EQ(last_msg_->signed_messages[19], 9446)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[19])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[19])),
+      9446)
       << "incorrect value for signed_messages[19], expected 9446, is "
       << last_msg_->signed_messages[19];
-  EXPECT_EQ(last_msg_->signed_messages[20], 9680)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[20])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[20])),
+      9680)
       << "incorrect value for signed_messages[20], expected 9680, is "
       << last_msg_->signed_messages[20];
-  EXPECT_EQ(last_msg_->signed_messages[21], 9914)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[21])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[21])),
+      9914)
       << "incorrect value for signed_messages[21], expected 9914, is "
       << last_msg_->signed_messages[21];
-  EXPECT_EQ(last_msg_->signed_messages[22], 10148)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[22])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[22])),
+      10148)
       << "incorrect value for signed_messages[22], expected 10148, is "
       << last_msg_->signed_messages[22];
-  EXPECT_EQ(last_msg_->signed_messages[23], 10382)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[23])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[23])),
+      10382)
       << "incorrect value for signed_messages[23], expected 10382, is "
       << last_msg_->signed_messages[23];
-  EXPECT_EQ(last_msg_->signed_messages[24], 10616)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[24])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[24])),
+      10616)
       << "incorrect value for signed_messages[24], expected 10616, is "
       << last_msg_->signed_messages[24];
 }

--- a/c/test/legacy/cpp/auto_check_sbp_signing_MsgEd25519SignatureDepB.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_signing_MsgEd25519SignatureDepB.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/signing.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_signing_MsgEd25519SignatureDepB0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -695,337 +702,585 @@ TEST_F(Test_legacy_auto_check_sbp_signing_MsgEd25519SignatureDepB0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->fingerprint[0], 100)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[0])),
+            100)
       << "incorrect value for fingerprint[0], expected 100, is "
       << last_msg_->fingerprint[0];
-  EXPECT_EQ(last_msg_->fingerprint[1], 101)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[1])),
+            101)
       << "incorrect value for fingerprint[1], expected 101, is "
       << last_msg_->fingerprint[1];
-  EXPECT_EQ(last_msg_->fingerprint[2], 102)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[2])),
+            102)
       << "incorrect value for fingerprint[2], expected 102, is "
       << last_msg_->fingerprint[2];
-  EXPECT_EQ(last_msg_->fingerprint[3], 103)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[3])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[3])),
+            103)
       << "incorrect value for fingerprint[3], expected 103, is "
       << last_msg_->fingerprint[3];
-  EXPECT_EQ(last_msg_->fingerprint[4], 104)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[4])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[4])),
+            104)
       << "incorrect value for fingerprint[4], expected 104, is "
       << last_msg_->fingerprint[4];
-  EXPECT_EQ(last_msg_->fingerprint[5], 105)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[5])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[5])),
+            105)
       << "incorrect value for fingerprint[5], expected 105, is "
       << last_msg_->fingerprint[5];
-  EXPECT_EQ(last_msg_->fingerprint[6], 106)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[6])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[6])),
+            106)
       << "incorrect value for fingerprint[6], expected 106, is "
       << last_msg_->fingerprint[6];
-  EXPECT_EQ(last_msg_->fingerprint[7], 107)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[7])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[7])),
+            107)
       << "incorrect value for fingerprint[7], expected 107, is "
       << last_msg_->fingerprint[7];
-  EXPECT_EQ(last_msg_->fingerprint[8], 108)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[8])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[8])),
+            108)
       << "incorrect value for fingerprint[8], expected 108, is "
       << last_msg_->fingerprint[8];
-  EXPECT_EQ(last_msg_->fingerprint[9], 109)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[9])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[9])),
+            109)
       << "incorrect value for fingerprint[9], expected 109, is "
       << last_msg_->fingerprint[9];
-  EXPECT_EQ(last_msg_->fingerprint[10], 110)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[10])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[10])),
+            110)
       << "incorrect value for fingerprint[10], expected 110, is "
       << last_msg_->fingerprint[10];
-  EXPECT_EQ(last_msg_->fingerprint[11], 111)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[11])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[11])),
+            111)
       << "incorrect value for fingerprint[11], expected 111, is "
       << last_msg_->fingerprint[11];
-  EXPECT_EQ(last_msg_->fingerprint[12], 112)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[12])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[12])),
+            112)
       << "incorrect value for fingerprint[12], expected 112, is "
       << last_msg_->fingerprint[12];
-  EXPECT_EQ(last_msg_->fingerprint[13], 113)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[13])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[13])),
+            113)
       << "incorrect value for fingerprint[13], expected 113, is "
       << last_msg_->fingerprint[13];
-  EXPECT_EQ(last_msg_->fingerprint[14], 114)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[14])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[14])),
+            114)
       << "incorrect value for fingerprint[14], expected 114, is "
       << last_msg_->fingerprint[14];
-  EXPECT_EQ(last_msg_->fingerprint[15], 115)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[15])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[15])),
+            115)
       << "incorrect value for fingerprint[15], expected 115, is "
       << last_msg_->fingerprint[15];
-  EXPECT_EQ(last_msg_->fingerprint[16], 116)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[16])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[16])),
+            116)
       << "incorrect value for fingerprint[16], expected 116, is "
       << last_msg_->fingerprint[16];
-  EXPECT_EQ(last_msg_->fingerprint[17], 117)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[17])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[17])),
+            117)
       << "incorrect value for fingerprint[17], expected 117, is "
       << last_msg_->fingerprint[17];
-  EXPECT_EQ(last_msg_->fingerprint[18], 118)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[18])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[18])),
+            118)
       << "incorrect value for fingerprint[18], expected 118, is "
       << last_msg_->fingerprint[18];
-  EXPECT_EQ(last_msg_->fingerprint[19], 119)
+  EXPECT_EQ(get_as<decltype(last_msg_->fingerprint[19])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->fingerprint[19])),
+            119)
       << "incorrect value for fingerprint[19], expected 119, is "
       << last_msg_->fingerprint[19];
-  EXPECT_EQ(last_msg_->on_demand_counter, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->on_demand_counter)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->on_demand_counter)),
+      0)
       << "incorrect value for on_demand_counter, expected 0, is "
       << last_msg_->on_demand_counter;
-  EXPECT_EQ(last_msg_->signature[0], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[0])),
+            0)
       << "incorrect value for signature[0], expected 0, is "
       << last_msg_->signature[0];
-  EXPECT_EQ(last_msg_->signature[1], 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[1])),
+            1)
       << "incorrect value for signature[1], expected 1, is "
       << last_msg_->signature[1];
-  EXPECT_EQ(last_msg_->signature[2], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[2])),
+            2)
       << "incorrect value for signature[2], expected 2, is "
       << last_msg_->signature[2];
-  EXPECT_EQ(last_msg_->signature[3], 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[3])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[3])),
+            3)
       << "incorrect value for signature[3], expected 3, is "
       << last_msg_->signature[3];
-  EXPECT_EQ(last_msg_->signature[4], 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[4])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[4])),
+            4)
       << "incorrect value for signature[4], expected 4, is "
       << last_msg_->signature[4];
-  EXPECT_EQ(last_msg_->signature[5], 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[5])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[5])),
+            5)
       << "incorrect value for signature[5], expected 5, is "
       << last_msg_->signature[5];
-  EXPECT_EQ(last_msg_->signature[6], 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[6])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[6])),
+            6)
       << "incorrect value for signature[6], expected 6, is "
       << last_msg_->signature[6];
-  EXPECT_EQ(last_msg_->signature[7], 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[7])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[7])),
+            7)
       << "incorrect value for signature[7], expected 7, is "
       << last_msg_->signature[7];
-  EXPECT_EQ(last_msg_->signature[8], 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[8])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[8])),
+            8)
       << "incorrect value for signature[8], expected 8, is "
       << last_msg_->signature[8];
-  EXPECT_EQ(last_msg_->signature[9], 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[9])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[9])),
+            9)
       << "incorrect value for signature[9], expected 9, is "
       << last_msg_->signature[9];
-  EXPECT_EQ(last_msg_->signature[10], 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[10])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[10])),
+            10)
       << "incorrect value for signature[10], expected 10, is "
       << last_msg_->signature[10];
-  EXPECT_EQ(last_msg_->signature[11], 11)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[11])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[11])),
+            11)
       << "incorrect value for signature[11], expected 11, is "
       << last_msg_->signature[11];
-  EXPECT_EQ(last_msg_->signature[12], 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[12])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[12])),
+            12)
       << "incorrect value for signature[12], expected 12, is "
       << last_msg_->signature[12];
-  EXPECT_EQ(last_msg_->signature[13], 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[13])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[13])),
+            13)
       << "incorrect value for signature[13], expected 13, is "
       << last_msg_->signature[13];
-  EXPECT_EQ(last_msg_->signature[14], 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[14])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[14])),
+            14)
       << "incorrect value for signature[14], expected 14, is "
       << last_msg_->signature[14];
-  EXPECT_EQ(last_msg_->signature[15], 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[15])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[15])),
+            15)
       << "incorrect value for signature[15], expected 15, is "
       << last_msg_->signature[15];
-  EXPECT_EQ(last_msg_->signature[16], 16)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[16])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[16])),
+            16)
       << "incorrect value for signature[16], expected 16, is "
       << last_msg_->signature[16];
-  EXPECT_EQ(last_msg_->signature[17], 17)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[17])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[17])),
+            17)
       << "incorrect value for signature[17], expected 17, is "
       << last_msg_->signature[17];
-  EXPECT_EQ(last_msg_->signature[18], 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[18])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[18])),
+            18)
       << "incorrect value for signature[18], expected 18, is "
       << last_msg_->signature[18];
-  EXPECT_EQ(last_msg_->signature[19], 19)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[19])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[19])),
+            19)
       << "incorrect value for signature[19], expected 19, is "
       << last_msg_->signature[19];
-  EXPECT_EQ(last_msg_->signature[20], 20)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[20])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[20])),
+            20)
       << "incorrect value for signature[20], expected 20, is "
       << last_msg_->signature[20];
-  EXPECT_EQ(last_msg_->signature[21], 21)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[21])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[21])),
+            21)
       << "incorrect value for signature[21], expected 21, is "
       << last_msg_->signature[21];
-  EXPECT_EQ(last_msg_->signature[22], 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[22])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[22])),
+            22)
       << "incorrect value for signature[22], expected 22, is "
       << last_msg_->signature[22];
-  EXPECT_EQ(last_msg_->signature[23], 23)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[23])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[23])),
+            23)
       << "incorrect value for signature[23], expected 23, is "
       << last_msg_->signature[23];
-  EXPECT_EQ(last_msg_->signature[24], 24)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[24])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[24])),
+            24)
       << "incorrect value for signature[24], expected 24, is "
       << last_msg_->signature[24];
-  EXPECT_EQ(last_msg_->signature[25], 25)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[25])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[25])),
+            25)
       << "incorrect value for signature[25], expected 25, is "
       << last_msg_->signature[25];
-  EXPECT_EQ(last_msg_->signature[26], 26)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[26])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[26])),
+            26)
       << "incorrect value for signature[26], expected 26, is "
       << last_msg_->signature[26];
-  EXPECT_EQ(last_msg_->signature[27], 27)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[27])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[27])),
+            27)
       << "incorrect value for signature[27], expected 27, is "
       << last_msg_->signature[27];
-  EXPECT_EQ(last_msg_->signature[28], 28)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[28])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[28])),
+            28)
       << "incorrect value for signature[28], expected 28, is "
       << last_msg_->signature[28];
-  EXPECT_EQ(last_msg_->signature[29], 29)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[29])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[29])),
+            29)
       << "incorrect value for signature[29], expected 29, is "
       << last_msg_->signature[29];
-  EXPECT_EQ(last_msg_->signature[30], 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[30])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[30])),
+            30)
       << "incorrect value for signature[30], expected 30, is "
       << last_msg_->signature[30];
-  EXPECT_EQ(last_msg_->signature[31], 31)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[31])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[31])),
+            31)
       << "incorrect value for signature[31], expected 31, is "
       << last_msg_->signature[31];
-  EXPECT_EQ(last_msg_->signature[32], 32)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[32])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[32])),
+            32)
       << "incorrect value for signature[32], expected 32, is "
       << last_msg_->signature[32];
-  EXPECT_EQ(last_msg_->signature[33], 33)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[33])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[33])),
+            33)
       << "incorrect value for signature[33], expected 33, is "
       << last_msg_->signature[33];
-  EXPECT_EQ(last_msg_->signature[34], 34)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[34])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[34])),
+            34)
       << "incorrect value for signature[34], expected 34, is "
       << last_msg_->signature[34];
-  EXPECT_EQ(last_msg_->signature[35], 35)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[35])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[35])),
+            35)
       << "incorrect value for signature[35], expected 35, is "
       << last_msg_->signature[35];
-  EXPECT_EQ(last_msg_->signature[36], 36)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[36])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[36])),
+            36)
       << "incorrect value for signature[36], expected 36, is "
       << last_msg_->signature[36];
-  EXPECT_EQ(last_msg_->signature[37], 37)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[37])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[37])),
+            37)
       << "incorrect value for signature[37], expected 37, is "
       << last_msg_->signature[37];
-  EXPECT_EQ(last_msg_->signature[38], 38)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[38])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[38])),
+            38)
       << "incorrect value for signature[38], expected 38, is "
       << last_msg_->signature[38];
-  EXPECT_EQ(last_msg_->signature[39], 39)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[39])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[39])),
+            39)
       << "incorrect value for signature[39], expected 39, is "
       << last_msg_->signature[39];
-  EXPECT_EQ(last_msg_->signature[40], 40)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[40])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[40])),
+            40)
       << "incorrect value for signature[40], expected 40, is "
       << last_msg_->signature[40];
-  EXPECT_EQ(last_msg_->signature[41], 41)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[41])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[41])),
+            41)
       << "incorrect value for signature[41], expected 41, is "
       << last_msg_->signature[41];
-  EXPECT_EQ(last_msg_->signature[42], 42)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[42])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[42])),
+            42)
       << "incorrect value for signature[42], expected 42, is "
       << last_msg_->signature[42];
-  EXPECT_EQ(last_msg_->signature[43], 43)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[43])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[43])),
+            43)
       << "incorrect value for signature[43], expected 43, is "
       << last_msg_->signature[43];
-  EXPECT_EQ(last_msg_->signature[44], 44)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[44])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[44])),
+            44)
       << "incorrect value for signature[44], expected 44, is "
       << last_msg_->signature[44];
-  EXPECT_EQ(last_msg_->signature[45], 45)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[45])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[45])),
+            45)
       << "incorrect value for signature[45], expected 45, is "
       << last_msg_->signature[45];
-  EXPECT_EQ(last_msg_->signature[46], 46)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[46])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[46])),
+            46)
       << "incorrect value for signature[46], expected 46, is "
       << last_msg_->signature[46];
-  EXPECT_EQ(last_msg_->signature[47], 47)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[47])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[47])),
+            47)
       << "incorrect value for signature[47], expected 47, is "
       << last_msg_->signature[47];
-  EXPECT_EQ(last_msg_->signature[48], 48)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[48])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[48])),
+            48)
       << "incorrect value for signature[48], expected 48, is "
       << last_msg_->signature[48];
-  EXPECT_EQ(last_msg_->signature[49], 49)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[49])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[49])),
+            49)
       << "incorrect value for signature[49], expected 49, is "
       << last_msg_->signature[49];
-  EXPECT_EQ(last_msg_->signature[50], 50)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[50])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[50])),
+            50)
       << "incorrect value for signature[50], expected 50, is "
       << last_msg_->signature[50];
-  EXPECT_EQ(last_msg_->signature[51], 51)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[51])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[51])),
+            51)
       << "incorrect value for signature[51], expected 51, is "
       << last_msg_->signature[51];
-  EXPECT_EQ(last_msg_->signature[52], 52)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[52])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[52])),
+            52)
       << "incorrect value for signature[52], expected 52, is "
       << last_msg_->signature[52];
-  EXPECT_EQ(last_msg_->signature[53], 53)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[53])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[53])),
+            53)
       << "incorrect value for signature[53], expected 53, is "
       << last_msg_->signature[53];
-  EXPECT_EQ(last_msg_->signature[54], 54)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[54])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[54])),
+            54)
       << "incorrect value for signature[54], expected 54, is "
       << last_msg_->signature[54];
-  EXPECT_EQ(last_msg_->signature[55], 55)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[55])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[55])),
+            55)
       << "incorrect value for signature[55], expected 55, is "
       << last_msg_->signature[55];
-  EXPECT_EQ(last_msg_->signature[56], 56)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[56])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[56])),
+            56)
       << "incorrect value for signature[56], expected 56, is "
       << last_msg_->signature[56];
-  EXPECT_EQ(last_msg_->signature[57], 57)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[57])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[57])),
+            57)
       << "incorrect value for signature[57], expected 57, is "
       << last_msg_->signature[57];
-  EXPECT_EQ(last_msg_->signature[58], 58)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[58])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[58])),
+            58)
       << "incorrect value for signature[58], expected 58, is "
       << last_msg_->signature[58];
-  EXPECT_EQ(last_msg_->signature[59], 59)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[59])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[59])),
+            59)
       << "incorrect value for signature[59], expected 59, is "
       << last_msg_->signature[59];
-  EXPECT_EQ(last_msg_->signature[60], 60)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[60])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[60])),
+            60)
       << "incorrect value for signature[60], expected 60, is "
       << last_msg_->signature[60];
-  EXPECT_EQ(last_msg_->signature[61], 61)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[61])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[61])),
+            61)
       << "incorrect value for signature[61], expected 61, is "
       << last_msg_->signature[61];
-  EXPECT_EQ(last_msg_->signature[62], 62)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[62])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[62])),
+            62)
       << "incorrect value for signature[62], expected 62, is "
       << last_msg_->signature[62];
-  EXPECT_EQ(last_msg_->signature[63], 63)
+  EXPECT_EQ(get_as<decltype(last_msg_->signature[63])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->signature[63])),
+            63)
       << "incorrect value for signature[63], expected 63, is "
       << last_msg_->signature[63];
-  EXPECT_EQ(last_msg_->signed_messages[0], 5000)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[0])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[0])),
+      5000)
       << "incorrect value for signed_messages[0], expected 5000, is "
       << last_msg_->signed_messages[0];
-  EXPECT_EQ(last_msg_->signed_messages[1], 5234)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[1])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[1])),
+      5234)
       << "incorrect value for signed_messages[1], expected 5234, is "
       << last_msg_->signed_messages[1];
-  EXPECT_EQ(last_msg_->signed_messages[2], 5468)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[2])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[2])),
+      5468)
       << "incorrect value for signed_messages[2], expected 5468, is "
       << last_msg_->signed_messages[2];
-  EXPECT_EQ(last_msg_->signed_messages[3], 5702)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[3])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[3])),
+      5702)
       << "incorrect value for signed_messages[3], expected 5702, is "
       << last_msg_->signed_messages[3];
-  EXPECT_EQ(last_msg_->signed_messages[4], 5936)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[4])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[4])),
+      5936)
       << "incorrect value for signed_messages[4], expected 5936, is "
       << last_msg_->signed_messages[4];
-  EXPECT_EQ(last_msg_->signed_messages[5], 6170)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[5])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[5])),
+      6170)
       << "incorrect value for signed_messages[5], expected 6170, is "
       << last_msg_->signed_messages[5];
-  EXPECT_EQ(last_msg_->signed_messages[6], 6404)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[6])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[6])),
+      6404)
       << "incorrect value for signed_messages[6], expected 6404, is "
       << last_msg_->signed_messages[6];
-  EXPECT_EQ(last_msg_->signed_messages[7], 6638)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[7])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[7])),
+      6638)
       << "incorrect value for signed_messages[7], expected 6638, is "
       << last_msg_->signed_messages[7];
-  EXPECT_EQ(last_msg_->signed_messages[8], 6872)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[8])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[8])),
+      6872)
       << "incorrect value for signed_messages[8], expected 6872, is "
       << last_msg_->signed_messages[8];
-  EXPECT_EQ(last_msg_->signed_messages[9], 7106)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[9])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[9])),
+      7106)
       << "incorrect value for signed_messages[9], expected 7106, is "
       << last_msg_->signed_messages[9];
-  EXPECT_EQ(last_msg_->signed_messages[10], 7340)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[10])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[10])),
+      7340)
       << "incorrect value for signed_messages[10], expected 7340, is "
       << last_msg_->signed_messages[10];
-  EXPECT_EQ(last_msg_->signed_messages[11], 7574)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[11])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[11])),
+      7574)
       << "incorrect value for signed_messages[11], expected 7574, is "
       << last_msg_->signed_messages[11];
-  EXPECT_EQ(last_msg_->signed_messages[12], 7808)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[12])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[12])),
+      7808)
       << "incorrect value for signed_messages[12], expected 7808, is "
       << last_msg_->signed_messages[12];
-  EXPECT_EQ(last_msg_->signed_messages[13], 8042)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[13])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[13])),
+      8042)
       << "incorrect value for signed_messages[13], expected 8042, is "
       << last_msg_->signed_messages[13];
-  EXPECT_EQ(last_msg_->signed_messages[14], 8276)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[14])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[14])),
+      8276)
       << "incorrect value for signed_messages[14], expected 8276, is "
       << last_msg_->signed_messages[14];
-  EXPECT_EQ(last_msg_->signed_messages[15], 8510)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[15])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[15])),
+      8510)
       << "incorrect value for signed_messages[15], expected 8510, is "
       << last_msg_->signed_messages[15];
-  EXPECT_EQ(last_msg_->signed_messages[16], 8744)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[16])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[16])),
+      8744)
       << "incorrect value for signed_messages[16], expected 8744, is "
       << last_msg_->signed_messages[16];
-  EXPECT_EQ(last_msg_->signed_messages[17], 8978)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[17])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[17])),
+      8978)
       << "incorrect value for signed_messages[17], expected 8978, is "
       << last_msg_->signed_messages[17];
-  EXPECT_EQ(last_msg_->signed_messages[18], 9212)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[18])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[18])),
+      9212)
       << "incorrect value for signed_messages[18], expected 9212, is "
       << last_msg_->signed_messages[18];
-  EXPECT_EQ(last_msg_->signed_messages[19], 9446)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[19])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[19])),
+      9446)
       << "incorrect value for signed_messages[19], expected 9446, is "
       << last_msg_->signed_messages[19];
-  EXPECT_EQ(last_msg_->signed_messages[20], 9680)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[20])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[20])),
+      9680)
       << "incorrect value for signed_messages[20], expected 9680, is "
       << last_msg_->signed_messages[20];
-  EXPECT_EQ(last_msg_->signed_messages[21], 9914)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[21])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[21])),
+      9914)
       << "incorrect value for signed_messages[21], expected 9914, is "
       << last_msg_->signed_messages[21];
-  EXPECT_EQ(last_msg_->signed_messages[22], 10148)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[22])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[22])),
+      10148)
       << "incorrect value for signed_messages[22], expected 10148, is "
       << last_msg_->signed_messages[22];
-  EXPECT_EQ(last_msg_->signed_messages[23], 10382)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[23])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[23])),
+      10382)
       << "incorrect value for signed_messages[23], expected 10382, is "
       << last_msg_->signed_messages[23];
-  EXPECT_EQ(last_msg_->signed_messages[24], 10616)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->signed_messages[24])>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->signed_messages[24])),
+      10616)
       << "incorrect value for signed_messages[24], expected 10616, is "
       << last_msg_->signed_messages[24];
-  EXPECT_EQ(last_msg_->stream_counter, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->stream_counter)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->stream_counter)),
+            1)
       << "incorrect value for stream_counter, expected 1, is "
       << last_msg_->stream_counter;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_solution_meta_MsgSolnMeta.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_solution_meta_MsgSolnMeta.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/solution_meta.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_solution_meta_MsgSolnMeta0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -847,732 +854,1448 @@ TEST_F(Test_legacy_auto_check_sbp_solution_meta_MsgSolnMeta0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 15360);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->age_corrections, 21256)
+  EXPECT_EQ(get_as<decltype(last_msg_->age_corrections)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->age_corrections)),
+            21256)
       << "incorrect value for age_corrections, expected 21256, is "
       << last_msg_->age_corrections;
-  EXPECT_EQ(last_msg_->age_gnss, 3573765977)
+  EXPECT_EQ(get_as<decltype(last_msg_->age_gnss)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->age_gnss)),
+            3573765977)
       << "incorrect value for age_gnss, expected 3573765977, is "
       << last_msg_->age_gnss;
-  EXPECT_EQ(last_msg_->hdop, 41156)
+  EXPECT_EQ(get_as<decltype(last_msg_->hdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->hdop)),
+            41156)
       << "incorrect value for hdop, expected 41156, is " << last_msg_->hdop;
-  EXPECT_EQ(last_msg_->pdop, 11642)
+  EXPECT_EQ(get_as<decltype(last_msg_->pdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pdop)),
+            11642)
       << "incorrect value for pdop, expected 11642, is " << last_msg_->pdop;
-  EXPECT_EQ(last_msg_->sol_in[0].flags, 109)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[0].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[0].flags)),
+            109)
       << "incorrect value for sol_in[0].flags, expected 109, is "
       << last_msg_->sol_in[0].flags;
-  EXPECT_EQ(last_msg_->sol_in[0].sensor_type, 95)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[0].sensor_type)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[0].sensor_type)),
+      95)
       << "incorrect value for sol_in[0].sensor_type, expected 95, is "
       << last_msg_->sol_in[0].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[1].flags, 131)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[1].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[1].flags)),
+            131)
       << "incorrect value for sol_in[1].flags, expected 131, is "
       << last_msg_->sol_in[1].flags;
-  EXPECT_EQ(last_msg_->sol_in[1].sensor_type, 86)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[1].sensor_type)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[1].sensor_type)),
+      86)
       << "incorrect value for sol_in[1].sensor_type, expected 86, is "
       << last_msg_->sol_in[1].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[2].flags, 70)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[2].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[2].flags)),
+            70)
       << "incorrect value for sol_in[2].flags, expected 70, is "
       << last_msg_->sol_in[2].flags;
-  EXPECT_EQ(last_msg_->sol_in[2].sensor_type, 71)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[2].sensor_type)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[2].sensor_type)),
+      71)
       << "incorrect value for sol_in[2].sensor_type, expected 71, is "
       << last_msg_->sol_in[2].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[3].flags, 73)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[3].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[3].flags)),
+            73)
       << "incorrect value for sol_in[3].flags, expected 73, is "
       << last_msg_->sol_in[3].flags;
-  EXPECT_EQ(last_msg_->sol_in[3].sensor_type, 84)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[3].sensor_type)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[3].sensor_type)),
+      84)
       << "incorrect value for sol_in[3].sensor_type, expected 84, is "
       << last_msg_->sol_in[3].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[4].flags, 26)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[4].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[4].flags)),
+            26)
       << "incorrect value for sol_in[4].flags, expected 26, is "
       << last_msg_->sol_in[4].flags;
-  EXPECT_EQ(last_msg_->sol_in[4].sensor_type, 131)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[4].sensor_type)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[4].sensor_type)),
+      131)
       << "incorrect value for sol_in[4].sensor_type, expected 131, is "
       << last_msg_->sol_in[4].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[5].flags, 247)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[5].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[5].flags)),
+            247)
       << "incorrect value for sol_in[5].flags, expected 247, is "
       << last_msg_->sol_in[5].flags;
-  EXPECT_EQ(last_msg_->sol_in[5].sensor_type, 82)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[5].sensor_type)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[5].sensor_type)),
+      82)
       << "incorrect value for sol_in[5].sensor_type, expected 82, is "
       << last_msg_->sol_in[5].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[6].flags, 97)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[6].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[6].flags)),
+            97)
       << "incorrect value for sol_in[6].flags, expected 97, is "
       << last_msg_->sol_in[6].flags;
-  EXPECT_EQ(last_msg_->sol_in[6].sensor_type, 140)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[6].sensor_type)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[6].sensor_type)),
+      140)
       << "incorrect value for sol_in[6].sensor_type, expected 140, is "
       << last_msg_->sol_in[6].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[7].flags, 110)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[7].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[7].flags)),
+            110)
       << "incorrect value for sol_in[7].flags, expected 110, is "
       << last_msg_->sol_in[7].flags;
-  EXPECT_EQ(last_msg_->sol_in[7].sensor_type, 115)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[7].sensor_type)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[7].sensor_type)),
+      115)
       << "incorrect value for sol_in[7].sensor_type, expected 115, is "
       << last_msg_->sol_in[7].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[8].flags, 253)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[8].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[8].flags)),
+            253)
       << "incorrect value for sol_in[8].flags, expected 253, is "
       << last_msg_->sol_in[8].flags;
-  EXPECT_EQ(last_msg_->sol_in[8].sensor_type, 118)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[8].sensor_type)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[8].sensor_type)),
+      118)
       << "incorrect value for sol_in[8].sensor_type, expected 118, is "
       << last_msg_->sol_in[8].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[9].flags, 122)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[9].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[9].flags)),
+            122)
       << "incorrect value for sol_in[9].flags, expected 122, is "
       << last_msg_->sol_in[9].flags;
-  EXPECT_EQ(last_msg_->sol_in[9].sensor_type, 2)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[9].sensor_type)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[9].sensor_type)),
+      2)
       << "incorrect value for sol_in[9].sensor_type, expected 2, is "
       << last_msg_->sol_in[9].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[10].flags, 148)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[10].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[10].flags)),
+      148)
       << "incorrect value for sol_in[10].flags, expected 148, is "
       << last_msg_->sol_in[10].flags;
-  EXPECT_EQ(last_msg_->sol_in[10].sensor_type, 186)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[10].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[10].sensor_type)),
+            186)
       << "incorrect value for sol_in[10].sensor_type, expected 186, is "
       << last_msg_->sol_in[10].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[11].flags, 148)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[11].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[11].flags)),
+      148)
       << "incorrect value for sol_in[11].flags, expected 148, is "
       << last_msg_->sol_in[11].flags;
-  EXPECT_EQ(last_msg_->sol_in[11].sensor_type, 122)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[11].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[11].sensor_type)),
+            122)
       << "incorrect value for sol_in[11].sensor_type, expected 122, is "
       << last_msg_->sol_in[11].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[12].flags, 231)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[12].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[12].flags)),
+      231)
       << "incorrect value for sol_in[12].flags, expected 231, is "
       << last_msg_->sol_in[12].flags;
-  EXPECT_EQ(last_msg_->sol_in[12].sensor_type, 180)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[12].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[12].sensor_type)),
+            180)
       << "incorrect value for sol_in[12].sensor_type, expected 180, is "
       << last_msg_->sol_in[12].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[13].flags, 46)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[13].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[13].flags)),
+      46)
       << "incorrect value for sol_in[13].flags, expected 46, is "
       << last_msg_->sol_in[13].flags;
-  EXPECT_EQ(last_msg_->sol_in[13].sensor_type, 68)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[13].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[13].sensor_type)),
+            68)
       << "incorrect value for sol_in[13].sensor_type, expected 68, is "
       << last_msg_->sol_in[13].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[14].flags, 102)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[14].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[14].flags)),
+      102)
       << "incorrect value for sol_in[14].flags, expected 102, is "
       << last_msg_->sol_in[14].flags;
-  EXPECT_EQ(last_msg_->sol_in[14].sensor_type, 190)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[14].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[14].sensor_type)),
+            190)
       << "incorrect value for sol_in[14].sensor_type, expected 190, is "
       << last_msg_->sol_in[14].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[15].flags, 48)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[15].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[15].flags)),
+      48)
       << "incorrect value for sol_in[15].flags, expected 48, is "
       << last_msg_->sol_in[15].flags;
-  EXPECT_EQ(last_msg_->sol_in[15].sensor_type, 243)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[15].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[15].sensor_type)),
+            243)
       << "incorrect value for sol_in[15].sensor_type, expected 243, is "
       << last_msg_->sol_in[15].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[16].flags, 15)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[16].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[16].flags)),
+      15)
       << "incorrect value for sol_in[16].flags, expected 15, is "
       << last_msg_->sol_in[16].flags;
-  EXPECT_EQ(last_msg_->sol_in[16].sensor_type, 192)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[16].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[16].sensor_type)),
+            192)
       << "incorrect value for sol_in[16].sensor_type, expected 192, is "
       << last_msg_->sol_in[16].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[17].flags, 89)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[17].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[17].flags)),
+      89)
       << "incorrect value for sol_in[17].flags, expected 89, is "
       << last_msg_->sol_in[17].flags;
-  EXPECT_EQ(last_msg_->sol_in[17].sensor_type, 208)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[17].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[17].sensor_type)),
+            208)
       << "incorrect value for sol_in[17].sensor_type, expected 208, is "
       << last_msg_->sol_in[17].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[18].flags, 10)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[18].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[18].flags)),
+      10)
       << "incorrect value for sol_in[18].flags, expected 10, is "
       << last_msg_->sol_in[18].flags;
-  EXPECT_EQ(last_msg_->sol_in[18].sensor_type, 56)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[18].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[18].sensor_type)),
+            56)
       << "incorrect value for sol_in[18].sensor_type, expected 56, is "
       << last_msg_->sol_in[18].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[19].flags, 2)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[19].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[19].flags)),
+      2)
       << "incorrect value for sol_in[19].flags, expected 2, is "
       << last_msg_->sol_in[19].flags;
-  EXPECT_EQ(last_msg_->sol_in[19].sensor_type, 245)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[19].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[19].sensor_type)),
+            245)
       << "incorrect value for sol_in[19].sensor_type, expected 245, is "
       << last_msg_->sol_in[19].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[20].flags, 201)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[20].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[20].flags)),
+      201)
       << "incorrect value for sol_in[20].flags, expected 201, is "
       << last_msg_->sol_in[20].flags;
-  EXPECT_EQ(last_msg_->sol_in[20].sensor_type, 254)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[20].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[20].sensor_type)),
+            254)
       << "incorrect value for sol_in[20].sensor_type, expected 254, is "
       << last_msg_->sol_in[20].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[21].flags, 32)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[21].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[21].flags)),
+      32)
       << "incorrect value for sol_in[21].flags, expected 32, is "
       << last_msg_->sol_in[21].flags;
-  EXPECT_EQ(last_msg_->sol_in[21].sensor_type, 120)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[21].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[21].sensor_type)),
+            120)
       << "incorrect value for sol_in[21].sensor_type, expected 120, is "
       << last_msg_->sol_in[21].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[22].flags, 2)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[22].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[22].flags)),
+      2)
       << "incorrect value for sol_in[22].flags, expected 2, is "
       << last_msg_->sol_in[22].flags;
-  EXPECT_EQ(last_msg_->sol_in[22].sensor_type, 126)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[22].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[22].sensor_type)),
+            126)
       << "incorrect value for sol_in[22].sensor_type, expected 126, is "
       << last_msg_->sol_in[22].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[23].flags, 161)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[23].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[23].flags)),
+      161)
       << "incorrect value for sol_in[23].flags, expected 161, is "
       << last_msg_->sol_in[23].flags;
-  EXPECT_EQ(last_msg_->sol_in[23].sensor_type, 83)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[23].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[23].sensor_type)),
+            83)
       << "incorrect value for sol_in[23].sensor_type, expected 83, is "
       << last_msg_->sol_in[23].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[24].flags, 123)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[24].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[24].flags)),
+      123)
       << "incorrect value for sol_in[24].flags, expected 123, is "
       << last_msg_->sol_in[24].flags;
-  EXPECT_EQ(last_msg_->sol_in[24].sensor_type, 238)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[24].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[24].sensor_type)),
+            238)
       << "incorrect value for sol_in[24].sensor_type, expected 238, is "
       << last_msg_->sol_in[24].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[25].flags, 230)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[25].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[25].flags)),
+      230)
       << "incorrect value for sol_in[25].flags, expected 230, is "
       << last_msg_->sol_in[25].flags;
-  EXPECT_EQ(last_msg_->sol_in[25].sensor_type, 102)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[25].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[25].sensor_type)),
+            102)
       << "incorrect value for sol_in[25].sensor_type, expected 102, is "
       << last_msg_->sol_in[25].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[26].flags, 190)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[26].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[26].flags)),
+      190)
       << "incorrect value for sol_in[26].flags, expected 190, is "
       << last_msg_->sol_in[26].flags;
-  EXPECT_EQ(last_msg_->sol_in[26].sensor_type, 76)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[26].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[26].sensor_type)),
+            76)
       << "incorrect value for sol_in[26].sensor_type, expected 76, is "
       << last_msg_->sol_in[26].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[27].flags, 182)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[27].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[27].flags)),
+      182)
       << "incorrect value for sol_in[27].flags, expected 182, is "
       << last_msg_->sol_in[27].flags;
-  EXPECT_EQ(last_msg_->sol_in[27].sensor_type, 225)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[27].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[27].sensor_type)),
+            225)
       << "incorrect value for sol_in[27].sensor_type, expected 225, is "
       << last_msg_->sol_in[27].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[28].flags, 228)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[28].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[28].flags)),
+      228)
       << "incorrect value for sol_in[28].flags, expected 228, is "
       << last_msg_->sol_in[28].flags;
-  EXPECT_EQ(last_msg_->sol_in[28].sensor_type, 207)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[28].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[28].sensor_type)),
+            207)
       << "incorrect value for sol_in[28].sensor_type, expected 207, is "
       << last_msg_->sol_in[28].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[29].flags, 218)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[29].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[29].flags)),
+      218)
       << "incorrect value for sol_in[29].flags, expected 218, is "
       << last_msg_->sol_in[29].flags;
-  EXPECT_EQ(last_msg_->sol_in[29].sensor_type, 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[29].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[29].sensor_type)),
+            7)
       << "incorrect value for sol_in[29].sensor_type, expected 7, is "
       << last_msg_->sol_in[29].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[30].flags, 89)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[30].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[30].flags)),
+      89)
       << "incorrect value for sol_in[30].flags, expected 89, is "
       << last_msg_->sol_in[30].flags;
-  EXPECT_EQ(last_msg_->sol_in[30].sensor_type, 117)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[30].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[30].sensor_type)),
+            117)
       << "incorrect value for sol_in[30].sensor_type, expected 117, is "
       << last_msg_->sol_in[30].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[31].flags, 191)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[31].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[31].flags)),
+      191)
       << "incorrect value for sol_in[31].flags, expected 191, is "
       << last_msg_->sol_in[31].flags;
-  EXPECT_EQ(last_msg_->sol_in[31].sensor_type, 29)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[31].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[31].sensor_type)),
+            29)
       << "incorrect value for sol_in[31].sensor_type, expected 29, is "
       << last_msg_->sol_in[31].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[32].flags, 248)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[32].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[32].flags)),
+      248)
       << "incorrect value for sol_in[32].flags, expected 248, is "
       << last_msg_->sol_in[32].flags;
-  EXPECT_EQ(last_msg_->sol_in[32].sensor_type, 56)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[32].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[32].sensor_type)),
+            56)
       << "incorrect value for sol_in[32].sensor_type, expected 56, is "
       << last_msg_->sol_in[32].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[33].flags, 255)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[33].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[33].flags)),
+      255)
       << "incorrect value for sol_in[33].flags, expected 255, is "
       << last_msg_->sol_in[33].flags;
-  EXPECT_EQ(last_msg_->sol_in[33].sensor_type, 185)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[33].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[33].sensor_type)),
+            185)
       << "incorrect value for sol_in[33].sensor_type, expected 185, is "
       << last_msg_->sol_in[33].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[34].flags, 18)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[34].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[34].flags)),
+      18)
       << "incorrect value for sol_in[34].flags, expected 18, is "
       << last_msg_->sol_in[34].flags;
-  EXPECT_EQ(last_msg_->sol_in[34].sensor_type, 46)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[34].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[34].sensor_type)),
+            46)
       << "incorrect value for sol_in[34].sensor_type, expected 46, is "
       << last_msg_->sol_in[34].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[35].flags, 142)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[35].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[35].flags)),
+      142)
       << "incorrect value for sol_in[35].flags, expected 142, is "
       << last_msg_->sol_in[35].flags;
-  EXPECT_EQ(last_msg_->sol_in[35].sensor_type, 72)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[35].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[35].sensor_type)),
+            72)
       << "incorrect value for sol_in[35].sensor_type, expected 72, is "
       << last_msg_->sol_in[35].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[36].flags, 113)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[36].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[36].flags)),
+      113)
       << "incorrect value for sol_in[36].flags, expected 113, is "
       << last_msg_->sol_in[36].flags;
-  EXPECT_EQ(last_msg_->sol_in[36].sensor_type, 82)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[36].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[36].sensor_type)),
+            82)
       << "incorrect value for sol_in[36].sensor_type, expected 82, is "
       << last_msg_->sol_in[36].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[37].flags, 4)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[37].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[37].flags)),
+      4)
       << "incorrect value for sol_in[37].flags, expected 4, is "
       << last_msg_->sol_in[37].flags;
-  EXPECT_EQ(last_msg_->sol_in[37].sensor_type, 26)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[37].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[37].sensor_type)),
+            26)
       << "incorrect value for sol_in[37].sensor_type, expected 26, is "
       << last_msg_->sol_in[37].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[38].flags, 254)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[38].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[38].flags)),
+      254)
       << "incorrect value for sol_in[38].flags, expected 254, is "
       << last_msg_->sol_in[38].flags;
-  EXPECT_EQ(last_msg_->sol_in[38].sensor_type, 172)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[38].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[38].sensor_type)),
+            172)
       << "incorrect value for sol_in[38].sensor_type, expected 172, is "
       << last_msg_->sol_in[38].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[39].flags, 136)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[39].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[39].flags)),
+      136)
       << "incorrect value for sol_in[39].flags, expected 136, is "
       << last_msg_->sol_in[39].flags;
-  EXPECT_EQ(last_msg_->sol_in[39].sensor_type, 178)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[39].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[39].sensor_type)),
+            178)
       << "incorrect value for sol_in[39].sensor_type, expected 178, is "
       << last_msg_->sol_in[39].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[40].flags, 115)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[40].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[40].flags)),
+      115)
       << "incorrect value for sol_in[40].flags, expected 115, is "
       << last_msg_->sol_in[40].flags;
-  EXPECT_EQ(last_msg_->sol_in[40].sensor_type, 113)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[40].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[40].sensor_type)),
+            113)
       << "incorrect value for sol_in[40].sensor_type, expected 113, is "
       << last_msg_->sol_in[40].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[41].flags, 193)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[41].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[41].flags)),
+      193)
       << "incorrect value for sol_in[41].flags, expected 193, is "
       << last_msg_->sol_in[41].flags;
-  EXPECT_EQ(last_msg_->sol_in[41].sensor_type, 58)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[41].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[41].sensor_type)),
+            58)
       << "incorrect value for sol_in[41].sensor_type, expected 58, is "
       << last_msg_->sol_in[41].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[42].flags, 227)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[42].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[42].flags)),
+      227)
       << "incorrect value for sol_in[42].flags, expected 227, is "
       << last_msg_->sol_in[42].flags;
-  EXPECT_EQ(last_msg_->sol_in[42].sensor_type, 89)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[42].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[42].sensor_type)),
+            89)
       << "incorrect value for sol_in[42].sensor_type, expected 89, is "
       << last_msg_->sol_in[42].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[43].flags, 246)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[43].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[43].flags)),
+      246)
       << "incorrect value for sol_in[43].flags, expected 246, is "
       << last_msg_->sol_in[43].flags;
-  EXPECT_EQ(last_msg_->sol_in[43].sensor_type, 182)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[43].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[43].sensor_type)),
+            182)
       << "incorrect value for sol_in[43].sensor_type, expected 182, is "
       << last_msg_->sol_in[43].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[44].flags, 77)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[44].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[44].flags)),
+      77)
       << "incorrect value for sol_in[44].flags, expected 77, is "
       << last_msg_->sol_in[44].flags;
-  EXPECT_EQ(last_msg_->sol_in[44].sensor_type, 76)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[44].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[44].sensor_type)),
+            76)
       << "incorrect value for sol_in[44].sensor_type, expected 76, is "
       << last_msg_->sol_in[44].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[45].flags, 245)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[45].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[45].flags)),
+      245)
       << "incorrect value for sol_in[45].flags, expected 245, is "
       << last_msg_->sol_in[45].flags;
-  EXPECT_EQ(last_msg_->sol_in[45].sensor_type, 108)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[45].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[45].sensor_type)),
+            108)
       << "incorrect value for sol_in[45].sensor_type, expected 108, is "
       << last_msg_->sol_in[45].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[46].flags, 31)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[46].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[46].flags)),
+      31)
       << "incorrect value for sol_in[46].flags, expected 31, is "
       << last_msg_->sol_in[46].flags;
-  EXPECT_EQ(last_msg_->sol_in[46].sensor_type, 41)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[46].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[46].sensor_type)),
+            41)
       << "incorrect value for sol_in[46].sensor_type, expected 41, is "
       << last_msg_->sol_in[46].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[47].flags, 124)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[47].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[47].flags)),
+      124)
       << "incorrect value for sol_in[47].flags, expected 124, is "
       << last_msg_->sol_in[47].flags;
-  EXPECT_EQ(last_msg_->sol_in[47].sensor_type, 70)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[47].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[47].sensor_type)),
+            70)
       << "incorrect value for sol_in[47].sensor_type, expected 70, is "
       << last_msg_->sol_in[47].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[48].flags, 145)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[48].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[48].flags)),
+      145)
       << "incorrect value for sol_in[48].flags, expected 145, is "
       << last_msg_->sol_in[48].flags;
-  EXPECT_EQ(last_msg_->sol_in[48].sensor_type, 249)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[48].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[48].sensor_type)),
+            249)
       << "incorrect value for sol_in[48].sensor_type, expected 249, is "
       << last_msg_->sol_in[48].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[49].flags, 78)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[49].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[49].flags)),
+      78)
       << "incorrect value for sol_in[49].flags, expected 78, is "
       << last_msg_->sol_in[49].flags;
-  EXPECT_EQ(last_msg_->sol_in[49].sensor_type, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[49].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[49].sensor_type)),
+            15)
       << "incorrect value for sol_in[49].sensor_type, expected 15, is "
       << last_msg_->sol_in[49].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[50].flags, 38)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[50].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[50].flags)),
+      38)
       << "incorrect value for sol_in[50].flags, expected 38, is "
       << last_msg_->sol_in[50].flags;
-  EXPECT_EQ(last_msg_->sol_in[50].sensor_type, 228)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[50].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[50].sensor_type)),
+            228)
       << "incorrect value for sol_in[50].sensor_type, expected 228, is "
       << last_msg_->sol_in[50].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[51].flags, 129)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[51].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[51].flags)),
+      129)
       << "incorrect value for sol_in[51].flags, expected 129, is "
       << last_msg_->sol_in[51].flags;
-  EXPECT_EQ(last_msg_->sol_in[51].sensor_type, 241)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[51].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[51].sensor_type)),
+            241)
       << "incorrect value for sol_in[51].sensor_type, expected 241, is "
       << last_msg_->sol_in[51].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[52].flags, 176)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[52].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[52].flags)),
+      176)
       << "incorrect value for sol_in[52].flags, expected 176, is "
       << last_msg_->sol_in[52].flags;
-  EXPECT_EQ(last_msg_->sol_in[52].sensor_type, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[52].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[52].sensor_type)),
+            8)
       << "incorrect value for sol_in[52].sensor_type, expected 8, is "
       << last_msg_->sol_in[52].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[53].flags, 72)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[53].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[53].flags)),
+      72)
       << "incorrect value for sol_in[53].flags, expected 72, is "
       << last_msg_->sol_in[53].flags;
-  EXPECT_EQ(last_msg_->sol_in[53].sensor_type, 251)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[53].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[53].sensor_type)),
+            251)
       << "incorrect value for sol_in[53].sensor_type, expected 251, is "
       << last_msg_->sol_in[53].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[54].flags, 80)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[54].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[54].flags)),
+      80)
       << "incorrect value for sol_in[54].flags, expected 80, is "
       << last_msg_->sol_in[54].flags;
-  EXPECT_EQ(last_msg_->sol_in[54].sensor_type, 248)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[54].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[54].sensor_type)),
+            248)
       << "incorrect value for sol_in[54].sensor_type, expected 248, is "
       << last_msg_->sol_in[54].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[55].flags, 244)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[55].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[55].flags)),
+      244)
       << "incorrect value for sol_in[55].flags, expected 244, is "
       << last_msg_->sol_in[55].flags;
-  EXPECT_EQ(last_msg_->sol_in[55].sensor_type, 115)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[55].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[55].sensor_type)),
+            115)
       << "incorrect value for sol_in[55].sensor_type, expected 115, is "
       << last_msg_->sol_in[55].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[56].flags, 145)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[56].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[56].flags)),
+      145)
       << "incorrect value for sol_in[56].flags, expected 145, is "
       << last_msg_->sol_in[56].flags;
-  EXPECT_EQ(last_msg_->sol_in[56].sensor_type, 231)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[56].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[56].sensor_type)),
+            231)
       << "incorrect value for sol_in[56].sensor_type, expected 231, is "
       << last_msg_->sol_in[56].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[57].flags, 190)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[57].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[57].flags)),
+      190)
       << "incorrect value for sol_in[57].flags, expected 190, is "
       << last_msg_->sol_in[57].flags;
-  EXPECT_EQ(last_msg_->sol_in[57].sensor_type, 191)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[57].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[57].sensor_type)),
+            191)
       << "incorrect value for sol_in[57].sensor_type, expected 191, is "
       << last_msg_->sol_in[57].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[58].flags, 168)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[58].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[58].flags)),
+      168)
       << "incorrect value for sol_in[58].flags, expected 168, is "
       << last_msg_->sol_in[58].flags;
-  EXPECT_EQ(last_msg_->sol_in[58].sensor_type, 178)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[58].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[58].sensor_type)),
+            178)
       << "incorrect value for sol_in[58].sensor_type, expected 178, is "
       << last_msg_->sol_in[58].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[59].flags, 233)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[59].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[59].flags)),
+      233)
       << "incorrect value for sol_in[59].flags, expected 233, is "
       << last_msg_->sol_in[59].flags;
-  EXPECT_EQ(last_msg_->sol_in[59].sensor_type, 89)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[59].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[59].sensor_type)),
+            89)
       << "incorrect value for sol_in[59].sensor_type, expected 89, is "
       << last_msg_->sol_in[59].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[60].flags, 176)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[60].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[60].flags)),
+      176)
       << "incorrect value for sol_in[60].flags, expected 176, is "
       << last_msg_->sol_in[60].flags;
-  EXPECT_EQ(last_msg_->sol_in[60].sensor_type, 69)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[60].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[60].sensor_type)),
+            69)
       << "incorrect value for sol_in[60].sensor_type, expected 69, is "
       << last_msg_->sol_in[60].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[61].flags, 140)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[61].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[61].flags)),
+      140)
       << "incorrect value for sol_in[61].flags, expected 140, is "
       << last_msg_->sol_in[61].flags;
-  EXPECT_EQ(last_msg_->sol_in[61].sensor_type, 174)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[61].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[61].sensor_type)),
+            174)
       << "incorrect value for sol_in[61].sensor_type, expected 174, is "
       << last_msg_->sol_in[61].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[62].flags, 141)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[62].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[62].flags)),
+      141)
       << "incorrect value for sol_in[62].flags, expected 141, is "
       << last_msg_->sol_in[62].flags;
-  EXPECT_EQ(last_msg_->sol_in[62].sensor_type, 182)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[62].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[62].sensor_type)),
+            182)
       << "incorrect value for sol_in[62].sensor_type, expected 182, is "
       << last_msg_->sol_in[62].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[63].flags, 82)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[63].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[63].flags)),
+      82)
       << "incorrect value for sol_in[63].flags, expected 82, is "
       << last_msg_->sol_in[63].flags;
-  EXPECT_EQ(last_msg_->sol_in[63].sensor_type, 81)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[63].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[63].sensor_type)),
+            81)
       << "incorrect value for sol_in[63].sensor_type, expected 81, is "
       << last_msg_->sol_in[63].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[64].flags, 79)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[64].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[64].flags)),
+      79)
       << "incorrect value for sol_in[64].flags, expected 79, is "
       << last_msg_->sol_in[64].flags;
-  EXPECT_EQ(last_msg_->sol_in[64].sensor_type, 92)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[64].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[64].sensor_type)),
+            92)
       << "incorrect value for sol_in[64].sensor_type, expected 92, is "
       << last_msg_->sol_in[64].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[65].flags, 223)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[65].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[65].flags)),
+      223)
       << "incorrect value for sol_in[65].flags, expected 223, is "
       << last_msg_->sol_in[65].flags;
-  EXPECT_EQ(last_msg_->sol_in[65].sensor_type, 101)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[65].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[65].sensor_type)),
+            101)
       << "incorrect value for sol_in[65].sensor_type, expected 101, is "
       << last_msg_->sol_in[65].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[66].flags, 64)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[66].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[66].flags)),
+      64)
       << "incorrect value for sol_in[66].flags, expected 64, is "
       << last_msg_->sol_in[66].flags;
-  EXPECT_EQ(last_msg_->sol_in[66].sensor_type, 100)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[66].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[66].sensor_type)),
+            100)
       << "incorrect value for sol_in[66].sensor_type, expected 100, is "
       << last_msg_->sol_in[66].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[67].flags, 215)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[67].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[67].flags)),
+      215)
       << "incorrect value for sol_in[67].flags, expected 215, is "
       << last_msg_->sol_in[67].flags;
-  EXPECT_EQ(last_msg_->sol_in[67].sensor_type, 184)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[67].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[67].sensor_type)),
+            184)
       << "incorrect value for sol_in[67].sensor_type, expected 184, is "
       << last_msg_->sol_in[67].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[68].flags, 37)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[68].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[68].flags)),
+      37)
       << "incorrect value for sol_in[68].flags, expected 37, is "
       << last_msg_->sol_in[68].flags;
-  EXPECT_EQ(last_msg_->sol_in[68].sensor_type, 124)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[68].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[68].sensor_type)),
+            124)
       << "incorrect value for sol_in[68].sensor_type, expected 124, is "
       << last_msg_->sol_in[68].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[69].flags, 227)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[69].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[69].flags)),
+      227)
       << "incorrect value for sol_in[69].flags, expected 227, is "
       << last_msg_->sol_in[69].flags;
-  EXPECT_EQ(last_msg_->sol_in[69].sensor_type, 21)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[69].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[69].sensor_type)),
+            21)
       << "incorrect value for sol_in[69].sensor_type, expected 21, is "
       << last_msg_->sol_in[69].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[70].flags, 102)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[70].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[70].flags)),
+      102)
       << "incorrect value for sol_in[70].flags, expected 102, is "
       << last_msg_->sol_in[70].flags;
-  EXPECT_EQ(last_msg_->sol_in[70].sensor_type, 135)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[70].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[70].sensor_type)),
+            135)
       << "incorrect value for sol_in[70].sensor_type, expected 135, is "
       << last_msg_->sol_in[70].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[71].flags, 36)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[71].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[71].flags)),
+      36)
       << "incorrect value for sol_in[71].flags, expected 36, is "
       << last_msg_->sol_in[71].flags;
-  EXPECT_EQ(last_msg_->sol_in[71].sensor_type, 72)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[71].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[71].sensor_type)),
+            72)
       << "incorrect value for sol_in[71].sensor_type, expected 72, is "
       << last_msg_->sol_in[71].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[72].flags, 56)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[72].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[72].flags)),
+      56)
       << "incorrect value for sol_in[72].flags, expected 56, is "
       << last_msg_->sol_in[72].flags;
-  EXPECT_EQ(last_msg_->sol_in[72].sensor_type, 219)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[72].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[72].sensor_type)),
+            219)
       << "incorrect value for sol_in[72].sensor_type, expected 219, is "
       << last_msg_->sol_in[72].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[73].flags, 90)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[73].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[73].flags)),
+      90)
       << "incorrect value for sol_in[73].flags, expected 90, is "
       << last_msg_->sol_in[73].flags;
-  EXPECT_EQ(last_msg_->sol_in[73].sensor_type, 146)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[73].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[73].sensor_type)),
+            146)
       << "incorrect value for sol_in[73].sensor_type, expected 146, is "
       << last_msg_->sol_in[73].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[74].flags, 104)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[74].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[74].flags)),
+      104)
       << "incorrect value for sol_in[74].flags, expected 104, is "
       << last_msg_->sol_in[74].flags;
-  EXPECT_EQ(last_msg_->sol_in[74].sensor_type, 219)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[74].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[74].sensor_type)),
+            219)
       << "incorrect value for sol_in[74].sensor_type, expected 219, is "
       << last_msg_->sol_in[74].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[75].flags, 102)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[75].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[75].flags)),
+      102)
       << "incorrect value for sol_in[75].flags, expected 102, is "
       << last_msg_->sol_in[75].flags;
-  EXPECT_EQ(last_msg_->sol_in[75].sensor_type, 227)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[75].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[75].sensor_type)),
+            227)
       << "incorrect value for sol_in[75].sensor_type, expected 227, is "
       << last_msg_->sol_in[75].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[76].flags, 12)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[76].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[76].flags)),
+      12)
       << "incorrect value for sol_in[76].flags, expected 12, is "
       << last_msg_->sol_in[76].flags;
-  EXPECT_EQ(last_msg_->sol_in[76].sensor_type, 83)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[76].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[76].sensor_type)),
+            83)
       << "incorrect value for sol_in[76].sensor_type, expected 83, is "
       << last_msg_->sol_in[76].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[77].flags, 122)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[77].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[77].flags)),
+      122)
       << "incorrect value for sol_in[77].flags, expected 122, is "
       << last_msg_->sol_in[77].flags;
-  EXPECT_EQ(last_msg_->sol_in[77].sensor_type, 41)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[77].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[77].sensor_type)),
+            41)
       << "incorrect value for sol_in[77].sensor_type, expected 41, is "
       << last_msg_->sol_in[77].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[78].flags, 94)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[78].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[78].flags)),
+      94)
       << "incorrect value for sol_in[78].flags, expected 94, is "
       << last_msg_->sol_in[78].flags;
-  EXPECT_EQ(last_msg_->sol_in[78].sensor_type, 173)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[78].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[78].sensor_type)),
+            173)
       << "incorrect value for sol_in[78].sensor_type, expected 173, is "
       << last_msg_->sol_in[78].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[79].flags, 174)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[79].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[79].flags)),
+      174)
       << "incorrect value for sol_in[79].flags, expected 174, is "
       << last_msg_->sol_in[79].flags;
-  EXPECT_EQ(last_msg_->sol_in[79].sensor_type, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[79].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[79].sensor_type)),
+            1)
       << "incorrect value for sol_in[79].sensor_type, expected 1, is "
       << last_msg_->sol_in[79].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[80].flags, 130)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[80].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[80].flags)),
+      130)
       << "incorrect value for sol_in[80].flags, expected 130, is "
       << last_msg_->sol_in[80].flags;
-  EXPECT_EQ(last_msg_->sol_in[80].sensor_type, 134)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[80].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[80].sensor_type)),
+            134)
       << "incorrect value for sol_in[80].sensor_type, expected 134, is "
       << last_msg_->sol_in[80].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[81].flags, 237)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[81].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[81].flags)),
+      237)
       << "incorrect value for sol_in[81].flags, expected 237, is "
       << last_msg_->sol_in[81].flags;
-  EXPECT_EQ(last_msg_->sol_in[81].sensor_type, 104)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[81].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[81].sensor_type)),
+            104)
       << "incorrect value for sol_in[81].sensor_type, expected 104, is "
       << last_msg_->sol_in[81].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[82].flags, 249)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[82].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[82].flags)),
+      249)
       << "incorrect value for sol_in[82].flags, expected 249, is "
       << last_msg_->sol_in[82].flags;
-  EXPECT_EQ(last_msg_->sol_in[82].sensor_type, 116)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[82].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[82].sensor_type)),
+            116)
       << "incorrect value for sol_in[82].sensor_type, expected 116, is "
       << last_msg_->sol_in[82].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[83].flags, 230)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[83].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[83].flags)),
+      230)
       << "incorrect value for sol_in[83].flags, expected 230, is "
       << last_msg_->sol_in[83].flags;
-  EXPECT_EQ(last_msg_->sol_in[83].sensor_type, 107)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[83].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[83].sensor_type)),
+            107)
       << "incorrect value for sol_in[83].sensor_type, expected 107, is "
       << last_msg_->sol_in[83].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[84].flags, 123)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[84].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[84].flags)),
+      123)
       << "incorrect value for sol_in[84].flags, expected 123, is "
       << last_msg_->sol_in[84].flags;
-  EXPECT_EQ(last_msg_->sol_in[84].sensor_type, 130)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[84].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[84].sensor_type)),
+            130)
       << "incorrect value for sol_in[84].sensor_type, expected 130, is "
       << last_msg_->sol_in[84].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[85].flags, 162)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[85].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[85].flags)),
+      162)
       << "incorrect value for sol_in[85].flags, expected 162, is "
       << last_msg_->sol_in[85].flags;
-  EXPECT_EQ(last_msg_->sol_in[85].sensor_type, 25)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[85].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[85].sensor_type)),
+            25)
       << "incorrect value for sol_in[85].sensor_type, expected 25, is "
       << last_msg_->sol_in[85].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[86].flags, 223)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[86].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[86].flags)),
+      223)
       << "incorrect value for sol_in[86].flags, expected 223, is "
       << last_msg_->sol_in[86].flags;
-  EXPECT_EQ(last_msg_->sol_in[86].sensor_type, 57)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[86].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[86].sensor_type)),
+            57)
       << "incorrect value for sol_in[86].sensor_type, expected 57, is "
       << last_msg_->sol_in[86].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[87].flags, 174)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[87].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[87].flags)),
+      174)
       << "incorrect value for sol_in[87].flags, expected 174, is "
       << last_msg_->sol_in[87].flags;
-  EXPECT_EQ(last_msg_->sol_in[87].sensor_type, 193)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[87].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[87].sensor_type)),
+            193)
       << "incorrect value for sol_in[87].sensor_type, expected 193, is "
       << last_msg_->sol_in[87].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[88].flags, 193)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[88].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[88].flags)),
+      193)
       << "incorrect value for sol_in[88].flags, expected 193, is "
       << last_msg_->sol_in[88].flags;
-  EXPECT_EQ(last_msg_->sol_in[88].sensor_type, 146)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[88].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[88].sensor_type)),
+            146)
       << "incorrect value for sol_in[88].sensor_type, expected 146, is "
       << last_msg_->sol_in[88].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[89].flags, 44)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[89].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[89].flags)),
+      44)
       << "incorrect value for sol_in[89].flags, expected 44, is "
       << last_msg_->sol_in[89].flags;
-  EXPECT_EQ(last_msg_->sol_in[89].sensor_type, 239)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[89].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[89].sensor_type)),
+            239)
       << "incorrect value for sol_in[89].sensor_type, expected 239, is "
       << last_msg_->sol_in[89].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[90].flags, 197)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[90].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[90].flags)),
+      197)
       << "incorrect value for sol_in[90].flags, expected 197, is "
       << last_msg_->sol_in[90].flags;
-  EXPECT_EQ(last_msg_->sol_in[90].sensor_type, 246)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[90].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[90].sensor_type)),
+            246)
       << "incorrect value for sol_in[90].sensor_type, expected 246, is "
       << last_msg_->sol_in[90].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[91].flags, 80)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[91].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[91].flags)),
+      80)
       << "incorrect value for sol_in[91].flags, expected 80, is "
       << last_msg_->sol_in[91].flags;
-  EXPECT_EQ(last_msg_->sol_in[91].sensor_type, 214)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[91].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[91].sensor_type)),
+            214)
       << "incorrect value for sol_in[91].sensor_type, expected 214, is "
       << last_msg_->sol_in[91].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[92].flags, 100)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[92].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[92].flags)),
+      100)
       << "incorrect value for sol_in[92].flags, expected 100, is "
       << last_msg_->sol_in[92].flags;
-  EXPECT_EQ(last_msg_->sol_in[92].sensor_type, 83)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[92].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[92].sensor_type)),
+            83)
       << "incorrect value for sol_in[92].sensor_type, expected 83, is "
       << last_msg_->sol_in[92].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[93].flags, 72)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[93].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[93].flags)),
+      72)
       << "incorrect value for sol_in[93].flags, expected 72, is "
       << last_msg_->sol_in[93].flags;
-  EXPECT_EQ(last_msg_->sol_in[93].sensor_type, 66)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[93].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[93].sensor_type)),
+            66)
       << "incorrect value for sol_in[93].sensor_type, expected 66, is "
       << last_msg_->sol_in[93].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[94].flags, 137)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[94].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[94].flags)),
+      137)
       << "incorrect value for sol_in[94].flags, expected 137, is "
       << last_msg_->sol_in[94].flags;
-  EXPECT_EQ(last_msg_->sol_in[94].sensor_type, 133)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[94].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[94].sensor_type)),
+            133)
       << "incorrect value for sol_in[94].sensor_type, expected 133, is "
       << last_msg_->sol_in[94].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[95].flags, 82)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[95].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[95].flags)),
+      82)
       << "incorrect value for sol_in[95].flags, expected 82, is "
       << last_msg_->sol_in[95].flags;
-  EXPECT_EQ(last_msg_->sol_in[95].sensor_type, 140)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[95].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[95].sensor_type)),
+            140)
       << "incorrect value for sol_in[95].sensor_type, expected 140, is "
       << last_msg_->sol_in[95].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[96].flags, 2)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[96].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[96].flags)),
+      2)
       << "incorrect value for sol_in[96].flags, expected 2, is "
       << last_msg_->sol_in[96].flags;
-  EXPECT_EQ(last_msg_->sol_in[96].sensor_type, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[96].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[96].sensor_type)),
+            2)
       << "incorrect value for sol_in[96].sensor_type, expected 2, is "
       << last_msg_->sol_in[96].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[97].flags, 9)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[97].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[97].flags)),
+      9)
       << "incorrect value for sol_in[97].flags, expected 9, is "
       << last_msg_->sol_in[97].flags;
-  EXPECT_EQ(last_msg_->sol_in[97].sensor_type, 96)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[97].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[97].sensor_type)),
+            96)
       << "incorrect value for sol_in[97].sensor_type, expected 96, is "
       << last_msg_->sol_in[97].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[98].flags, 158)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[98].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[98].flags)),
+      158)
       << "incorrect value for sol_in[98].flags, expected 158, is "
       << last_msg_->sol_in[98].flags;
-  EXPECT_EQ(last_msg_->sol_in[98].sensor_type, 96)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[98].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[98].sensor_type)),
+            96)
       << "incorrect value for sol_in[98].sensor_type, expected 96, is "
       << last_msg_->sol_in[98].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[99].flags, 97)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[99].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[99].flags)),
+      97)
       << "incorrect value for sol_in[99].flags, expected 97, is "
       << last_msg_->sol_in[99].flags;
-  EXPECT_EQ(last_msg_->sol_in[99].sensor_type, 134)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[99].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[99].sensor_type)),
+            134)
       << "incorrect value for sol_in[99].sensor_type, expected 134, is "
       << last_msg_->sol_in[99].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[100].flags, 129)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[100].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[100].flags)),
+      129)
       << "incorrect value for sol_in[100].flags, expected 129, is "
       << last_msg_->sol_in[100].flags;
-  EXPECT_EQ(last_msg_->sol_in[100].sensor_type, 43)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[100].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[100].sensor_type)),
+            43)
       << "incorrect value for sol_in[100].sensor_type, expected 43, is "
       << last_msg_->sol_in[100].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[101].flags, 25)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[101].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[101].flags)),
+      25)
       << "incorrect value for sol_in[101].flags, expected 25, is "
       << last_msg_->sol_in[101].flags;
-  EXPECT_EQ(last_msg_->sol_in[101].sensor_type, 141)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[101].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[101].sensor_type)),
+            141)
       << "incorrect value for sol_in[101].sensor_type, expected 141, is "
       << last_msg_->sol_in[101].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[102].flags, 200)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[102].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[102].flags)),
+      200)
       << "incorrect value for sol_in[102].flags, expected 200, is "
       << last_msg_->sol_in[102].flags;
-  EXPECT_EQ(last_msg_->sol_in[102].sensor_type, 183)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[102].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[102].sensor_type)),
+            183)
       << "incorrect value for sol_in[102].sensor_type, expected 183, is "
       << last_msg_->sol_in[102].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[103].flags, 57)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[103].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[103].flags)),
+      57)
       << "incorrect value for sol_in[103].flags, expected 57, is "
       << last_msg_->sol_in[103].flags;
-  EXPECT_EQ(last_msg_->sol_in[103].sensor_type, 214)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[103].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[103].sensor_type)),
+            214)
       << "incorrect value for sol_in[103].sensor_type, expected 214, is "
       << last_msg_->sol_in[103].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[104].flags, 103)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[104].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[104].flags)),
+      103)
       << "incorrect value for sol_in[104].flags, expected 103, is "
       << last_msg_->sol_in[104].flags;
-  EXPECT_EQ(last_msg_->sol_in[104].sensor_type, 248)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[104].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[104].sensor_type)),
+            248)
       << "incorrect value for sol_in[104].sensor_type, expected 248, is "
       << last_msg_->sol_in[104].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[105].flags, 65)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[105].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[105].flags)),
+      65)
       << "incorrect value for sol_in[105].flags, expected 65, is "
       << last_msg_->sol_in[105].flags;
-  EXPECT_EQ(last_msg_->sol_in[105].sensor_type, 222)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[105].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[105].sensor_type)),
+            222)
       << "incorrect value for sol_in[105].sensor_type, expected 222, is "
       << last_msg_->sol_in[105].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[106].flags, 15)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[106].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[106].flags)),
+      15)
       << "incorrect value for sol_in[106].flags, expected 15, is "
       << last_msg_->sol_in[106].flags;
-  EXPECT_EQ(last_msg_->sol_in[106].sensor_type, 195)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[106].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[106].sensor_type)),
+            195)
       << "incorrect value for sol_in[106].sensor_type, expected 195, is "
       << last_msg_->sol_in[106].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[107].flags, 21)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[107].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[107].flags)),
+      21)
       << "incorrect value for sol_in[107].flags, expected 21, is "
       << last_msg_->sol_in[107].flags;
-  EXPECT_EQ(last_msg_->sol_in[107].sensor_type, 244)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[107].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[107].sensor_type)),
+            244)
       << "incorrect value for sol_in[107].sensor_type, expected 244, is "
       << last_msg_->sol_in[107].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[108].flags, 46)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[108].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[108].flags)),
+      46)
       << "incorrect value for sol_in[108].flags, expected 46, is "
       << last_msg_->sol_in[108].flags;
-  EXPECT_EQ(last_msg_->sol_in[108].sensor_type, 180)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[108].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[108].sensor_type)),
+            180)
       << "incorrect value for sol_in[108].sensor_type, expected 180, is "
       << last_msg_->sol_in[108].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[109].flags, 130)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[109].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[109].flags)),
+      130)
       << "incorrect value for sol_in[109].flags, expected 130, is "
       << last_msg_->sol_in[109].flags;
-  EXPECT_EQ(last_msg_->sol_in[109].sensor_type, 140)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[109].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[109].sensor_type)),
+            140)
       << "incorrect value for sol_in[109].sensor_type, expected 140, is "
       << last_msg_->sol_in[109].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[110].flags, 17)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[110].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[110].flags)),
+      17)
       << "incorrect value for sol_in[110].flags, expected 17, is "
       << last_msg_->sol_in[110].flags;
-  EXPECT_EQ(last_msg_->sol_in[110].sensor_type, 36)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[110].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[110].sensor_type)),
+            36)
       << "incorrect value for sol_in[110].sensor_type, expected 36, is "
       << last_msg_->sol_in[110].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[111].flags, 209)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[111].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[111].flags)),
+      209)
       << "incorrect value for sol_in[111].flags, expected 209, is "
       << last_msg_->sol_in[111].flags;
-  EXPECT_EQ(last_msg_->sol_in[111].sensor_type, 194)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[111].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[111].sensor_type)),
+            194)
       << "incorrect value for sol_in[111].sensor_type, expected 194, is "
       << last_msg_->sol_in[111].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[112].flags, 254)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[112].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[112].flags)),
+      254)
       << "incorrect value for sol_in[112].flags, expected 254, is "
       << last_msg_->sol_in[112].flags;
-  EXPECT_EQ(last_msg_->sol_in[112].sensor_type, 65)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[112].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[112].sensor_type)),
+            65)
       << "incorrect value for sol_in[112].sensor_type, expected 65, is "
       << last_msg_->sol_in[112].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[113].flags, 103)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[113].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[113].flags)),
+      103)
       << "incorrect value for sol_in[113].flags, expected 103, is "
       << last_msg_->sol_in[113].flags;
-  EXPECT_EQ(last_msg_->sol_in[113].sensor_type, 115)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[113].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[113].sensor_type)),
+            115)
       << "incorrect value for sol_in[113].sensor_type, expected 115, is "
       << last_msg_->sol_in[113].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[114].flags, 129)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[114].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[114].flags)),
+      129)
       << "incorrect value for sol_in[114].flags, expected 129, is "
       << last_msg_->sol_in[114].flags;
-  EXPECT_EQ(last_msg_->sol_in[114].sensor_type, 152)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[114].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[114].sensor_type)),
+            152)
       << "incorrect value for sol_in[114].sensor_type, expected 152, is "
       << last_msg_->sol_in[114].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[115].flags, 235)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[115].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[115].flags)),
+      235)
       << "incorrect value for sol_in[115].flags, expected 235, is "
       << last_msg_->sol_in[115].flags;
-  EXPECT_EQ(last_msg_->sol_in[115].sensor_type, 234)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[115].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[115].sensor_type)),
+            234)
       << "incorrect value for sol_in[115].sensor_type, expected 234, is "
       << last_msg_->sol_in[115].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[116].flags, 234)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[116].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[116].flags)),
+      234)
       << "incorrect value for sol_in[116].flags, expected 234, is "
       << last_msg_->sol_in[116].flags;
-  EXPECT_EQ(last_msg_->sol_in[116].sensor_type, 194)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[116].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[116].sensor_type)),
+            194)
       << "incorrect value for sol_in[116].sensor_type, expected 194, is "
       << last_msg_->sol_in[116].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[117].flags, 201)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[117].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[117].flags)),
+      201)
       << "incorrect value for sol_in[117].flags, expected 201, is "
       << last_msg_->sol_in[117].flags;
-  EXPECT_EQ(last_msg_->sol_in[117].sensor_type, 170)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[117].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[117].sensor_type)),
+            170)
       << "incorrect value for sol_in[117].sensor_type, expected 170, is "
       << last_msg_->sol_in[117].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[118].flags, 154)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[118].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[118].flags)),
+      154)
       << "incorrect value for sol_in[118].flags, expected 154, is "
       << last_msg_->sol_in[118].flags;
-  EXPECT_EQ(last_msg_->sol_in[118].sensor_type, 210)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[118].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[118].sensor_type)),
+            210)
       << "incorrect value for sol_in[118].sensor_type, expected 210, is "
       << last_msg_->sol_in[118].sensor_type;
-  EXPECT_EQ(last_msg_->tow, 3628191792)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            3628191792)
       << "incorrect value for tow, expected 3628191792, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->vdop, 58512)
+  EXPECT_EQ(get_as<decltype(last_msg_->vdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->vdop)),
+            58512)
       << "incorrect value for vdop, expected 58512, is " << last_msg_->vdop;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_solution_meta_MsgSolnMetaDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_solution_meta_MsgSolnMetaDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/solution_meta.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_solution_meta_MsgSolnMetaDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -843,732 +850,1449 @@ TEST_F(Test_legacy_auto_check_sbp_solution_meta_MsgSolnMetaDepA0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 61780);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->age_corrections, 48671)
+  EXPECT_EQ(get_as<decltype(last_msg_->age_corrections)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->age_corrections)),
+            48671)
       << "incorrect value for age_corrections, expected 48671, is "
       << last_msg_->age_corrections;
-  EXPECT_EQ(last_msg_->alignment_status, 115)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->alignment_status)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->alignment_status)),
+      115)
       << "incorrect value for alignment_status, expected 115, is "
       << last_msg_->alignment_status;
-  EXPECT_EQ(last_msg_->hdop, 31133)
+  EXPECT_EQ(get_as<decltype(last_msg_->hdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->hdop)),
+            31133)
       << "incorrect value for hdop, expected 31133, is " << last_msg_->hdop;
-  EXPECT_EQ(last_msg_->last_used_gnss_pos_tow, 610745181)
+  EXPECT_EQ(get_as<decltype(last_msg_->last_used_gnss_pos_tow)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->last_used_gnss_pos_tow)),
+            610745181)
       << "incorrect value for last_used_gnss_pos_tow, expected 610745181, is "
       << last_msg_->last_used_gnss_pos_tow;
-  EXPECT_EQ(last_msg_->last_used_gnss_vel_tow, 782016851)
+  EXPECT_EQ(get_as<decltype(last_msg_->last_used_gnss_vel_tow)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->last_used_gnss_vel_tow)),
+            782016851)
       << "incorrect value for last_used_gnss_vel_tow, expected 782016851, is "
       << last_msg_->last_used_gnss_vel_tow;
-  EXPECT_EQ(last_msg_->n_sats, 238)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            238)
       << "incorrect value for n_sats, expected 238, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->pdop, 57015)
+  EXPECT_EQ(get_as<decltype(last_msg_->pdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pdop)),
+            57015)
       << "incorrect value for pdop, expected 57015, is " << last_msg_->pdop;
-  EXPECT_EQ(last_msg_->sol_in[0].flags, 67)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[0].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[0].flags)),
+            67)
       << "incorrect value for sol_in[0].flags, expected 67, is "
       << last_msg_->sol_in[0].flags;
-  EXPECT_EQ(last_msg_->sol_in[0].sensor_type, 253)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[0].sensor_type)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[0].sensor_type)),
+      253)
       << "incorrect value for sol_in[0].sensor_type, expected 253, is "
       << last_msg_->sol_in[0].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[1].flags, 200)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[1].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[1].flags)),
+            200)
       << "incorrect value for sol_in[1].flags, expected 200, is "
       << last_msg_->sol_in[1].flags;
-  EXPECT_EQ(last_msg_->sol_in[1].sensor_type, 87)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[1].sensor_type)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[1].sensor_type)),
+      87)
       << "incorrect value for sol_in[1].sensor_type, expected 87, is "
       << last_msg_->sol_in[1].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[2].flags, 250)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[2].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[2].flags)),
+            250)
       << "incorrect value for sol_in[2].flags, expected 250, is "
       << last_msg_->sol_in[2].flags;
-  EXPECT_EQ(last_msg_->sol_in[2].sensor_type, 39)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[2].sensor_type)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[2].sensor_type)),
+      39)
       << "incorrect value for sol_in[2].sensor_type, expected 39, is "
       << last_msg_->sol_in[2].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[3].flags, 242)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[3].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[3].flags)),
+            242)
       << "incorrect value for sol_in[3].flags, expected 242, is "
       << last_msg_->sol_in[3].flags;
-  EXPECT_EQ(last_msg_->sol_in[3].sensor_type, 245)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[3].sensor_type)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[3].sensor_type)),
+      245)
       << "incorrect value for sol_in[3].sensor_type, expected 245, is "
       << last_msg_->sol_in[3].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[4].flags, 72)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[4].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[4].flags)),
+            72)
       << "incorrect value for sol_in[4].flags, expected 72, is "
       << last_msg_->sol_in[4].flags;
-  EXPECT_EQ(last_msg_->sol_in[4].sensor_type, 228)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[4].sensor_type)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[4].sensor_type)),
+      228)
       << "incorrect value for sol_in[4].sensor_type, expected 228, is "
       << last_msg_->sol_in[4].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[5].flags, 222)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[5].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[5].flags)),
+            222)
       << "incorrect value for sol_in[5].flags, expected 222, is "
       << last_msg_->sol_in[5].flags;
-  EXPECT_EQ(last_msg_->sol_in[5].sensor_type, 18)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[5].sensor_type)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[5].sensor_type)),
+      18)
       << "incorrect value for sol_in[5].sensor_type, expected 18, is "
       << last_msg_->sol_in[5].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[6].flags, 88)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[6].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[6].flags)),
+            88)
       << "incorrect value for sol_in[6].flags, expected 88, is "
       << last_msg_->sol_in[6].flags;
-  EXPECT_EQ(last_msg_->sol_in[6].sensor_type, 11)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[6].sensor_type)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[6].sensor_type)),
+      11)
       << "incorrect value for sol_in[6].sensor_type, expected 11, is "
       << last_msg_->sol_in[6].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[7].flags, 218)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[7].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[7].flags)),
+            218)
       << "incorrect value for sol_in[7].flags, expected 218, is "
       << last_msg_->sol_in[7].flags;
-  EXPECT_EQ(last_msg_->sol_in[7].sensor_type, 207)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[7].sensor_type)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[7].sensor_type)),
+      207)
       << "incorrect value for sol_in[7].sensor_type, expected 207, is "
       << last_msg_->sol_in[7].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[8].flags, 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[8].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[8].flags)),
+            13)
       << "incorrect value for sol_in[8].flags, expected 13, is "
       << last_msg_->sol_in[8].flags;
-  EXPECT_EQ(last_msg_->sol_in[8].sensor_type, 231)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[8].sensor_type)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[8].sensor_type)),
+      231)
       << "incorrect value for sol_in[8].sensor_type, expected 231, is "
       << last_msg_->sol_in[8].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[9].flags, 224)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[9].flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[9].flags)),
+            224)
       << "incorrect value for sol_in[9].flags, expected 224, is "
       << last_msg_->sol_in[9].flags;
-  EXPECT_EQ(last_msg_->sol_in[9].sensor_type, 226)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[9].sensor_type)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[9].sensor_type)),
+      226)
       << "incorrect value for sol_in[9].sensor_type, expected 226, is "
       << last_msg_->sol_in[9].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[10].flags, 196)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[10].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[10].flags)),
+      196)
       << "incorrect value for sol_in[10].flags, expected 196, is "
       << last_msg_->sol_in[10].flags;
-  EXPECT_EQ(last_msg_->sol_in[10].sensor_type, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[10].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[10].sensor_type)),
+            22)
       << "incorrect value for sol_in[10].sensor_type, expected 22, is "
       << last_msg_->sol_in[10].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[11].flags, 242)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[11].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[11].flags)),
+      242)
       << "incorrect value for sol_in[11].flags, expected 242, is "
       << last_msg_->sol_in[11].flags;
-  EXPECT_EQ(last_msg_->sol_in[11].sensor_type, 21)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[11].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[11].sensor_type)),
+            21)
       << "incorrect value for sol_in[11].sensor_type, expected 21, is "
       << last_msg_->sol_in[11].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[12].flags, 89)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[12].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[12].flags)),
+      89)
       << "incorrect value for sol_in[12].flags, expected 89, is "
       << last_msg_->sol_in[12].flags;
-  EXPECT_EQ(last_msg_->sol_in[12].sensor_type, 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[12].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[12].sensor_type)),
+            12)
       << "incorrect value for sol_in[12].sensor_type, expected 12, is "
       << last_msg_->sol_in[12].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[13].flags, 219)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[13].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[13].flags)),
+      219)
       << "incorrect value for sol_in[13].flags, expected 219, is "
       << last_msg_->sol_in[13].flags;
-  EXPECT_EQ(last_msg_->sol_in[13].sensor_type, 71)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[13].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[13].sensor_type)),
+            71)
       << "incorrect value for sol_in[13].sensor_type, expected 71, is "
       << last_msg_->sol_in[13].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[14].flags, 85)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[14].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[14].flags)),
+      85)
       << "incorrect value for sol_in[14].flags, expected 85, is "
       << last_msg_->sol_in[14].flags;
-  EXPECT_EQ(last_msg_->sol_in[14].sensor_type, 182)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[14].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[14].sensor_type)),
+            182)
       << "incorrect value for sol_in[14].sensor_type, expected 182, is "
       << last_msg_->sol_in[14].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[15].flags, 204)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[15].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[15].flags)),
+      204)
       << "incorrect value for sol_in[15].flags, expected 204, is "
       << last_msg_->sol_in[15].flags;
-  EXPECT_EQ(last_msg_->sol_in[15].sensor_type, 145)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[15].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[15].sensor_type)),
+            145)
       << "incorrect value for sol_in[15].sensor_type, expected 145, is "
       << last_msg_->sol_in[15].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[16].flags, 40)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[16].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[16].flags)),
+      40)
       << "incorrect value for sol_in[16].flags, expected 40, is "
       << last_msg_->sol_in[16].flags;
-  EXPECT_EQ(last_msg_->sol_in[16].sensor_type, 146)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[16].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[16].sensor_type)),
+            146)
       << "incorrect value for sol_in[16].sensor_type, expected 146, is "
       << last_msg_->sol_in[16].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[17].flags, 51)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[17].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[17].flags)),
+      51)
       << "incorrect value for sol_in[17].flags, expected 51, is "
       << last_msg_->sol_in[17].flags;
-  EXPECT_EQ(last_msg_->sol_in[17].sensor_type, 204)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[17].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[17].sensor_type)),
+            204)
       << "incorrect value for sol_in[17].sensor_type, expected 204, is "
       << last_msg_->sol_in[17].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[18].flags, 153)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[18].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[18].flags)),
+      153)
       << "incorrect value for sol_in[18].flags, expected 153, is "
       << last_msg_->sol_in[18].flags;
-  EXPECT_EQ(last_msg_->sol_in[18].sensor_type, 21)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[18].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[18].sensor_type)),
+            21)
       << "incorrect value for sol_in[18].sensor_type, expected 21, is "
       << last_msg_->sol_in[18].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[19].flags, 44)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[19].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[19].flags)),
+      44)
       << "incorrect value for sol_in[19].flags, expected 44, is "
       << last_msg_->sol_in[19].flags;
-  EXPECT_EQ(last_msg_->sol_in[19].sensor_type, 227)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[19].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[19].sensor_type)),
+            227)
       << "incorrect value for sol_in[19].sensor_type, expected 227, is "
       << last_msg_->sol_in[19].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[20].flags, 28)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[20].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[20].flags)),
+      28)
       << "incorrect value for sol_in[20].flags, expected 28, is "
       << last_msg_->sol_in[20].flags;
-  EXPECT_EQ(last_msg_->sol_in[20].sensor_type, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[20].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[20].sensor_type)),
+            15)
       << "incorrect value for sol_in[20].sensor_type, expected 15, is "
       << last_msg_->sol_in[20].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[21].flags, 39)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[21].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[21].flags)),
+      39)
       << "incorrect value for sol_in[21].flags, expected 39, is "
       << last_msg_->sol_in[21].flags;
-  EXPECT_EQ(last_msg_->sol_in[21].sensor_type, 255)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[21].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[21].sensor_type)),
+            255)
       << "incorrect value for sol_in[21].sensor_type, expected 255, is "
       << last_msg_->sol_in[21].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[22].flags, 216)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[22].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[22].flags)),
+      216)
       << "incorrect value for sol_in[22].flags, expected 216, is "
       << last_msg_->sol_in[22].flags;
-  EXPECT_EQ(last_msg_->sol_in[22].sensor_type, 205)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[22].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[22].sensor_type)),
+            205)
       << "incorrect value for sol_in[22].sensor_type, expected 205, is "
       << last_msg_->sol_in[22].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[23].flags, 190)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[23].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[23].flags)),
+      190)
       << "incorrect value for sol_in[23].flags, expected 190, is "
       << last_msg_->sol_in[23].flags;
-  EXPECT_EQ(last_msg_->sol_in[23].sensor_type, 240)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[23].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[23].sensor_type)),
+            240)
       << "incorrect value for sol_in[23].sensor_type, expected 240, is "
       << last_msg_->sol_in[23].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[24].flags, 219)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[24].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[24].flags)),
+      219)
       << "incorrect value for sol_in[24].flags, expected 219, is "
       << last_msg_->sol_in[24].flags;
-  EXPECT_EQ(last_msg_->sol_in[24].sensor_type, 93)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[24].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[24].sensor_type)),
+            93)
       << "incorrect value for sol_in[24].sensor_type, expected 93, is "
       << last_msg_->sol_in[24].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[25].flags, 42)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[25].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[25].flags)),
+      42)
       << "incorrect value for sol_in[25].flags, expected 42, is "
       << last_msg_->sol_in[25].flags;
-  EXPECT_EQ(last_msg_->sol_in[25].sensor_type, 103)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[25].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[25].sensor_type)),
+            103)
       << "incorrect value for sol_in[25].sensor_type, expected 103, is "
       << last_msg_->sol_in[25].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[26].flags, 182)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[26].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[26].flags)),
+      182)
       << "incorrect value for sol_in[26].flags, expected 182, is "
       << last_msg_->sol_in[26].flags;
-  EXPECT_EQ(last_msg_->sol_in[26].sensor_type, 41)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[26].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[26].sensor_type)),
+            41)
       << "incorrect value for sol_in[26].sensor_type, expected 41, is "
       << last_msg_->sol_in[26].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[27].flags, 222)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[27].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[27].flags)),
+      222)
       << "incorrect value for sol_in[27].flags, expected 222, is "
       << last_msg_->sol_in[27].flags;
-  EXPECT_EQ(last_msg_->sol_in[27].sensor_type, 76)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[27].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[27].sensor_type)),
+            76)
       << "incorrect value for sol_in[27].sensor_type, expected 76, is "
       << last_msg_->sol_in[27].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[28].flags, 23)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[28].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[28].flags)),
+      23)
       << "incorrect value for sol_in[28].flags, expected 23, is "
       << last_msg_->sol_in[28].flags;
-  EXPECT_EQ(last_msg_->sol_in[28].sensor_type, 17)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[28].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[28].sensor_type)),
+            17)
       << "incorrect value for sol_in[28].sensor_type, expected 17, is "
       << last_msg_->sol_in[28].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[29].flags, 31)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[29].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[29].flags)),
+      31)
       << "incorrect value for sol_in[29].flags, expected 31, is "
       << last_msg_->sol_in[29].flags;
-  EXPECT_EQ(last_msg_->sol_in[29].sensor_type, 125)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[29].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[29].sensor_type)),
+            125)
       << "incorrect value for sol_in[29].sensor_type, expected 125, is "
       << last_msg_->sol_in[29].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[30].flags, 229)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[30].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[30].flags)),
+      229)
       << "incorrect value for sol_in[30].flags, expected 229, is "
       << last_msg_->sol_in[30].flags;
-  EXPECT_EQ(last_msg_->sol_in[30].sensor_type, 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[30].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[30].sensor_type)),
+            18)
       << "incorrect value for sol_in[30].sensor_type, expected 18, is "
       << last_msg_->sol_in[30].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[31].flags, 47)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[31].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[31].flags)),
+      47)
       << "incorrect value for sol_in[31].flags, expected 47, is "
       << last_msg_->sol_in[31].flags;
-  EXPECT_EQ(last_msg_->sol_in[31].sensor_type, 28)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[31].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[31].sensor_type)),
+            28)
       << "incorrect value for sol_in[31].sensor_type, expected 28, is "
       << last_msg_->sol_in[31].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[32].flags, 25)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[32].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[32].flags)),
+      25)
       << "incorrect value for sol_in[32].flags, expected 25, is "
       << last_msg_->sol_in[32].flags;
-  EXPECT_EQ(last_msg_->sol_in[32].sensor_type, 214)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[32].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[32].sensor_type)),
+            214)
       << "incorrect value for sol_in[32].sensor_type, expected 214, is "
       << last_msg_->sol_in[32].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[33].flags, 84)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[33].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[33].flags)),
+      84)
       << "incorrect value for sol_in[33].flags, expected 84, is "
       << last_msg_->sol_in[33].flags;
-  EXPECT_EQ(last_msg_->sol_in[33].sensor_type, 100)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[33].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[33].sensor_type)),
+            100)
       << "incorrect value for sol_in[33].sensor_type, expected 100, is "
       << last_msg_->sol_in[33].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[34].flags, 72)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[34].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[34].flags)),
+      72)
       << "incorrect value for sol_in[34].flags, expected 72, is "
       << last_msg_->sol_in[34].flags;
-  EXPECT_EQ(last_msg_->sol_in[34].sensor_type, 106)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[34].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[34].sensor_type)),
+            106)
       << "incorrect value for sol_in[34].sensor_type, expected 106, is "
       << last_msg_->sol_in[34].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[35].flags, 10)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[35].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[35].flags)),
+      10)
       << "incorrect value for sol_in[35].flags, expected 10, is "
       << last_msg_->sol_in[35].flags;
-  EXPECT_EQ(last_msg_->sol_in[35].sensor_type, 48)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[35].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[35].sensor_type)),
+            48)
       << "incorrect value for sol_in[35].sensor_type, expected 48, is "
       << last_msg_->sol_in[35].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[36].flags, 232)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[36].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[36].flags)),
+      232)
       << "incorrect value for sol_in[36].flags, expected 232, is "
       << last_msg_->sol_in[36].flags;
-  EXPECT_EQ(last_msg_->sol_in[36].sensor_type, 222)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[36].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[36].sensor_type)),
+            222)
       << "incorrect value for sol_in[36].sensor_type, expected 222, is "
       << last_msg_->sol_in[36].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[37].flags, 73)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[37].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[37].flags)),
+      73)
       << "incorrect value for sol_in[37].flags, expected 73, is "
       << last_msg_->sol_in[37].flags;
-  EXPECT_EQ(last_msg_->sol_in[37].sensor_type, 235)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[37].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[37].sensor_type)),
+            235)
       << "incorrect value for sol_in[37].sensor_type, expected 235, is "
       << last_msg_->sol_in[37].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[38].flags, 163)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[38].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[38].flags)),
+      163)
       << "incorrect value for sol_in[38].flags, expected 163, is "
       << last_msg_->sol_in[38].flags;
-  EXPECT_EQ(last_msg_->sol_in[38].sensor_type, 109)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[38].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[38].sensor_type)),
+            109)
       << "incorrect value for sol_in[38].sensor_type, expected 109, is "
       << last_msg_->sol_in[38].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[39].flags, 152)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[39].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[39].flags)),
+      152)
       << "incorrect value for sol_in[39].flags, expected 152, is "
       << last_msg_->sol_in[39].flags;
-  EXPECT_EQ(last_msg_->sol_in[39].sensor_type, 51)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[39].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[39].sensor_type)),
+            51)
       << "incorrect value for sol_in[39].sensor_type, expected 51, is "
       << last_msg_->sol_in[39].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[40].flags, 235)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[40].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[40].flags)),
+      235)
       << "incorrect value for sol_in[40].flags, expected 235, is "
       << last_msg_->sol_in[40].flags;
-  EXPECT_EQ(last_msg_->sol_in[40].sensor_type, 133)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[40].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[40].sensor_type)),
+            133)
       << "incorrect value for sol_in[40].sensor_type, expected 133, is "
       << last_msg_->sol_in[40].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[41].flags, 70)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[41].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[41].flags)),
+      70)
       << "incorrect value for sol_in[41].flags, expected 70, is "
       << last_msg_->sol_in[41].flags;
-  EXPECT_EQ(last_msg_->sol_in[41].sensor_type, 87)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[41].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[41].sensor_type)),
+            87)
       << "incorrect value for sol_in[41].sensor_type, expected 87, is "
       << last_msg_->sol_in[41].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[42].flags, 108)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[42].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[42].flags)),
+      108)
       << "incorrect value for sol_in[42].flags, expected 108, is "
       << last_msg_->sol_in[42].flags;
-  EXPECT_EQ(last_msg_->sol_in[42].sensor_type, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[42].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[42].sensor_type)),
+            2)
       << "incorrect value for sol_in[42].sensor_type, expected 2, is "
       << last_msg_->sol_in[42].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[43].flags, 101)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[43].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[43].flags)),
+      101)
       << "incorrect value for sol_in[43].flags, expected 101, is "
       << last_msg_->sol_in[43].flags;
-  EXPECT_EQ(last_msg_->sol_in[43].sensor_type, 91)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[43].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[43].sensor_type)),
+            91)
       << "incorrect value for sol_in[43].sensor_type, expected 91, is "
       << last_msg_->sol_in[43].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[44].flags, 55)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[44].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[44].flags)),
+      55)
       << "incorrect value for sol_in[44].flags, expected 55, is "
       << last_msg_->sol_in[44].flags;
-  EXPECT_EQ(last_msg_->sol_in[44].sensor_type, 200)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[44].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[44].sensor_type)),
+            200)
       << "incorrect value for sol_in[44].sensor_type, expected 200, is "
       << last_msg_->sol_in[44].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[45].flags, 156)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[45].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[45].flags)),
+      156)
       << "incorrect value for sol_in[45].flags, expected 156, is "
       << last_msg_->sol_in[45].flags;
-  EXPECT_EQ(last_msg_->sol_in[45].sensor_type, 24)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[45].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[45].sensor_type)),
+            24)
       << "incorrect value for sol_in[45].sensor_type, expected 24, is "
       << last_msg_->sol_in[45].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[46].flags, 73)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[46].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[46].flags)),
+      73)
       << "incorrect value for sol_in[46].flags, expected 73, is "
       << last_msg_->sol_in[46].flags;
-  EXPECT_EQ(last_msg_->sol_in[46].sensor_type, 233)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[46].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[46].sensor_type)),
+            233)
       << "incorrect value for sol_in[46].sensor_type, expected 233, is "
       << last_msg_->sol_in[46].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[47].flags, 66)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[47].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[47].flags)),
+      66)
       << "incorrect value for sol_in[47].flags, expected 66, is "
       << last_msg_->sol_in[47].flags;
-  EXPECT_EQ(last_msg_->sol_in[47].sensor_type, 39)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[47].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[47].sensor_type)),
+            39)
       << "incorrect value for sol_in[47].sensor_type, expected 39, is "
       << last_msg_->sol_in[47].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[48].flags, 140)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[48].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[48].flags)),
+      140)
       << "incorrect value for sol_in[48].flags, expected 140, is "
       << last_msg_->sol_in[48].flags;
-  EXPECT_EQ(last_msg_->sol_in[48].sensor_type, 97)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[48].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[48].sensor_type)),
+            97)
       << "incorrect value for sol_in[48].sensor_type, expected 97, is "
       << last_msg_->sol_in[48].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[49].flags, 227)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[49].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[49].flags)),
+      227)
       << "incorrect value for sol_in[49].flags, expected 227, is "
       << last_msg_->sol_in[49].flags;
-  EXPECT_EQ(last_msg_->sol_in[49].sensor_type, 252)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[49].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[49].sensor_type)),
+            252)
       << "incorrect value for sol_in[49].sensor_type, expected 252, is "
       << last_msg_->sol_in[49].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[50].flags, 237)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[50].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[50].flags)),
+      237)
       << "incorrect value for sol_in[50].flags, expected 237, is "
       << last_msg_->sol_in[50].flags;
-  EXPECT_EQ(last_msg_->sol_in[50].sensor_type, 230)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[50].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[50].sensor_type)),
+            230)
       << "incorrect value for sol_in[50].sensor_type, expected 230, is "
       << last_msg_->sol_in[50].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[51].flags, 241)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[51].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[51].flags)),
+      241)
       << "incorrect value for sol_in[51].flags, expected 241, is "
       << last_msg_->sol_in[51].flags;
-  EXPECT_EQ(last_msg_->sol_in[51].sensor_type, 135)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[51].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[51].sensor_type)),
+            135)
       << "incorrect value for sol_in[51].sensor_type, expected 135, is "
       << last_msg_->sol_in[51].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[52].flags, 205)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[52].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[52].flags)),
+      205)
       << "incorrect value for sol_in[52].flags, expected 205, is "
       << last_msg_->sol_in[52].flags;
-  EXPECT_EQ(last_msg_->sol_in[52].sensor_type, 245)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[52].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[52].sensor_type)),
+            245)
       << "incorrect value for sol_in[52].sensor_type, expected 245, is "
       << last_msg_->sol_in[52].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[53].flags, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[53].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[53].flags)),
+      0)
       << "incorrect value for sol_in[53].flags, expected 0, is "
       << last_msg_->sol_in[53].flags;
-  EXPECT_EQ(last_msg_->sol_in[53].sensor_type, 70)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[53].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[53].sensor_type)),
+            70)
       << "incorrect value for sol_in[53].sensor_type, expected 70, is "
       << last_msg_->sol_in[53].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[54].flags, 188)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[54].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[54].flags)),
+      188)
       << "incorrect value for sol_in[54].flags, expected 188, is "
       << last_msg_->sol_in[54].flags;
-  EXPECT_EQ(last_msg_->sol_in[54].sensor_type, 219)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[54].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[54].sensor_type)),
+            219)
       << "incorrect value for sol_in[54].sensor_type, expected 219, is "
       << last_msg_->sol_in[54].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[55].flags, 136)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[55].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[55].flags)),
+      136)
       << "incorrect value for sol_in[55].flags, expected 136, is "
       << last_msg_->sol_in[55].flags;
-  EXPECT_EQ(last_msg_->sol_in[55].sensor_type, 107)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[55].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[55].sensor_type)),
+            107)
       << "incorrect value for sol_in[55].sensor_type, expected 107, is "
       << last_msg_->sol_in[55].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[56].flags, 58)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[56].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[56].flags)),
+      58)
       << "incorrect value for sol_in[56].flags, expected 58, is "
       << last_msg_->sol_in[56].flags;
-  EXPECT_EQ(last_msg_->sol_in[56].sensor_type, 178)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[56].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[56].sensor_type)),
+            178)
       << "incorrect value for sol_in[56].sensor_type, expected 178, is "
       << last_msg_->sol_in[56].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[57].flags, 29)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[57].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[57].flags)),
+      29)
       << "incorrect value for sol_in[57].flags, expected 29, is "
       << last_msg_->sol_in[57].flags;
-  EXPECT_EQ(last_msg_->sol_in[57].sensor_type, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[57].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[57].sensor_type)),
+            1)
       << "incorrect value for sol_in[57].sensor_type, expected 1, is "
       << last_msg_->sol_in[57].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[58].flags, 213)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[58].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[58].flags)),
+      213)
       << "incorrect value for sol_in[58].flags, expected 213, is "
       << last_msg_->sol_in[58].flags;
-  EXPECT_EQ(last_msg_->sol_in[58].sensor_type, 44)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[58].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[58].sensor_type)),
+            44)
       << "incorrect value for sol_in[58].sensor_type, expected 44, is "
       << last_msg_->sol_in[58].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[59].flags, 147)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[59].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[59].flags)),
+      147)
       << "incorrect value for sol_in[59].flags, expected 147, is "
       << last_msg_->sol_in[59].flags;
-  EXPECT_EQ(last_msg_->sol_in[59].sensor_type, 225)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[59].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[59].sensor_type)),
+            225)
       << "incorrect value for sol_in[59].sensor_type, expected 225, is "
       << last_msg_->sol_in[59].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[60].flags, 96)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[60].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[60].flags)),
+      96)
       << "incorrect value for sol_in[60].flags, expected 96, is "
       << last_msg_->sol_in[60].flags;
-  EXPECT_EQ(last_msg_->sol_in[60].sensor_type, 190)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[60].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[60].sensor_type)),
+            190)
       << "incorrect value for sol_in[60].sensor_type, expected 190, is "
       << last_msg_->sol_in[60].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[61].flags, 108)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[61].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[61].flags)),
+      108)
       << "incorrect value for sol_in[61].flags, expected 108, is "
       << last_msg_->sol_in[61].flags;
-  EXPECT_EQ(last_msg_->sol_in[61].sensor_type, 192)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[61].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[61].sensor_type)),
+            192)
       << "incorrect value for sol_in[61].sensor_type, expected 192, is "
       << last_msg_->sol_in[61].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[62].flags, 15)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[62].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[62].flags)),
+      15)
       << "incorrect value for sol_in[62].flags, expected 15, is "
       << last_msg_->sol_in[62].flags;
-  EXPECT_EQ(last_msg_->sol_in[62].sensor_type, 228)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[62].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[62].sensor_type)),
+            228)
       << "incorrect value for sol_in[62].sensor_type, expected 228, is "
       << last_msg_->sol_in[62].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[63].flags, 18)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[63].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[63].flags)),
+      18)
       << "incorrect value for sol_in[63].flags, expected 18, is "
       << last_msg_->sol_in[63].flags;
-  EXPECT_EQ(last_msg_->sol_in[63].sensor_type, 203)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[63].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[63].sensor_type)),
+            203)
       << "incorrect value for sol_in[63].sensor_type, expected 203, is "
       << last_msg_->sol_in[63].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[64].flags, 222)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[64].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[64].flags)),
+      222)
       << "incorrect value for sol_in[64].flags, expected 222, is "
       << last_msg_->sol_in[64].flags;
-  EXPECT_EQ(last_msg_->sol_in[64].sensor_type, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[64].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[64].sensor_type)),
+            3)
       << "incorrect value for sol_in[64].sensor_type, expected 3, is "
       << last_msg_->sol_in[64].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[65].flags, 68)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[65].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[65].flags)),
+      68)
       << "incorrect value for sol_in[65].flags, expected 68, is "
       << last_msg_->sol_in[65].flags;
-  EXPECT_EQ(last_msg_->sol_in[65].sensor_type, 180)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[65].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[65].sensor_type)),
+            180)
       << "incorrect value for sol_in[65].sensor_type, expected 180, is "
       << last_msg_->sol_in[65].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[66].flags, 229)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[66].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[66].flags)),
+      229)
       << "incorrect value for sol_in[66].flags, expected 229, is "
       << last_msg_->sol_in[66].flags;
-  EXPECT_EQ(last_msg_->sol_in[66].sensor_type, 101)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[66].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[66].sensor_type)),
+            101)
       << "incorrect value for sol_in[66].sensor_type, expected 101, is "
       << last_msg_->sol_in[66].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[67].flags, 203)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[67].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[67].flags)),
+      203)
       << "incorrect value for sol_in[67].flags, expected 203, is "
       << last_msg_->sol_in[67].flags;
-  EXPECT_EQ(last_msg_->sol_in[67].sensor_type, 223)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[67].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[67].sensor_type)),
+            223)
       << "incorrect value for sol_in[67].sensor_type, expected 223, is "
       << last_msg_->sol_in[67].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[68].flags, 164)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[68].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[68].flags)),
+      164)
       << "incorrect value for sol_in[68].flags, expected 164, is "
       << last_msg_->sol_in[68].flags;
-  EXPECT_EQ(last_msg_->sol_in[68].sensor_type, 243)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[68].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[68].sensor_type)),
+            243)
       << "incorrect value for sol_in[68].sensor_type, expected 243, is "
       << last_msg_->sol_in[68].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[69].flags, 165)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[69].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[69].flags)),
+      165)
       << "incorrect value for sol_in[69].flags, expected 165, is "
       << last_msg_->sol_in[69].flags;
-  EXPECT_EQ(last_msg_->sol_in[69].sensor_type, 92)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[69].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[69].sensor_type)),
+            92)
       << "incorrect value for sol_in[69].sensor_type, expected 92, is "
       << last_msg_->sol_in[69].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[70].flags, 159)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[70].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[70].flags)),
+      159)
       << "incorrect value for sol_in[70].flags, expected 159, is "
       << last_msg_->sol_in[70].flags;
-  EXPECT_EQ(last_msg_->sol_in[70].sensor_type, 220)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[70].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[70].sensor_type)),
+            220)
       << "incorrect value for sol_in[70].sensor_type, expected 220, is "
       << last_msg_->sol_in[70].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[71].flags, 121)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[71].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[71].flags)),
+      121)
       << "incorrect value for sol_in[71].flags, expected 121, is "
       << last_msg_->sol_in[71].flags;
-  EXPECT_EQ(last_msg_->sol_in[71].sensor_type, 174)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[71].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[71].sensor_type)),
+            174)
       << "incorrect value for sol_in[71].sensor_type, expected 174, is "
       << last_msg_->sol_in[71].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[72].flags, 167)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[72].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[72].flags)),
+      167)
       << "incorrect value for sol_in[72].flags, expected 167, is "
       << last_msg_->sol_in[72].flags;
-  EXPECT_EQ(last_msg_->sol_in[72].sensor_type, 112)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[72].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[72].sensor_type)),
+            112)
       << "incorrect value for sol_in[72].sensor_type, expected 112, is "
       << last_msg_->sol_in[72].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[73].flags, 40)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[73].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[73].flags)),
+      40)
       << "incorrect value for sol_in[73].flags, expected 40, is "
       << last_msg_->sol_in[73].flags;
-  EXPECT_EQ(last_msg_->sol_in[73].sensor_type, 240)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[73].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[73].sensor_type)),
+            240)
       << "incorrect value for sol_in[73].sensor_type, expected 240, is "
       << last_msg_->sol_in[73].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[74].flags, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[74].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[74].flags)),
+      3)
       << "incorrect value for sol_in[74].flags, expected 3, is "
       << last_msg_->sol_in[74].flags;
-  EXPECT_EQ(last_msg_->sol_in[74].sensor_type, 59)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[74].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[74].sensor_type)),
+            59)
       << "incorrect value for sol_in[74].sensor_type, expected 59, is "
       << last_msg_->sol_in[74].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[75].flags, 52)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[75].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[75].flags)),
+      52)
       << "incorrect value for sol_in[75].flags, expected 52, is "
       << last_msg_->sol_in[75].flags;
-  EXPECT_EQ(last_msg_->sol_in[75].sensor_type, 230)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[75].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[75].sensor_type)),
+            230)
       << "incorrect value for sol_in[75].sensor_type, expected 230, is "
       << last_msg_->sol_in[75].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[76].flags, 148)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[76].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[76].flags)),
+      148)
       << "incorrect value for sol_in[76].flags, expected 148, is "
       << last_msg_->sol_in[76].flags;
-  EXPECT_EQ(last_msg_->sol_in[76].sensor_type, 149)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[76].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[76].sensor_type)),
+            149)
       << "incorrect value for sol_in[76].sensor_type, expected 149, is "
       << last_msg_->sol_in[76].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[77].flags, 142)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[77].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[77].flags)),
+      142)
       << "incorrect value for sol_in[77].flags, expected 142, is "
       << last_msg_->sol_in[77].flags;
-  EXPECT_EQ(last_msg_->sol_in[77].sensor_type, 218)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[77].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[77].sensor_type)),
+            218)
       << "incorrect value for sol_in[77].sensor_type, expected 218, is "
       << last_msg_->sol_in[77].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[78].flags, 109)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[78].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[78].flags)),
+      109)
       << "incorrect value for sol_in[78].flags, expected 109, is "
       << last_msg_->sol_in[78].flags;
-  EXPECT_EQ(last_msg_->sol_in[78].sensor_type, 212)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[78].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[78].sensor_type)),
+            212)
       << "incorrect value for sol_in[78].sensor_type, expected 212, is "
       << last_msg_->sol_in[78].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[79].flags, 71)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[79].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[79].flags)),
+      71)
       << "incorrect value for sol_in[79].flags, expected 71, is "
       << last_msg_->sol_in[79].flags;
-  EXPECT_EQ(last_msg_->sol_in[79].sensor_type, 176)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[79].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[79].sensor_type)),
+            176)
       << "incorrect value for sol_in[79].sensor_type, expected 176, is "
       << last_msg_->sol_in[79].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[80].flags, 172)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[80].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[80].flags)),
+      172)
       << "incorrect value for sol_in[80].flags, expected 172, is "
       << last_msg_->sol_in[80].flags;
-  EXPECT_EQ(last_msg_->sol_in[80].sensor_type, 179)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[80].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[80].sensor_type)),
+            179)
       << "incorrect value for sol_in[80].sensor_type, expected 179, is "
       << last_msg_->sol_in[80].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[81].flags, 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[81].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[81].flags)),
+      1)
       << "incorrect value for sol_in[81].flags, expected 1, is "
       << last_msg_->sol_in[81].flags;
-  EXPECT_EQ(last_msg_->sol_in[81].sensor_type, 77)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[81].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[81].sensor_type)),
+            77)
       << "incorrect value for sol_in[81].sensor_type, expected 77, is "
       << last_msg_->sol_in[81].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[82].flags, 70)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[82].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[82].flags)),
+      70)
       << "incorrect value for sol_in[82].flags, expected 70, is "
       << last_msg_->sol_in[82].flags;
-  EXPECT_EQ(last_msg_->sol_in[82].sensor_type, 193)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[82].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[82].sensor_type)),
+            193)
       << "incorrect value for sol_in[82].sensor_type, expected 193, is "
       << last_msg_->sol_in[82].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[83].flags, 149)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[83].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[83].flags)),
+      149)
       << "incorrect value for sol_in[83].flags, expected 149, is "
       << last_msg_->sol_in[83].flags;
-  EXPECT_EQ(last_msg_->sol_in[83].sensor_type, 147)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[83].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[83].sensor_type)),
+            147)
       << "incorrect value for sol_in[83].sensor_type, expected 147, is "
       << last_msg_->sol_in[83].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[84].flags, 144)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[84].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[84].flags)),
+      144)
       << "incorrect value for sol_in[84].flags, expected 144, is "
       << last_msg_->sol_in[84].flags;
-  EXPECT_EQ(last_msg_->sol_in[84].sensor_type, 23)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[84].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[84].sensor_type)),
+            23)
       << "incorrect value for sol_in[84].sensor_type, expected 23, is "
       << last_msg_->sol_in[84].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[85].flags, 239)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[85].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[85].flags)),
+      239)
       << "incorrect value for sol_in[85].flags, expected 239, is "
       << last_msg_->sol_in[85].flags;
-  EXPECT_EQ(last_msg_->sol_in[85].sensor_type, 148)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[85].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[85].sensor_type)),
+            148)
       << "incorrect value for sol_in[85].sensor_type, expected 148, is "
       << last_msg_->sol_in[85].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[86].flags, 186)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[86].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[86].flags)),
+      186)
       << "incorrect value for sol_in[86].flags, expected 186, is "
       << last_msg_->sol_in[86].flags;
-  EXPECT_EQ(last_msg_->sol_in[86].sensor_type, 195)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[86].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[86].sensor_type)),
+            195)
       << "incorrect value for sol_in[86].sensor_type, expected 195, is "
       << last_msg_->sol_in[86].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[87].flags, 30)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[87].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[87].flags)),
+      30)
       << "incorrect value for sol_in[87].flags, expected 30, is "
       << last_msg_->sol_in[87].flags;
-  EXPECT_EQ(last_msg_->sol_in[87].sensor_type, 86)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[87].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[87].sensor_type)),
+            86)
       << "incorrect value for sol_in[87].sensor_type, expected 86, is "
       << last_msg_->sol_in[87].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[88].flags, 143)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[88].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[88].flags)),
+      143)
       << "incorrect value for sol_in[88].flags, expected 143, is "
       << last_msg_->sol_in[88].flags;
-  EXPECT_EQ(last_msg_->sol_in[88].sensor_type, 34)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[88].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[88].sensor_type)),
+            34)
       << "incorrect value for sol_in[88].sensor_type, expected 34, is "
       << last_msg_->sol_in[88].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[89].flags, 207)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[89].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[89].flags)),
+      207)
       << "incorrect value for sol_in[89].flags, expected 207, is "
       << last_msg_->sol_in[89].flags;
-  EXPECT_EQ(last_msg_->sol_in[89].sensor_type, 156)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[89].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[89].sensor_type)),
+            156)
       << "incorrect value for sol_in[89].sensor_type, expected 156, is "
       << last_msg_->sol_in[89].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[90].flags, 55)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[90].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[90].flags)),
+      55)
       << "incorrect value for sol_in[90].flags, expected 55, is "
       << last_msg_->sol_in[90].flags;
-  EXPECT_EQ(last_msg_->sol_in[90].sensor_type, 63)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[90].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[90].sensor_type)),
+            63)
       << "incorrect value for sol_in[90].sensor_type, expected 63, is "
       << last_msg_->sol_in[90].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[91].flags, 255)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[91].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[91].flags)),
+      255)
       << "incorrect value for sol_in[91].flags, expected 255, is "
       << last_msg_->sol_in[91].flags;
-  EXPECT_EQ(last_msg_->sol_in[91].sensor_type, 117)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[91].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[91].sensor_type)),
+            117)
       << "incorrect value for sol_in[91].sensor_type, expected 117, is "
       << last_msg_->sol_in[91].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[92].flags, 222)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[92].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[92].flags)),
+      222)
       << "incorrect value for sol_in[92].flags, expected 222, is "
       << last_msg_->sol_in[92].flags;
-  EXPECT_EQ(last_msg_->sol_in[92].sensor_type, 222)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[92].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[92].sensor_type)),
+            222)
       << "incorrect value for sol_in[92].sensor_type, expected 222, is "
       << last_msg_->sol_in[92].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[93].flags, 145)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[93].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[93].flags)),
+      145)
       << "incorrect value for sol_in[93].flags, expected 145, is "
       << last_msg_->sol_in[93].flags;
-  EXPECT_EQ(last_msg_->sol_in[93].sensor_type, 219)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[93].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[93].sensor_type)),
+            219)
       << "incorrect value for sol_in[93].sensor_type, expected 219, is "
       << last_msg_->sol_in[93].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[94].flags, 191)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[94].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[94].flags)),
+      191)
       << "incorrect value for sol_in[94].flags, expected 191, is "
       << last_msg_->sol_in[94].flags;
-  EXPECT_EQ(last_msg_->sol_in[94].sensor_type, 224)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[94].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[94].sensor_type)),
+            224)
       << "incorrect value for sol_in[94].sensor_type, expected 224, is "
       << last_msg_->sol_in[94].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[95].flags, 109)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[95].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[95].flags)),
+      109)
       << "incorrect value for sol_in[95].flags, expected 109, is "
       << last_msg_->sol_in[95].flags;
-  EXPECT_EQ(last_msg_->sol_in[95].sensor_type, 210)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[95].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[95].sensor_type)),
+            210)
       << "incorrect value for sol_in[95].sensor_type, expected 210, is "
       << last_msg_->sol_in[95].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[96].flags, 153)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[96].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[96].flags)),
+      153)
       << "incorrect value for sol_in[96].flags, expected 153, is "
       << last_msg_->sol_in[96].flags;
-  EXPECT_EQ(last_msg_->sol_in[96].sensor_type, 86)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[96].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[96].sensor_type)),
+            86)
       << "incorrect value for sol_in[96].sensor_type, expected 86, is "
       << last_msg_->sol_in[96].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[97].flags, 32)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[97].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[97].flags)),
+      32)
       << "incorrect value for sol_in[97].flags, expected 32, is "
       << last_msg_->sol_in[97].flags;
-  EXPECT_EQ(last_msg_->sol_in[97].sensor_type, 21)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[97].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[97].sensor_type)),
+            21)
       << "incorrect value for sol_in[97].sensor_type, expected 21, is "
       << last_msg_->sol_in[97].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[98].flags, 10)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[98].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[98].flags)),
+      10)
       << "incorrect value for sol_in[98].flags, expected 10, is "
       << last_msg_->sol_in[98].flags;
-  EXPECT_EQ(last_msg_->sol_in[98].sensor_type, 226)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[98].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[98].sensor_type)),
+            226)
       << "incorrect value for sol_in[98].sensor_type, expected 226, is "
       << last_msg_->sol_in[98].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[99].flags, 63)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[99].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[99].flags)),
+      63)
       << "incorrect value for sol_in[99].flags, expected 63, is "
       << last_msg_->sol_in[99].flags;
-  EXPECT_EQ(last_msg_->sol_in[99].sensor_type, 60)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[99].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[99].sensor_type)),
+            60)
       << "incorrect value for sol_in[99].sensor_type, expected 60, is "
       << last_msg_->sol_in[99].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[100].flags, 236)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[100].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[100].flags)),
+      236)
       << "incorrect value for sol_in[100].flags, expected 236, is "
       << last_msg_->sol_in[100].flags;
-  EXPECT_EQ(last_msg_->sol_in[100].sensor_type, 106)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[100].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[100].sensor_type)),
+            106)
       << "incorrect value for sol_in[100].sensor_type, expected 106, is "
       << last_msg_->sol_in[100].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[101].flags, 96)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[101].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[101].flags)),
+      96)
       << "incorrect value for sol_in[101].flags, expected 96, is "
       << last_msg_->sol_in[101].flags;
-  EXPECT_EQ(last_msg_->sol_in[101].sensor_type, 93)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[101].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[101].sensor_type)),
+            93)
       << "incorrect value for sol_in[101].sensor_type, expected 93, is "
       << last_msg_->sol_in[101].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[102].flags, 163)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[102].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[102].flags)),
+      163)
       << "incorrect value for sol_in[102].flags, expected 163, is "
       << last_msg_->sol_in[102].flags;
-  EXPECT_EQ(last_msg_->sol_in[102].sensor_type, 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[102].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[102].sensor_type)),
+            30)
       << "incorrect value for sol_in[102].sensor_type, expected 30, is "
       << last_msg_->sol_in[102].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[103].flags, 238)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[103].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[103].flags)),
+      238)
       << "incorrect value for sol_in[103].flags, expected 238, is "
       << last_msg_->sol_in[103].flags;
-  EXPECT_EQ(last_msg_->sol_in[103].sensor_type, 106)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[103].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[103].sensor_type)),
+            106)
       << "incorrect value for sol_in[103].sensor_type, expected 106, is "
       << last_msg_->sol_in[103].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[104].flags, 133)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[104].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[104].flags)),
+      133)
       << "incorrect value for sol_in[104].flags, expected 133, is "
       << last_msg_->sol_in[104].flags;
-  EXPECT_EQ(last_msg_->sol_in[104].sensor_type, 147)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[104].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[104].sensor_type)),
+            147)
       << "incorrect value for sol_in[104].sensor_type, expected 147, is "
       << last_msg_->sol_in[104].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[105].flags, 107)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[105].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[105].flags)),
+      107)
       << "incorrect value for sol_in[105].flags, expected 107, is "
       << last_msg_->sol_in[105].flags;
-  EXPECT_EQ(last_msg_->sol_in[105].sensor_type, 132)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[105].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[105].sensor_type)),
+            132)
       << "incorrect value for sol_in[105].sensor_type, expected 132, is "
       << last_msg_->sol_in[105].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[106].flags, 214)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[106].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[106].flags)),
+      214)
       << "incorrect value for sol_in[106].flags, expected 214, is "
       << last_msg_->sol_in[106].flags;
-  EXPECT_EQ(last_msg_->sol_in[106].sensor_type, 152)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[106].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[106].sensor_type)),
+            152)
       << "incorrect value for sol_in[106].sensor_type, expected 152, is "
       << last_msg_->sol_in[106].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[107].flags, 185)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[107].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[107].flags)),
+      185)
       << "incorrect value for sol_in[107].flags, expected 185, is "
       << last_msg_->sol_in[107].flags;
-  EXPECT_EQ(last_msg_->sol_in[107].sensor_type, 221)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[107].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[107].sensor_type)),
+            221)
       << "incorrect value for sol_in[107].sensor_type, expected 221, is "
       << last_msg_->sol_in[107].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[108].flags, 21)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[108].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[108].flags)),
+      21)
       << "incorrect value for sol_in[108].flags, expected 21, is "
       << last_msg_->sol_in[108].flags;
-  EXPECT_EQ(last_msg_->sol_in[108].sensor_type, 202)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[108].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[108].sensor_type)),
+            202)
       << "incorrect value for sol_in[108].sensor_type, expected 202, is "
       << last_msg_->sol_in[108].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[109].flags, 51)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[109].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[109].flags)),
+      51)
       << "incorrect value for sol_in[109].flags, expected 51, is "
       << last_msg_->sol_in[109].flags;
-  EXPECT_EQ(last_msg_->sol_in[109].sensor_type, 252)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[109].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[109].sensor_type)),
+            252)
       << "incorrect value for sol_in[109].sensor_type, expected 252, is "
       << last_msg_->sol_in[109].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[110].flags, 59)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[110].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[110].flags)),
+      59)
       << "incorrect value for sol_in[110].flags, expected 59, is "
       << last_msg_->sol_in[110].flags;
-  EXPECT_EQ(last_msg_->sol_in[110].sensor_type, 130)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[110].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[110].sensor_type)),
+            130)
       << "incorrect value for sol_in[110].sensor_type, expected 130, is "
       << last_msg_->sol_in[110].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[111].flags, 202)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[111].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[111].flags)),
+      202)
       << "incorrect value for sol_in[111].flags, expected 202, is "
       << last_msg_->sol_in[111].flags;
-  EXPECT_EQ(last_msg_->sol_in[111].sensor_type, 166)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[111].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[111].sensor_type)),
+            166)
       << "incorrect value for sol_in[111].sensor_type, expected 166, is "
       << last_msg_->sol_in[111].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[112].flags, 170)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[112].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[112].flags)),
+      170)
       << "incorrect value for sol_in[112].flags, expected 170, is "
       << last_msg_->sol_in[112].flags;
-  EXPECT_EQ(last_msg_->sol_in[112].sensor_type, 127)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[112].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[112].sensor_type)),
+            127)
       << "incorrect value for sol_in[112].sensor_type, expected 127, is "
       << last_msg_->sol_in[112].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[113].flags, 193)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[113].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[113].flags)),
+      193)
       << "incorrect value for sol_in[113].flags, expected 193, is "
       << last_msg_->sol_in[113].flags;
-  EXPECT_EQ(last_msg_->sol_in[113].sensor_type, 58)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[113].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[113].sensor_type)),
+            58)
       << "incorrect value for sol_in[113].sensor_type, expected 58, is "
       << last_msg_->sol_in[113].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[114].flags, 125)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[114].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[114].flags)),
+      125)
       << "incorrect value for sol_in[114].flags, expected 125, is "
       << last_msg_->sol_in[114].flags;
-  EXPECT_EQ(last_msg_->sol_in[114].sensor_type, 215)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[114].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[114].sensor_type)),
+            215)
       << "incorrect value for sol_in[114].sensor_type, expected 215, is "
       << last_msg_->sol_in[114].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[115].flags, 58)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[115].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[115].flags)),
+      58)
       << "incorrect value for sol_in[115].flags, expected 58, is "
       << last_msg_->sol_in[115].flags;
-  EXPECT_EQ(last_msg_->sol_in[115].sensor_type, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[115].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[115].sensor_type)),
+            22)
       << "incorrect value for sol_in[115].sensor_type, expected 22, is "
       << last_msg_->sol_in[115].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[116].flags, 47)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[116].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[116].flags)),
+      47)
       << "incorrect value for sol_in[116].flags, expected 47, is "
       << last_msg_->sol_in[116].flags;
-  EXPECT_EQ(last_msg_->sol_in[116].sensor_type, 135)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[116].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[116].sensor_type)),
+            135)
       << "incorrect value for sol_in[116].sensor_type, expected 135, is "
       << last_msg_->sol_in[116].sensor_type;
-  EXPECT_EQ(last_msg_->sol_in[117].flags, 142)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sol_in[117].flags)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sol_in[117].flags)),
+      142)
       << "incorrect value for sol_in[117].flags, expected 142, is "
       << last_msg_->sol_in[117].flags;
-  EXPECT_EQ(last_msg_->sol_in[117].sensor_type, 88)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_in[117].sensor_type)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sol_in[117].sensor_type)),
+            88)
       << "incorrect value for sol_in[117].sensor_type, expected 88, is "
       << last_msg_->sol_in[117].sensor_type;
-  EXPECT_EQ(last_msg_->vdop, 41989)
+  EXPECT_EQ(get_as<decltype(last_msg_->vdop)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->vdop)),
+            41989)
       << "incorrect value for vdop, expected 41989, is " << last_msg_->vdop;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrCodeBiases.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrCodeBiases.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/ssr.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_ssr_MsgSsrCodeBiases0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -618,506 +625,913 @@ TEST_F(Test_legacy_auto_check_sbp_ssr_MsgSsrCodeBiases0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 22311);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->biases[0].code, 51)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[0].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[0].code)),
+            51)
       << "incorrect value for biases[0].code, expected 51, is "
       << last_msg_->biases[0].code;
-  EXPECT_EQ(last_msg_->biases[0].value, -31996)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[0].value)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[0].value)),
+            -31996)
       << "incorrect value for biases[0].value, expected -31996, is "
       << last_msg_->biases[0].value;
-  EXPECT_EQ(last_msg_->biases[1].code, 240)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[1].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[1].code)),
+            240)
       << "incorrect value for biases[1].code, expected 240, is "
       << last_msg_->biases[1].code;
-  EXPECT_EQ(last_msg_->biases[1].value, 21368)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[1].value)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[1].value)),
+            21368)
       << "incorrect value for biases[1].value, expected 21368, is "
       << last_msg_->biases[1].value;
-  EXPECT_EQ(last_msg_->biases[2].code, 148)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[2].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[2].code)),
+            148)
       << "incorrect value for biases[2].code, expected 148, is "
       << last_msg_->biases[2].code;
-  EXPECT_EQ(last_msg_->biases[2].value, -10799)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[2].value)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[2].value)),
+            -10799)
       << "incorrect value for biases[2].value, expected -10799, is "
       << last_msg_->biases[2].value;
-  EXPECT_EQ(last_msg_->biases[3].code, 62)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[3].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[3].code)),
+            62)
       << "incorrect value for biases[3].code, expected 62, is "
       << last_msg_->biases[3].code;
-  EXPECT_EQ(last_msg_->biases[3].value, -5916)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[3].value)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[3].value)),
+            -5916)
       << "incorrect value for biases[3].value, expected -5916, is "
       << last_msg_->biases[3].value;
-  EXPECT_EQ(last_msg_->biases[4].code, 71)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[4].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[4].code)),
+            71)
       << "incorrect value for biases[4].code, expected 71, is "
       << last_msg_->biases[4].code;
-  EXPECT_EQ(last_msg_->biases[4].value, -17342)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[4].value)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[4].value)),
+            -17342)
       << "incorrect value for biases[4].value, expected -17342, is "
       << last_msg_->biases[4].value;
-  EXPECT_EQ(last_msg_->biases[5].code, 210)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[5].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[5].code)),
+            210)
       << "incorrect value for biases[5].code, expected 210, is "
       << last_msg_->biases[5].code;
-  EXPECT_EQ(last_msg_->biases[5].value, 13952)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[5].value)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[5].value)),
+            13952)
       << "incorrect value for biases[5].value, expected 13952, is "
       << last_msg_->biases[5].value;
-  EXPECT_EQ(last_msg_->biases[6].code, 131)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[6].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[6].code)),
+            131)
       << "incorrect value for biases[6].code, expected 131, is "
       << last_msg_->biases[6].code;
-  EXPECT_EQ(last_msg_->biases[6].value, -32360)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[6].value)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[6].value)),
+            -32360)
       << "incorrect value for biases[6].value, expected -32360, is "
       << last_msg_->biases[6].value;
-  EXPECT_EQ(last_msg_->biases[7].code, 111)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[7].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[7].code)),
+            111)
       << "incorrect value for biases[7].code, expected 111, is "
       << last_msg_->biases[7].code;
-  EXPECT_EQ(last_msg_->biases[7].value, -3445)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[7].value)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[7].value)),
+            -3445)
       << "incorrect value for biases[7].value, expected -3445, is "
       << last_msg_->biases[7].value;
-  EXPECT_EQ(last_msg_->biases[8].code, 177)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[8].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[8].code)),
+            177)
       << "incorrect value for biases[8].code, expected 177, is "
       << last_msg_->biases[8].code;
-  EXPECT_EQ(last_msg_->biases[8].value, 11409)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[8].value)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[8].value)),
+            11409)
       << "incorrect value for biases[8].value, expected 11409, is "
       << last_msg_->biases[8].value;
-  EXPECT_EQ(last_msg_->biases[9].code, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[9].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[9].code)),
+            9)
       << "incorrect value for biases[9].code, expected 9, is "
       << last_msg_->biases[9].code;
-  EXPECT_EQ(last_msg_->biases[9].value, -12299)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[9].value)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[9].value)),
+            -12299)
       << "incorrect value for biases[9].value, expected -12299, is "
       << last_msg_->biases[9].value;
-  EXPECT_EQ(last_msg_->biases[10].code, 241)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[10].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[10].code)),
+            241)
       << "incorrect value for biases[10].code, expected 241, is "
       << last_msg_->biases[10].code;
-  EXPECT_EQ(last_msg_->biases[10].value, -26934)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[10].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[10].value)),
+      -26934)
       << "incorrect value for biases[10].value, expected -26934, is "
       << last_msg_->biases[10].value;
-  EXPECT_EQ(last_msg_->biases[11].code, 141)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[11].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[11].code)),
+            141)
       << "incorrect value for biases[11].code, expected 141, is "
       << last_msg_->biases[11].code;
-  EXPECT_EQ(last_msg_->biases[11].value, -24782)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[11].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[11].value)),
+      -24782)
       << "incorrect value for biases[11].value, expected -24782, is "
       << last_msg_->biases[11].value;
-  EXPECT_EQ(last_msg_->biases[12].code, 220)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[12].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[12].code)),
+            220)
       << "incorrect value for biases[12].code, expected 220, is "
       << last_msg_->biases[12].code;
-  EXPECT_EQ(last_msg_->biases[12].value, 9611)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[12].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[12].value)),
+      9611)
       << "incorrect value for biases[12].value, expected 9611, is "
       << last_msg_->biases[12].value;
-  EXPECT_EQ(last_msg_->biases[13].code, 187)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[13].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[13].code)),
+            187)
       << "incorrect value for biases[13].code, expected 187, is "
       << last_msg_->biases[13].code;
-  EXPECT_EQ(last_msg_->biases[13].value, -16542)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[13].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[13].value)),
+      -16542)
       << "incorrect value for biases[13].value, expected -16542, is "
       << last_msg_->biases[13].value;
-  EXPECT_EQ(last_msg_->biases[14].code, 23)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[14].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[14].code)),
+            23)
       << "incorrect value for biases[14].code, expected 23, is "
       << last_msg_->biases[14].code;
-  EXPECT_EQ(last_msg_->biases[14].value, -30592)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[14].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[14].value)),
+      -30592)
       << "incorrect value for biases[14].value, expected -30592, is "
       << last_msg_->biases[14].value;
-  EXPECT_EQ(last_msg_->biases[15].code, 167)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[15].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[15].code)),
+            167)
       << "incorrect value for biases[15].code, expected 167, is "
       << last_msg_->biases[15].code;
-  EXPECT_EQ(last_msg_->biases[15].value, 1736)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[15].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[15].value)),
+      1736)
       << "incorrect value for biases[15].value, expected 1736, is "
       << last_msg_->biases[15].value;
-  EXPECT_EQ(last_msg_->biases[16].code, 211)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[16].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[16].code)),
+            211)
       << "incorrect value for biases[16].code, expected 211, is "
       << last_msg_->biases[16].code;
-  EXPECT_EQ(last_msg_->biases[16].value, 5978)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[16].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[16].value)),
+      5978)
       << "incorrect value for biases[16].value, expected 5978, is "
       << last_msg_->biases[16].value;
-  EXPECT_EQ(last_msg_->biases[17].code, 244)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[17].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[17].code)),
+            244)
       << "incorrect value for biases[17].code, expected 244, is "
       << last_msg_->biases[17].code;
-  EXPECT_EQ(last_msg_->biases[17].value, -10358)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[17].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[17].value)),
+      -10358)
       << "incorrect value for biases[17].value, expected -10358, is "
       << last_msg_->biases[17].value;
-  EXPECT_EQ(last_msg_->biases[18].code, 209)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[18].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[18].code)),
+            209)
       << "incorrect value for biases[18].code, expected 209, is "
       << last_msg_->biases[18].code;
-  EXPECT_EQ(last_msg_->biases[18].value, 3467)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[18].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[18].value)),
+      3467)
       << "incorrect value for biases[18].value, expected 3467, is "
       << last_msg_->biases[18].value;
-  EXPECT_EQ(last_msg_->biases[19].code, 101)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[19].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[19].code)),
+            101)
       << "incorrect value for biases[19].code, expected 101, is "
       << last_msg_->biases[19].code;
-  EXPECT_EQ(last_msg_->biases[19].value, 1824)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[19].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[19].value)),
+      1824)
       << "incorrect value for biases[19].value, expected 1824, is "
       << last_msg_->biases[19].value;
-  EXPECT_EQ(last_msg_->biases[20].code, 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[20].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[20].code)),
+            18)
       << "incorrect value for biases[20].code, expected 18, is "
       << last_msg_->biases[20].code;
-  EXPECT_EQ(last_msg_->biases[20].value, 17949)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[20].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[20].value)),
+      17949)
       << "incorrect value for biases[20].value, expected 17949, is "
       << last_msg_->biases[20].value;
-  EXPECT_EQ(last_msg_->biases[21].code, 250)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[21].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[21].code)),
+            250)
       << "incorrect value for biases[21].code, expected 250, is "
       << last_msg_->biases[21].code;
-  EXPECT_EQ(last_msg_->biases[21].value, 18797)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[21].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[21].value)),
+      18797)
       << "incorrect value for biases[21].value, expected 18797, is "
       << last_msg_->biases[21].value;
-  EXPECT_EQ(last_msg_->biases[22].code, 202)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[22].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[22].code)),
+            202)
       << "incorrect value for biases[22].code, expected 202, is "
       << last_msg_->biases[22].code;
-  EXPECT_EQ(last_msg_->biases[22].value, -28593)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[22].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[22].value)),
+      -28593)
       << "incorrect value for biases[22].value, expected -28593, is "
       << last_msg_->biases[22].value;
-  EXPECT_EQ(last_msg_->biases[23].code, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[23].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[23].code)),
+            9)
       << "incorrect value for biases[23].code, expected 9, is "
       << last_msg_->biases[23].code;
-  EXPECT_EQ(last_msg_->biases[23].value, 17810)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[23].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[23].value)),
+      17810)
       << "incorrect value for biases[23].value, expected 17810, is "
       << last_msg_->biases[23].value;
-  EXPECT_EQ(last_msg_->biases[24].code, 241)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[24].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[24].code)),
+            241)
       << "incorrect value for biases[24].code, expected 241, is "
       << last_msg_->biases[24].code;
-  EXPECT_EQ(last_msg_->biases[24].value, 5684)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[24].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[24].value)),
+      5684)
       << "incorrect value for biases[24].value, expected 5684, is "
       << last_msg_->biases[24].value;
-  EXPECT_EQ(last_msg_->biases[25].code, 99)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[25].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[25].code)),
+            99)
       << "incorrect value for biases[25].code, expected 99, is "
       << last_msg_->biases[25].code;
-  EXPECT_EQ(last_msg_->biases[25].value, -13214)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[25].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[25].value)),
+      -13214)
       << "incorrect value for biases[25].value, expected -13214, is "
       << last_msg_->biases[25].value;
-  EXPECT_EQ(last_msg_->biases[26].code, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[26].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[26].code)),
+            3)
       << "incorrect value for biases[26].code, expected 3, is "
       << last_msg_->biases[26].code;
-  EXPECT_EQ(last_msg_->biases[26].value, -6485)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[26].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[26].value)),
+      -6485)
       << "incorrect value for biases[26].value, expected -6485, is "
       << last_msg_->biases[26].value;
-  EXPECT_EQ(last_msg_->biases[27].code, 180)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[27].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[27].code)),
+            180)
       << "incorrect value for biases[27].code, expected 180, is "
       << last_msg_->biases[27].code;
-  EXPECT_EQ(last_msg_->biases[27].value, 15947)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[27].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[27].value)),
+      15947)
       << "incorrect value for biases[27].value, expected 15947, is "
       << last_msg_->biases[27].value;
-  EXPECT_EQ(last_msg_->biases[28].code, 145)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[28].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[28].code)),
+            145)
       << "incorrect value for biases[28].code, expected 145, is "
       << last_msg_->biases[28].code;
-  EXPECT_EQ(last_msg_->biases[28].value, -32170)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[28].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[28].value)),
+      -32170)
       << "incorrect value for biases[28].value, expected -32170, is "
       << last_msg_->biases[28].value;
-  EXPECT_EQ(last_msg_->biases[29].code, 31)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[29].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[29].code)),
+            31)
       << "incorrect value for biases[29].code, expected 31, is "
       << last_msg_->biases[29].code;
-  EXPECT_EQ(last_msg_->biases[29].value, -25826)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[29].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[29].value)),
+      -25826)
       << "incorrect value for biases[29].value, expected -25826, is "
       << last_msg_->biases[29].value;
-  EXPECT_EQ(last_msg_->biases[30].code, 37)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[30].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[30].code)),
+            37)
       << "incorrect value for biases[30].code, expected 37, is "
       << last_msg_->biases[30].code;
-  EXPECT_EQ(last_msg_->biases[30].value, 14098)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[30].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[30].value)),
+      14098)
       << "incorrect value for biases[30].value, expected 14098, is "
       << last_msg_->biases[30].value;
-  EXPECT_EQ(last_msg_->biases[31].code, 210)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[31].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[31].code)),
+            210)
       << "incorrect value for biases[31].code, expected 210, is "
       << last_msg_->biases[31].code;
-  EXPECT_EQ(last_msg_->biases[31].value, 32551)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[31].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[31].value)),
+      32551)
       << "incorrect value for biases[31].value, expected 32551, is "
       << last_msg_->biases[31].value;
-  EXPECT_EQ(last_msg_->biases[32].code, 242)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[32].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[32].code)),
+            242)
       << "incorrect value for biases[32].code, expected 242, is "
       << last_msg_->biases[32].code;
-  EXPECT_EQ(last_msg_->biases[32].value, 3394)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[32].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[32].value)),
+      3394)
       << "incorrect value for biases[32].value, expected 3394, is "
       << last_msg_->biases[32].value;
-  EXPECT_EQ(last_msg_->biases[33].code, 237)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[33].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[33].code)),
+            237)
       << "incorrect value for biases[33].code, expected 237, is "
       << last_msg_->biases[33].code;
-  EXPECT_EQ(last_msg_->biases[33].value, -21864)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[33].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[33].value)),
+      -21864)
       << "incorrect value for biases[33].value, expected -21864, is "
       << last_msg_->biases[33].value;
-  EXPECT_EQ(last_msg_->biases[34].code, 212)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[34].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[34].code)),
+            212)
       << "incorrect value for biases[34].code, expected 212, is "
       << last_msg_->biases[34].code;
-  EXPECT_EQ(last_msg_->biases[34].value, -2545)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[34].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[34].value)),
+      -2545)
       << "incorrect value for biases[34].value, expected -2545, is "
       << last_msg_->biases[34].value;
-  EXPECT_EQ(last_msg_->biases[35].code, 59)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[35].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[35].code)),
+            59)
       << "incorrect value for biases[35].code, expected 59, is "
       << last_msg_->biases[35].code;
-  EXPECT_EQ(last_msg_->biases[35].value, -19362)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[35].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[35].value)),
+      -19362)
       << "incorrect value for biases[35].value, expected -19362, is "
       << last_msg_->biases[35].value;
-  EXPECT_EQ(last_msg_->biases[36].code, 195)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[36].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[36].code)),
+            195)
       << "incorrect value for biases[36].code, expected 195, is "
       << last_msg_->biases[36].code;
-  EXPECT_EQ(last_msg_->biases[36].value, 17821)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[36].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[36].value)),
+      17821)
       << "incorrect value for biases[36].value, expected 17821, is "
       << last_msg_->biases[36].value;
-  EXPECT_EQ(last_msg_->biases[37].code, 100)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[37].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[37].code)),
+            100)
       << "incorrect value for biases[37].code, expected 100, is "
       << last_msg_->biases[37].code;
-  EXPECT_EQ(last_msg_->biases[37].value, 4215)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[37].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[37].value)),
+      4215)
       << "incorrect value for biases[37].value, expected 4215, is "
       << last_msg_->biases[37].value;
-  EXPECT_EQ(last_msg_->biases[38].code, 68)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[38].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[38].code)),
+            68)
       << "incorrect value for biases[38].code, expected 68, is "
       << last_msg_->biases[38].code;
-  EXPECT_EQ(last_msg_->biases[38].value, -20557)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[38].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[38].value)),
+      -20557)
       << "incorrect value for biases[38].value, expected -20557, is "
       << last_msg_->biases[38].value;
-  EXPECT_EQ(last_msg_->biases[39].code, 144)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[39].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[39].code)),
+            144)
       << "incorrect value for biases[39].code, expected 144, is "
       << last_msg_->biases[39].code;
-  EXPECT_EQ(last_msg_->biases[39].value, 20849)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[39].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[39].value)),
+      20849)
       << "incorrect value for biases[39].value, expected 20849, is "
       << last_msg_->biases[39].value;
-  EXPECT_EQ(last_msg_->biases[40].code, 82)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[40].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[40].code)),
+            82)
       << "incorrect value for biases[40].code, expected 82, is "
       << last_msg_->biases[40].code;
-  EXPECT_EQ(last_msg_->biases[40].value, -26850)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[40].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[40].value)),
+      -26850)
       << "incorrect value for biases[40].value, expected -26850, is "
       << last_msg_->biases[40].value;
-  EXPECT_EQ(last_msg_->biases[41].code, 21)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[41].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[41].code)),
+            21)
       << "incorrect value for biases[41].code, expected 21, is "
       << last_msg_->biases[41].code;
-  EXPECT_EQ(last_msg_->biases[41].value, 10605)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[41].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[41].value)),
+      10605)
       << "incorrect value for biases[41].value, expected 10605, is "
       << last_msg_->biases[41].value;
-  EXPECT_EQ(last_msg_->biases[42].code, 225)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[42].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[42].code)),
+            225)
       << "incorrect value for biases[42].code, expected 225, is "
       << last_msg_->biases[42].code;
-  EXPECT_EQ(last_msg_->biases[42].value, 19720)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[42].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[42].value)),
+      19720)
       << "incorrect value for biases[42].value, expected 19720, is "
       << last_msg_->biases[42].value;
-  EXPECT_EQ(last_msg_->biases[43].code, 164)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[43].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[43].code)),
+            164)
       << "incorrect value for biases[43].code, expected 164, is "
       << last_msg_->biases[43].code;
-  EXPECT_EQ(last_msg_->biases[43].value, 157)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[43].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[43].value)),
+      157)
       << "incorrect value for biases[43].value, expected 157, is "
       << last_msg_->biases[43].value;
-  EXPECT_EQ(last_msg_->biases[44].code, 73)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[44].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[44].code)),
+            73)
       << "incorrect value for biases[44].code, expected 73, is "
       << last_msg_->biases[44].code;
-  EXPECT_EQ(last_msg_->biases[44].value, 1566)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[44].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[44].value)),
+      1566)
       << "incorrect value for biases[44].value, expected 1566, is "
       << last_msg_->biases[44].value;
-  EXPECT_EQ(last_msg_->biases[45].code, 78)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[45].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[45].code)),
+            78)
       << "incorrect value for biases[45].code, expected 78, is "
       << last_msg_->biases[45].code;
-  EXPECT_EQ(last_msg_->biases[45].value, -28847)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[45].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[45].value)),
+      -28847)
       << "incorrect value for biases[45].value, expected -28847, is "
       << last_msg_->biases[45].value;
-  EXPECT_EQ(last_msg_->biases[46].code, 116)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[46].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[46].code)),
+            116)
       << "incorrect value for biases[46].code, expected 116, is "
       << last_msg_->biases[46].code;
-  EXPECT_EQ(last_msg_->biases[46].value, -26640)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[46].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[46].value)),
+      -26640)
       << "incorrect value for biases[46].value, expected -26640, is "
       << last_msg_->biases[46].value;
-  EXPECT_EQ(last_msg_->biases[47].code, 55)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[47].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[47].code)),
+            55)
       << "incorrect value for biases[47].code, expected 55, is "
       << last_msg_->biases[47].code;
-  EXPECT_EQ(last_msg_->biases[47].value, -22087)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[47].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[47].value)),
+      -22087)
       << "incorrect value for biases[47].value, expected -22087, is "
       << last_msg_->biases[47].value;
-  EXPECT_EQ(last_msg_->biases[48].code, 254)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[48].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[48].code)),
+            254)
       << "incorrect value for biases[48].code, expected 254, is "
       << last_msg_->biases[48].code;
-  EXPECT_EQ(last_msg_->biases[48].value, 10035)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[48].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[48].value)),
+      10035)
       << "incorrect value for biases[48].value, expected 10035, is "
       << last_msg_->biases[48].value;
-  EXPECT_EQ(last_msg_->biases[49].code, 74)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[49].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[49].code)),
+            74)
       << "incorrect value for biases[49].code, expected 74, is "
       << last_msg_->biases[49].code;
-  EXPECT_EQ(last_msg_->biases[49].value, -2129)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[49].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[49].value)),
+      -2129)
       << "incorrect value for biases[49].value, expected -2129, is "
       << last_msg_->biases[49].value;
-  EXPECT_EQ(last_msg_->biases[50].code, 34)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[50].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[50].code)),
+            34)
       << "incorrect value for biases[50].code, expected 34, is "
       << last_msg_->biases[50].code;
-  EXPECT_EQ(last_msg_->biases[50].value, 19041)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[50].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[50].value)),
+      19041)
       << "incorrect value for biases[50].value, expected 19041, is "
       << last_msg_->biases[50].value;
-  EXPECT_EQ(last_msg_->biases[51].code, 97)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[51].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[51].code)),
+            97)
       << "incorrect value for biases[51].code, expected 97, is "
       << last_msg_->biases[51].code;
-  EXPECT_EQ(last_msg_->biases[51].value, 12464)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[51].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[51].value)),
+      12464)
       << "incorrect value for biases[51].value, expected 12464, is "
       << last_msg_->biases[51].value;
-  EXPECT_EQ(last_msg_->biases[52].code, 236)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[52].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[52].code)),
+            236)
       << "incorrect value for biases[52].code, expected 236, is "
       << last_msg_->biases[52].code;
-  EXPECT_EQ(last_msg_->biases[52].value, 3245)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[52].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[52].value)),
+      3245)
       << "incorrect value for biases[52].value, expected 3245, is "
       << last_msg_->biases[52].value;
-  EXPECT_EQ(last_msg_->biases[53].code, 174)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[53].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[53].code)),
+            174)
       << "incorrect value for biases[53].code, expected 174, is "
       << last_msg_->biases[53].code;
-  EXPECT_EQ(last_msg_->biases[53].value, -32155)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[53].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[53].value)),
+      -32155)
       << "incorrect value for biases[53].value, expected -32155, is "
       << last_msg_->biases[53].value;
-  EXPECT_EQ(last_msg_->biases[54].code, 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[54].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[54].code)),
+            30)
       << "incorrect value for biases[54].code, expected 30, is "
       << last_msg_->biases[54].code;
-  EXPECT_EQ(last_msg_->biases[54].value, -15959)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[54].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[54].value)),
+      -15959)
       << "incorrect value for biases[54].value, expected -15959, is "
       << last_msg_->biases[54].value;
-  EXPECT_EQ(last_msg_->biases[55].code, 190)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[55].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[55].code)),
+            190)
       << "incorrect value for biases[55].code, expected 190, is "
       << last_msg_->biases[55].code;
-  EXPECT_EQ(last_msg_->biases[55].value, -15156)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[55].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[55].value)),
+      -15156)
       << "incorrect value for biases[55].value, expected -15156, is "
       << last_msg_->biases[55].value;
-  EXPECT_EQ(last_msg_->biases[56].code, 123)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[56].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[56].code)),
+            123)
       << "incorrect value for biases[56].code, expected 123, is "
       << last_msg_->biases[56].code;
-  EXPECT_EQ(last_msg_->biases[56].value, 6507)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[56].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[56].value)),
+      6507)
       << "incorrect value for biases[56].value, expected 6507, is "
       << last_msg_->biases[56].value;
-  EXPECT_EQ(last_msg_->biases[57].code, 225)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[57].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[57].code)),
+            225)
       << "incorrect value for biases[57].code, expected 225, is "
       << last_msg_->biases[57].code;
-  EXPECT_EQ(last_msg_->biases[57].value, 2378)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[57].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[57].value)),
+      2378)
       << "incorrect value for biases[57].value, expected 2378, is "
       << last_msg_->biases[57].value;
-  EXPECT_EQ(last_msg_->biases[58].code, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[58].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[58].code)),
+            10)
       << "incorrect value for biases[58].code, expected 10, is "
       << last_msg_->biases[58].code;
-  EXPECT_EQ(last_msg_->biases[58].value, 823)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[58].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[58].value)),
+      823)
       << "incorrect value for biases[58].value, expected 823, is "
       << last_msg_->biases[58].value;
-  EXPECT_EQ(last_msg_->biases[59].code, 131)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[59].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[59].code)),
+            131)
       << "incorrect value for biases[59].code, expected 131, is "
       << last_msg_->biases[59].code;
-  EXPECT_EQ(last_msg_->biases[59].value, 25590)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[59].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[59].value)),
+      25590)
       << "incorrect value for biases[59].value, expected 25590, is "
       << last_msg_->biases[59].value;
-  EXPECT_EQ(last_msg_->biases[60].code, 133)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[60].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[60].code)),
+            133)
       << "incorrect value for biases[60].code, expected 133, is "
       << last_msg_->biases[60].code;
-  EXPECT_EQ(last_msg_->biases[60].value, -7390)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[60].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[60].value)),
+      -7390)
       << "incorrect value for biases[60].value, expected -7390, is "
       << last_msg_->biases[60].value;
-  EXPECT_EQ(last_msg_->biases[61].code, 203)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[61].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[61].code)),
+            203)
       << "incorrect value for biases[61].code, expected 203, is "
       << last_msg_->biases[61].code;
-  EXPECT_EQ(last_msg_->biases[61].value, 4676)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[61].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[61].value)),
+      4676)
       << "incorrect value for biases[61].value, expected 4676, is "
       << last_msg_->biases[61].value;
-  EXPECT_EQ(last_msg_->biases[62].code, 97)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[62].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[62].code)),
+            97)
       << "incorrect value for biases[62].code, expected 97, is "
       << last_msg_->biases[62].code;
-  EXPECT_EQ(last_msg_->biases[62].value, 23007)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[62].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[62].value)),
+      23007)
       << "incorrect value for biases[62].value, expected 23007, is "
       << last_msg_->biases[62].value;
-  EXPECT_EQ(last_msg_->biases[63].code, 192)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[63].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[63].code)),
+            192)
       << "incorrect value for biases[63].code, expected 192, is "
       << last_msg_->biases[63].code;
-  EXPECT_EQ(last_msg_->biases[63].value, 13046)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[63].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[63].value)),
+      13046)
       << "incorrect value for biases[63].value, expected 13046, is "
       << last_msg_->biases[63].value;
-  EXPECT_EQ(last_msg_->biases[64].code, 69)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[64].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[64].code)),
+            69)
       << "incorrect value for biases[64].code, expected 69, is "
       << last_msg_->biases[64].code;
-  EXPECT_EQ(last_msg_->biases[64].value, 2651)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[64].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[64].value)),
+      2651)
       << "incorrect value for biases[64].value, expected 2651, is "
       << last_msg_->biases[64].value;
-  EXPECT_EQ(last_msg_->biases[65].code, 151)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[65].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[65].code)),
+            151)
       << "incorrect value for biases[65].code, expected 151, is "
       << last_msg_->biases[65].code;
-  EXPECT_EQ(last_msg_->biases[65].value, 30282)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[65].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[65].value)),
+      30282)
       << "incorrect value for biases[65].value, expected 30282, is "
       << last_msg_->biases[65].value;
-  EXPECT_EQ(last_msg_->biases[66].code, 110)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[66].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[66].code)),
+            110)
       << "incorrect value for biases[66].code, expected 110, is "
       << last_msg_->biases[66].code;
-  EXPECT_EQ(last_msg_->biases[66].value, -22492)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[66].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[66].value)),
+      -22492)
       << "incorrect value for biases[66].value, expected -22492, is "
       << last_msg_->biases[66].value;
-  EXPECT_EQ(last_msg_->biases[67].code, 247)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[67].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[67].code)),
+            247)
       << "incorrect value for biases[67].code, expected 247, is "
       << last_msg_->biases[67].code;
-  EXPECT_EQ(last_msg_->biases[67].value, 19872)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[67].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[67].value)),
+      19872)
       << "incorrect value for biases[67].value, expected 19872, is "
       << last_msg_->biases[67].value;
-  EXPECT_EQ(last_msg_->biases[68].code, 179)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[68].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[68].code)),
+            179)
       << "incorrect value for biases[68].code, expected 179, is "
       << last_msg_->biases[68].code;
-  EXPECT_EQ(last_msg_->biases[68].value, -19827)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[68].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[68].value)),
+      -19827)
       << "incorrect value for biases[68].value, expected -19827, is "
       << last_msg_->biases[68].value;
-  EXPECT_EQ(last_msg_->biases[69].code, 99)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[69].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[69].code)),
+            99)
       << "incorrect value for biases[69].code, expected 99, is "
       << last_msg_->biases[69].code;
-  EXPECT_EQ(last_msg_->biases[69].value, 30911)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[69].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[69].value)),
+      30911)
       << "incorrect value for biases[69].value, expected 30911, is "
       << last_msg_->biases[69].value;
-  EXPECT_EQ(last_msg_->biases[70].code, 77)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[70].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[70].code)),
+            77)
       << "incorrect value for biases[70].code, expected 77, is "
       << last_msg_->biases[70].code;
-  EXPECT_EQ(last_msg_->biases[70].value, 23488)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[70].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[70].value)),
+      23488)
       << "incorrect value for biases[70].value, expected 23488, is "
       << last_msg_->biases[70].value;
-  EXPECT_EQ(last_msg_->biases[71].code, 224)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[71].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[71].code)),
+            224)
       << "incorrect value for biases[71].code, expected 224, is "
       << last_msg_->biases[71].code;
-  EXPECT_EQ(last_msg_->biases[71].value, -7679)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[71].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[71].value)),
+      -7679)
       << "incorrect value for biases[71].value, expected -7679, is "
       << last_msg_->biases[71].value;
-  EXPECT_EQ(last_msg_->biases[72].code, 50)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[72].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[72].code)),
+            50)
       << "incorrect value for biases[72].code, expected 50, is "
       << last_msg_->biases[72].code;
-  EXPECT_EQ(last_msg_->biases[72].value, -28073)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[72].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[72].value)),
+      -28073)
       << "incorrect value for biases[72].value, expected -28073, is "
       << last_msg_->biases[72].value;
-  EXPECT_EQ(last_msg_->biases[73].code, 148)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[73].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[73].code)),
+            148)
       << "incorrect value for biases[73].code, expected 148, is "
       << last_msg_->biases[73].code;
-  EXPECT_EQ(last_msg_->biases[73].value, 25838)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[73].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[73].value)),
+      25838)
       << "incorrect value for biases[73].value, expected 25838, is "
       << last_msg_->biases[73].value;
-  EXPECT_EQ(last_msg_->biases[74].code, 179)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[74].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[74].code)),
+            179)
       << "incorrect value for biases[74].code, expected 179, is "
       << last_msg_->biases[74].code;
-  EXPECT_EQ(last_msg_->biases[74].value, -7299)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[74].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[74].value)),
+      -7299)
       << "incorrect value for biases[74].value, expected -7299, is "
       << last_msg_->biases[74].value;
-  EXPECT_EQ(last_msg_->biases[75].code, 215)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[75].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[75].code)),
+            215)
       << "incorrect value for biases[75].code, expected 215, is "
       << last_msg_->biases[75].code;
-  EXPECT_EQ(last_msg_->biases[75].value, -18328)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[75].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[75].value)),
+      -18328)
       << "incorrect value for biases[75].value, expected -18328, is "
       << last_msg_->biases[75].value;
-  EXPECT_EQ(last_msg_->biases[76].code, 31)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[76].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[76].code)),
+            31)
       << "incorrect value for biases[76].code, expected 31, is "
       << last_msg_->biases[76].code;
-  EXPECT_EQ(last_msg_->biases[76].value, 23097)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[76].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[76].value)),
+      23097)
       << "incorrect value for biases[76].value, expected 23097, is "
       << last_msg_->biases[76].value;
-  EXPECT_EQ(last_msg_->biases[77].code, 79)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[77].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[77].code)),
+            79)
       << "incorrect value for biases[77].code, expected 79, is "
       << last_msg_->biases[77].code;
-  EXPECT_EQ(last_msg_->biases[77].value, -25579)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[77].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[77].value)),
+      -25579)
       << "incorrect value for biases[77].value, expected -25579, is "
       << last_msg_->biases[77].value;
-  EXPECT_EQ(last_msg_->biases[78].code, 245)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[78].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[78].code)),
+            245)
       << "incorrect value for biases[78].code, expected 245, is "
       << last_msg_->biases[78].code;
-  EXPECT_EQ(last_msg_->biases[78].value, 15441)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[78].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[78].value)),
+      15441)
       << "incorrect value for biases[78].value, expected 15441, is "
       << last_msg_->biases[78].value;
-  EXPECT_EQ(last_msg_->biases[79].code, 93)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[79].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[79].code)),
+            93)
       << "incorrect value for biases[79].code, expected 93, is "
       << last_msg_->biases[79].code;
-  EXPECT_EQ(last_msg_->biases[79].value, 15530)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[79].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[79].value)),
+      15530)
       << "incorrect value for biases[79].value, expected 15530, is "
       << last_msg_->biases[79].value;
-  EXPECT_EQ(last_msg_->biases[80].code, 200)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[80].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[80].code)),
+            200)
       << "incorrect value for biases[80].code, expected 200, is "
       << last_msg_->biases[80].code;
-  EXPECT_EQ(last_msg_->biases[80].value, 3495)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->biases[80].value)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->biases[80].value)),
+      3495)
       << "incorrect value for biases[80].value, expected 3495, is "
       << last_msg_->biases[80].value;
-  EXPECT_EQ(last_msg_->iod_ssr, 132)
+  EXPECT_EQ(get_as<decltype(last_msg_->iod_ssr)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iod_ssr)),
+            132)
       << "incorrect value for iod_ssr, expected 132, is " << last_msg_->iod_ssr;
-  EXPECT_EQ(last_msg_->sid.code, 241)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.code)),
+            241)
       << "incorrect value for sid.code, expected 241, is "
       << last_msg_->sid.code;
-  EXPECT_EQ(last_msg_->sid.sat, 133)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.sat)),
+            133)
       << "incorrect value for sid.sat, expected 133, is " << last_msg_->sid.sat;
-  EXPECT_EQ(last_msg_->time.tow, 387144400)
+  EXPECT_EQ(get_as<decltype(last_msg_->time.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->time.tow)),
+            387144400)
       << "incorrect value for time.tow, expected 387144400, is "
       << last_msg_->time.tow;
-  EXPECT_EQ(last_msg_->time.wn, 16905)
+  EXPECT_EQ(get_as<decltype(last_msg_->time.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->time.wn)),
+            16905)
       << "incorrect value for time.wn, expected 16905, is "
       << last_msg_->time.wn;
-  EXPECT_EQ(last_msg_->update_interval, 254)
+  EXPECT_EQ(get_as<decltype(last_msg_->update_interval)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->update_interval)),
+            254)
       << "incorrect value for update_interval, expected 254, is "
       << last_msg_->update_interval;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrCodePhaseBiasesBounds.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrCodePhaseBiasesBounds.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/ssr.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_ssr_MsgSsrCodePhaseBiasesBounds0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -154,95 +161,180 @@ TEST_F(Test_legacy_auto_check_sbp_ssr_MsgSsrCodePhaseBiasesBounds0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->const_id, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->const_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->const_id)),
+            1)
       << "incorrect value for const_id, expected 1, is " << last_msg_->const_id;
-  EXPECT_EQ(last_msg_->header.num_msgs, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.num_msgs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.num_msgs)),
+            1)
       << "incorrect value for header.num_msgs, expected 1, is "
       << last_msg_->header.num_msgs;
-  EXPECT_EQ(last_msg_->header.seq_num, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.seq_num)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.seq_num)),
+            2)
       << "incorrect value for header.seq_num, expected 2, is "
       << last_msg_->header.seq_num;
-  EXPECT_EQ(last_msg_->header.sol_id, 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.sol_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.sol_id)),
+            14)
       << "incorrect value for header.sol_id, expected 14, is "
       << last_msg_->header.sol_id;
-  EXPECT_EQ(last_msg_->header.time.tow, 180)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.time.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.time.tow)),
+            180)
       << "incorrect value for header.time.tow, expected 180, is "
       << last_msg_->header.time.tow;
-  EXPECT_EQ(last_msg_->header.time.wn, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.time.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.time.wn)),
+            3)
       << "incorrect value for header.time.wn, expected 3, is "
       << last_msg_->header.time.wn;
-  EXPECT_EQ(last_msg_->header.update_interval, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.update_interval)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->header.update_interval)),
+            1)
       << "incorrect value for header.update_interval, expected 1, is "
       << last_msg_->header.update_interval;
-  EXPECT_EQ(last_msg_->n_sats_signals, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats_signals)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats_signals)),
+            3)
       << "incorrect value for n_sats_signals, expected 3, is "
       << last_msg_->n_sats_signals;
-  EXPECT_EQ(last_msg_->satellites_signals[0].code_bias_bound_mu, 39)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->satellites_signals[0].code_bias_bound_mu)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->satellites_signals[0].code_bias_bound_mu)),
+      39)
       << "incorrect value for satellites_signals[0].code_bias_bound_mu, "
          "expected 39, is "
       << last_msg_->satellites_signals[0].code_bias_bound_mu;
-  EXPECT_EQ(last_msg_->satellites_signals[0].code_bias_bound_sig, 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->satellites_signals[0].code_bias_bound_sig)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->satellites_signals[0].code_bias_bound_sig)),
+      1)
       << "incorrect value for satellites_signals[0].code_bias_bound_sig, "
          "expected 1, is "
       << last_msg_->satellites_signals[0].code_bias_bound_sig;
-  EXPECT_EQ(last_msg_->satellites_signals[0].phase_bias_bound_mu, 39)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->satellites_signals[0].phase_bias_bound_mu)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->satellites_signals[0].phase_bias_bound_mu)),
+      39)
       << "incorrect value for satellites_signals[0].phase_bias_bound_mu, "
          "expected 39, is "
       << last_msg_->satellites_signals[0].phase_bias_bound_mu;
-  EXPECT_EQ(last_msg_->satellites_signals[0].phase_bias_bound_sig, 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->satellites_signals[0].phase_bias_bound_sig)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->satellites_signals[0].phase_bias_bound_sig)),
+      1)
       << "incorrect value for satellites_signals[0].phase_bias_bound_sig, "
          "expected 1, is "
       << last_msg_->satellites_signals[0].phase_bias_bound_sig;
-  EXPECT_EQ(last_msg_->satellites_signals[0].sat_id, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->satellites_signals[0].sat_id)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->satellites_signals[0].sat_id)),
+            0)
       << "incorrect value for satellites_signals[0].sat_id, expected 0, is "
       << last_msg_->satellites_signals[0].sat_id;
-  EXPECT_EQ(last_msg_->satellites_signals[0].signal_id, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->satellites_signals[0].signal_id)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->satellites_signals[0].signal_id)),
+            3)
       << "incorrect value for satellites_signals[0].signal_id, expected 3, is "
       << last_msg_->satellites_signals[0].signal_id;
-  EXPECT_EQ(last_msg_->satellites_signals[1].code_bias_bound_mu, 39)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->satellites_signals[1].code_bias_bound_mu)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->satellites_signals[1].code_bias_bound_mu)),
+      39)
       << "incorrect value for satellites_signals[1].code_bias_bound_mu, "
          "expected 39, is "
       << last_msg_->satellites_signals[1].code_bias_bound_mu;
-  EXPECT_EQ(last_msg_->satellites_signals[1].code_bias_bound_sig, 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->satellites_signals[1].code_bias_bound_sig)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->satellites_signals[1].code_bias_bound_sig)),
+      1)
       << "incorrect value for satellites_signals[1].code_bias_bound_sig, "
          "expected 1, is "
       << last_msg_->satellites_signals[1].code_bias_bound_sig;
-  EXPECT_EQ(last_msg_->satellites_signals[1].phase_bias_bound_mu, 39)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->satellites_signals[1].phase_bias_bound_mu)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->satellites_signals[1].phase_bias_bound_mu)),
+      39)
       << "incorrect value for satellites_signals[1].phase_bias_bound_mu, "
          "expected 39, is "
       << last_msg_->satellites_signals[1].phase_bias_bound_mu;
-  EXPECT_EQ(last_msg_->satellites_signals[1].phase_bias_bound_sig, 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->satellites_signals[1].phase_bias_bound_sig)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->satellites_signals[1].phase_bias_bound_sig)),
+      1)
       << "incorrect value for satellites_signals[1].phase_bias_bound_sig, "
          "expected 1, is "
       << last_msg_->satellites_signals[1].phase_bias_bound_sig;
-  EXPECT_EQ(last_msg_->satellites_signals[1].sat_id, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->satellites_signals[1].sat_id)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->satellites_signals[1].sat_id)),
+            1)
       << "incorrect value for satellites_signals[1].sat_id, expected 1, is "
       << last_msg_->satellites_signals[1].sat_id;
-  EXPECT_EQ(last_msg_->satellites_signals[1].signal_id, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->satellites_signals[1].signal_id)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->satellites_signals[1].signal_id)),
+            3)
       << "incorrect value for satellites_signals[1].signal_id, expected 3, is "
       << last_msg_->satellites_signals[1].signal_id;
-  EXPECT_EQ(last_msg_->satellites_signals[2].code_bias_bound_mu, 39)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->satellites_signals[2].code_bias_bound_mu)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->satellites_signals[2].code_bias_bound_mu)),
+      39)
       << "incorrect value for satellites_signals[2].code_bias_bound_mu, "
          "expected 39, is "
       << last_msg_->satellites_signals[2].code_bias_bound_mu;
-  EXPECT_EQ(last_msg_->satellites_signals[2].code_bias_bound_sig, 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->satellites_signals[2].code_bias_bound_sig)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->satellites_signals[2].code_bias_bound_sig)),
+      1)
       << "incorrect value for satellites_signals[2].code_bias_bound_sig, "
          "expected 1, is "
       << last_msg_->satellites_signals[2].code_bias_bound_sig;
-  EXPECT_EQ(last_msg_->satellites_signals[2].phase_bias_bound_mu, 39)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->satellites_signals[2].phase_bias_bound_mu)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->satellites_signals[2].phase_bias_bound_mu)),
+      39)
       << "incorrect value for satellites_signals[2].phase_bias_bound_mu, "
          "expected 39, is "
       << last_msg_->satellites_signals[2].phase_bias_bound_mu;
-  EXPECT_EQ(last_msg_->satellites_signals[2].phase_bias_bound_sig, 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->satellites_signals[2].phase_bias_bound_sig)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->satellites_signals[2].phase_bias_bound_sig)),
+      1)
       << "incorrect value for satellites_signals[2].phase_bias_bound_sig, "
          "expected 1, is "
       << last_msg_->satellites_signals[2].phase_bias_bound_sig;
-  EXPECT_EQ(last_msg_->satellites_signals[2].sat_id, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->satellites_signals[2].sat_id)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->satellites_signals[2].sat_id)),
+            1)
       << "incorrect value for satellites_signals[2].sat_id, expected 1, is "
       << last_msg_->satellites_signals[2].sat_id;
-  EXPECT_EQ(last_msg_->satellites_signals[2].signal_id, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->satellites_signals[2].signal_id)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->satellites_signals[2].signal_id)),
+            1)
       << "incorrect value for satellites_signals[2].signal_id, expected 1, is "
       << last_msg_->satellites_signals[2].signal_id;
-  EXPECT_EQ(last_msg_->ssr_iod, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->ssr_iod)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ssr_iod)),
+            15)
       << "incorrect value for ssr_iod, expected 15, is " << last_msg_->ssr_iod;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrGridDefinitionDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrGridDefinitionDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/ssr.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_ssr_MsgSsrGridDefinitionDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -1364,760 +1371,1268 @@ TEST_F(Test_legacy_auto_check_sbp_ssr_MsgSsrGridDefinitionDepA0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 63413);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->header.area_width, 43860)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->header.area_width)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->header.area_width)),
+      43860)
       << "incorrect value for header.area_width, expected 43860, is "
       << last_msg_->header.area_width;
-  EXPECT_EQ(last_msg_->header.lat_nw_corner_enc, 34021)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.lat_nw_corner_enc)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->header.lat_nw_corner_enc)),
+            34021)
       << "incorrect value for header.lat_nw_corner_enc, expected 34021, is "
       << last_msg_->header.lat_nw_corner_enc;
-  EXPECT_EQ(last_msg_->header.lon_nw_corner_enc, 11919)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.lon_nw_corner_enc)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->header.lon_nw_corner_enc)),
+            11919)
       << "incorrect value for header.lon_nw_corner_enc, expected 11919, is "
       << last_msg_->header.lon_nw_corner_enc;
-  EXPECT_EQ(last_msg_->header.num_msgs, 204)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.num_msgs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.num_msgs)),
+            204)
       << "incorrect value for header.num_msgs, expected 204, is "
       << last_msg_->header.num_msgs;
-  EXPECT_EQ(last_msg_->header.region_size_inverse, 11)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.region_size_inverse)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->header.region_size_inverse)),
+            11)
       << "incorrect value for header.region_size_inverse, expected 11, is "
       << last_msg_->header.region_size_inverse;
-  EXPECT_EQ(last_msg_->header.seq_num, 52)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.seq_num)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.seq_num)),
+            52)
       << "incorrect value for header.seq_num, expected 52, is "
       << last_msg_->header.seq_num;
-  EXPECT_EQ(last_msg_->rle_list[0], 92)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[0])),
+            92)
       << "incorrect value for rle_list[0], expected 92, is "
       << last_msg_->rle_list[0];
-  EXPECT_EQ(last_msg_->rle_list[1], 104)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[1])),
+            104)
       << "incorrect value for rle_list[1], expected 104, is "
       << last_msg_->rle_list[1];
-  EXPECT_EQ(last_msg_->rle_list[2], 25)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[2])),
+            25)
       << "incorrect value for rle_list[2], expected 25, is "
       << last_msg_->rle_list[2];
-  EXPECT_EQ(last_msg_->rle_list[3], 204)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[3])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[3])),
+            204)
       << "incorrect value for rle_list[3], expected 204, is "
       << last_msg_->rle_list[3];
-  EXPECT_EQ(last_msg_->rle_list[4], 182)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[4])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[4])),
+            182)
       << "incorrect value for rle_list[4], expected 182, is "
       << last_msg_->rle_list[4];
-  EXPECT_EQ(last_msg_->rle_list[5], 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[5])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[5])),
+            22)
       << "incorrect value for rle_list[5], expected 22, is "
       << last_msg_->rle_list[5];
-  EXPECT_EQ(last_msg_->rle_list[6], 98)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[6])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[6])),
+            98)
       << "incorrect value for rle_list[6], expected 98, is "
       << last_msg_->rle_list[6];
-  EXPECT_EQ(last_msg_->rle_list[7], 203)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[7])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[7])),
+            203)
       << "incorrect value for rle_list[7], expected 203, is "
       << last_msg_->rle_list[7];
-  EXPECT_EQ(last_msg_->rle_list[8], 123)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[8])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[8])),
+            123)
       << "incorrect value for rle_list[8], expected 123, is "
       << last_msg_->rle_list[8];
-  EXPECT_EQ(last_msg_->rle_list[9], 211)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[9])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[9])),
+            211)
       << "incorrect value for rle_list[9], expected 211, is "
       << last_msg_->rle_list[9];
-  EXPECT_EQ(last_msg_->rle_list[10], 38)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[10])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[10])),
+            38)
       << "incorrect value for rle_list[10], expected 38, is "
       << last_msg_->rle_list[10];
-  EXPECT_EQ(last_msg_->rle_list[11], 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[11])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[11])),
+            13)
       << "incorrect value for rle_list[11], expected 13, is "
       << last_msg_->rle_list[11];
-  EXPECT_EQ(last_msg_->rle_list[12], 253)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[12])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[12])),
+            253)
       << "incorrect value for rle_list[12], expected 253, is "
       << last_msg_->rle_list[12];
-  EXPECT_EQ(last_msg_->rle_list[13], 129)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[13])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[13])),
+            129)
       << "incorrect value for rle_list[13], expected 129, is "
       << last_msg_->rle_list[13];
-  EXPECT_EQ(last_msg_->rle_list[14], 173)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[14])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[14])),
+            173)
       << "incorrect value for rle_list[14], expected 173, is "
       << last_msg_->rle_list[14];
-  EXPECT_EQ(last_msg_->rle_list[15], 171)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[15])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[15])),
+            171)
       << "incorrect value for rle_list[15], expected 171, is "
       << last_msg_->rle_list[15];
-  EXPECT_EQ(last_msg_->rle_list[16], 235)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[16])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[16])),
+            235)
       << "incorrect value for rle_list[16], expected 235, is "
       << last_msg_->rle_list[16];
-  EXPECT_EQ(last_msg_->rle_list[17], 253)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[17])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[17])),
+            253)
       << "incorrect value for rle_list[17], expected 253, is "
       << last_msg_->rle_list[17];
-  EXPECT_EQ(last_msg_->rle_list[18], 26)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[18])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[18])),
+            26)
       << "incorrect value for rle_list[18], expected 26, is "
       << last_msg_->rle_list[18];
-  EXPECT_EQ(last_msg_->rle_list[19], 203)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[19])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[19])),
+            203)
       << "incorrect value for rle_list[19], expected 203, is "
       << last_msg_->rle_list[19];
-  EXPECT_EQ(last_msg_->rle_list[20], 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[20])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[20])),
+            3)
       << "incorrect value for rle_list[20], expected 3, is "
       << last_msg_->rle_list[20];
-  EXPECT_EQ(last_msg_->rle_list[21], 120)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[21])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[21])),
+            120)
       << "incorrect value for rle_list[21], expected 120, is "
       << last_msg_->rle_list[21];
-  EXPECT_EQ(last_msg_->rle_list[22], 126)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[22])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[22])),
+            126)
       << "incorrect value for rle_list[22], expected 126, is "
       << last_msg_->rle_list[22];
-  EXPECT_EQ(last_msg_->rle_list[23], 42)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[23])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[23])),
+            42)
       << "incorrect value for rle_list[23], expected 42, is "
       << last_msg_->rle_list[23];
-  EXPECT_EQ(last_msg_->rle_list[24], 44)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[24])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[24])),
+            44)
       << "incorrect value for rle_list[24], expected 44, is "
       << last_msg_->rle_list[24];
-  EXPECT_EQ(last_msg_->rle_list[25], 39)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[25])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[25])),
+            39)
       << "incorrect value for rle_list[25], expected 39, is "
       << last_msg_->rle_list[25];
-  EXPECT_EQ(last_msg_->rle_list[26], 87)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[26])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[26])),
+            87)
       << "incorrect value for rle_list[26], expected 87, is "
       << last_msg_->rle_list[26];
-  EXPECT_EQ(last_msg_->rle_list[27], 69)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[27])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[27])),
+            69)
       << "incorrect value for rle_list[27], expected 69, is "
       << last_msg_->rle_list[27];
-  EXPECT_EQ(last_msg_->rle_list[28], 154)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[28])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[28])),
+            154)
       << "incorrect value for rle_list[28], expected 154, is "
       << last_msg_->rle_list[28];
-  EXPECT_EQ(last_msg_->rle_list[29], 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[29])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[29])),
+            13)
       << "incorrect value for rle_list[29], expected 13, is "
       << last_msg_->rle_list[29];
-  EXPECT_EQ(last_msg_->rle_list[30], 28)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[30])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[30])),
+            28)
       << "incorrect value for rle_list[30], expected 28, is "
       << last_msg_->rle_list[30];
-  EXPECT_EQ(last_msg_->rle_list[31], 179)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[31])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[31])),
+            179)
       << "incorrect value for rle_list[31], expected 179, is "
       << last_msg_->rle_list[31];
-  EXPECT_EQ(last_msg_->rle_list[32], 32)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[32])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[32])),
+            32)
       << "incorrect value for rle_list[32], expected 32, is "
       << last_msg_->rle_list[32];
-  EXPECT_EQ(last_msg_->rle_list[33], 47)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[33])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[33])),
+            47)
       << "incorrect value for rle_list[33], expected 47, is "
       << last_msg_->rle_list[33];
-  EXPECT_EQ(last_msg_->rle_list[34], 36)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[34])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[34])),
+            36)
       << "incorrect value for rle_list[34], expected 36, is "
       << last_msg_->rle_list[34];
-  EXPECT_EQ(last_msg_->rle_list[35], 195)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[35])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[35])),
+            195)
       << "incorrect value for rle_list[35], expected 195, is "
       << last_msg_->rle_list[35];
-  EXPECT_EQ(last_msg_->rle_list[36], 39)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[36])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[36])),
+            39)
       << "incorrect value for rle_list[36], expected 39, is "
       << last_msg_->rle_list[36];
-  EXPECT_EQ(last_msg_->rle_list[37], 198)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[37])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[37])),
+            198)
       << "incorrect value for rle_list[37], expected 198, is "
       << last_msg_->rle_list[37];
-  EXPECT_EQ(last_msg_->rle_list[38], 134)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[38])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[38])),
+            134)
       << "incorrect value for rle_list[38], expected 134, is "
       << last_msg_->rle_list[38];
-  EXPECT_EQ(last_msg_->rle_list[39], 235)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[39])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[39])),
+            235)
       << "incorrect value for rle_list[39], expected 235, is "
       << last_msg_->rle_list[39];
-  EXPECT_EQ(last_msg_->rle_list[40], 134)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[40])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[40])),
+            134)
       << "incorrect value for rle_list[40], expected 134, is "
       << last_msg_->rle_list[40];
-  EXPECT_EQ(last_msg_->rle_list[41], 57)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[41])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[41])),
+            57)
       << "incorrect value for rle_list[41], expected 57, is "
       << last_msg_->rle_list[41];
-  EXPECT_EQ(last_msg_->rle_list[42], 120)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[42])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[42])),
+            120)
       << "incorrect value for rle_list[42], expected 120, is "
       << last_msg_->rle_list[42];
-  EXPECT_EQ(last_msg_->rle_list[43], 243)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[43])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[43])),
+            243)
       << "incorrect value for rle_list[43], expected 243, is "
       << last_msg_->rle_list[43];
-  EXPECT_EQ(last_msg_->rle_list[44], 151)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[44])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[44])),
+            151)
       << "incorrect value for rle_list[44], expected 151, is "
       << last_msg_->rle_list[44];
-  EXPECT_EQ(last_msg_->rle_list[45], 35)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[45])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[45])),
+            35)
       << "incorrect value for rle_list[45], expected 35, is "
       << last_msg_->rle_list[45];
-  EXPECT_EQ(last_msg_->rle_list[46], 17)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[46])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[46])),
+            17)
       << "incorrect value for rle_list[46], expected 17, is "
       << last_msg_->rle_list[46];
-  EXPECT_EQ(last_msg_->rle_list[47], 201)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[47])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[47])),
+            201)
       << "incorrect value for rle_list[47], expected 201, is "
       << last_msg_->rle_list[47];
-  EXPECT_EQ(last_msg_->rle_list[48], 211)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[48])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[48])),
+            211)
       << "incorrect value for rle_list[48], expected 211, is "
       << last_msg_->rle_list[48];
-  EXPECT_EQ(last_msg_->rle_list[49], 125)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[49])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[49])),
+            125)
       << "incorrect value for rle_list[49], expected 125, is "
       << last_msg_->rle_list[49];
-  EXPECT_EQ(last_msg_->rle_list[50], 117)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[50])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[50])),
+            117)
       << "incorrect value for rle_list[50], expected 117, is "
       << last_msg_->rle_list[50];
-  EXPECT_EQ(last_msg_->rle_list[51], 164)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[51])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[51])),
+            164)
       << "incorrect value for rle_list[51], expected 164, is "
       << last_msg_->rle_list[51];
-  EXPECT_EQ(last_msg_->rle_list[52], 142)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[52])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[52])),
+            142)
       << "incorrect value for rle_list[52], expected 142, is "
       << last_msg_->rle_list[52];
-  EXPECT_EQ(last_msg_->rle_list[53], 101)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[53])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[53])),
+            101)
       << "incorrect value for rle_list[53], expected 101, is "
       << last_msg_->rle_list[53];
-  EXPECT_EQ(last_msg_->rle_list[54], 239)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[54])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[54])),
+            239)
       << "incorrect value for rle_list[54], expected 239, is "
       << last_msg_->rle_list[54];
-  EXPECT_EQ(last_msg_->rle_list[55], 144)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[55])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[55])),
+            144)
       << "incorrect value for rle_list[55], expected 144, is "
       << last_msg_->rle_list[55];
-  EXPECT_EQ(last_msg_->rle_list[56], 158)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[56])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[56])),
+            158)
       << "incorrect value for rle_list[56], expected 158, is "
       << last_msg_->rle_list[56];
-  EXPECT_EQ(last_msg_->rle_list[57], 239)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[57])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[57])),
+            239)
       << "incorrect value for rle_list[57], expected 239, is "
       << last_msg_->rle_list[57];
-  EXPECT_EQ(last_msg_->rle_list[58], 90)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[58])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[58])),
+            90)
       << "incorrect value for rle_list[58], expected 90, is "
       << last_msg_->rle_list[58];
-  EXPECT_EQ(last_msg_->rle_list[59], 56)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[59])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[59])),
+            56)
       << "incorrect value for rle_list[59], expected 56, is "
       << last_msg_->rle_list[59];
-  EXPECT_EQ(last_msg_->rle_list[60], 71)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[60])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[60])),
+            71)
       << "incorrect value for rle_list[60], expected 71, is "
       << last_msg_->rle_list[60];
-  EXPECT_EQ(last_msg_->rle_list[61], 120)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[61])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[61])),
+            120)
       << "incorrect value for rle_list[61], expected 120, is "
       << last_msg_->rle_list[61];
-  EXPECT_EQ(last_msg_->rle_list[62], 67)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[62])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[62])),
+            67)
       << "incorrect value for rle_list[62], expected 67, is "
       << last_msg_->rle_list[62];
-  EXPECT_EQ(last_msg_->rle_list[63], 221)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[63])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[63])),
+            221)
       << "incorrect value for rle_list[63], expected 221, is "
       << last_msg_->rle_list[63];
-  EXPECT_EQ(last_msg_->rle_list[64], 114)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[64])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[64])),
+            114)
       << "incorrect value for rle_list[64], expected 114, is "
       << last_msg_->rle_list[64];
-  EXPECT_EQ(last_msg_->rle_list[65], 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[65])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[65])),
+            10)
       << "incorrect value for rle_list[65], expected 10, is "
       << last_msg_->rle_list[65];
-  EXPECT_EQ(last_msg_->rle_list[66], 190)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[66])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[66])),
+            190)
       << "incorrect value for rle_list[66], expected 190, is "
       << last_msg_->rle_list[66];
-  EXPECT_EQ(last_msg_->rle_list[67], 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[67])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[67])),
+            4)
       << "incorrect value for rle_list[67], expected 4, is "
       << last_msg_->rle_list[67];
-  EXPECT_EQ(last_msg_->rle_list[68], 230)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[68])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[68])),
+            230)
       << "incorrect value for rle_list[68], expected 230, is "
       << last_msg_->rle_list[68];
-  EXPECT_EQ(last_msg_->rle_list[69], 164)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[69])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[69])),
+            164)
       << "incorrect value for rle_list[69], expected 164, is "
       << last_msg_->rle_list[69];
-  EXPECT_EQ(last_msg_->rle_list[70], 171)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[70])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[70])),
+            171)
       << "incorrect value for rle_list[70], expected 171, is "
       << last_msg_->rle_list[70];
-  EXPECT_EQ(last_msg_->rle_list[71], 78)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[71])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[71])),
+            78)
       << "incorrect value for rle_list[71], expected 78, is "
       << last_msg_->rle_list[71];
-  EXPECT_EQ(last_msg_->rle_list[72], 185)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[72])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[72])),
+            185)
       << "incorrect value for rle_list[72], expected 185, is "
       << last_msg_->rle_list[72];
-  EXPECT_EQ(last_msg_->rle_list[73], 90)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[73])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[73])),
+            90)
       << "incorrect value for rle_list[73], expected 90, is "
       << last_msg_->rle_list[73];
-  EXPECT_EQ(last_msg_->rle_list[74], 46)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[74])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[74])),
+            46)
       << "incorrect value for rle_list[74], expected 46, is "
       << last_msg_->rle_list[74];
-  EXPECT_EQ(last_msg_->rle_list[75], 177)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[75])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[75])),
+            177)
       << "incorrect value for rle_list[75], expected 177, is "
       << last_msg_->rle_list[75];
-  EXPECT_EQ(last_msg_->rle_list[76], 82)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[76])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[76])),
+            82)
       << "incorrect value for rle_list[76], expected 82, is "
       << last_msg_->rle_list[76];
-  EXPECT_EQ(last_msg_->rle_list[77], 228)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[77])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[77])),
+            228)
       << "incorrect value for rle_list[77], expected 228, is "
       << last_msg_->rle_list[77];
-  EXPECT_EQ(last_msg_->rle_list[78], 123)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[78])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[78])),
+            123)
       << "incorrect value for rle_list[78], expected 123, is "
       << last_msg_->rle_list[78];
-  EXPECT_EQ(last_msg_->rle_list[79], 222)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[79])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[79])),
+            222)
       << "incorrect value for rle_list[79], expected 222, is "
       << last_msg_->rle_list[79];
-  EXPECT_EQ(last_msg_->rle_list[80], 227)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[80])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[80])),
+            227)
       << "incorrect value for rle_list[80], expected 227, is "
       << last_msg_->rle_list[80];
-  EXPECT_EQ(last_msg_->rle_list[81], 145)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[81])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[81])),
+            145)
       << "incorrect value for rle_list[81], expected 145, is "
       << last_msg_->rle_list[81];
-  EXPECT_EQ(last_msg_->rle_list[82], 195)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[82])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[82])),
+            195)
       << "incorrect value for rle_list[82], expected 195, is "
       << last_msg_->rle_list[82];
-  EXPECT_EQ(last_msg_->rle_list[83], 219)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[83])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[83])),
+            219)
       << "incorrect value for rle_list[83], expected 219, is "
       << last_msg_->rle_list[83];
-  EXPECT_EQ(last_msg_->rle_list[84], 27)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[84])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[84])),
+            27)
       << "incorrect value for rle_list[84], expected 27, is "
       << last_msg_->rle_list[84];
-  EXPECT_EQ(last_msg_->rle_list[85], 56)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[85])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[85])),
+            56)
       << "incorrect value for rle_list[85], expected 56, is "
       << last_msg_->rle_list[85];
-  EXPECT_EQ(last_msg_->rle_list[86], 227)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[86])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[86])),
+            227)
       << "incorrect value for rle_list[86], expected 227, is "
       << last_msg_->rle_list[86];
-  EXPECT_EQ(last_msg_->rle_list[87], 246)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[87])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[87])),
+            246)
       << "incorrect value for rle_list[87], expected 246, is "
       << last_msg_->rle_list[87];
-  EXPECT_EQ(last_msg_->rle_list[88], 215)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[88])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[88])),
+            215)
       << "incorrect value for rle_list[88], expected 215, is "
       << last_msg_->rle_list[88];
-  EXPECT_EQ(last_msg_->rle_list[89], 144)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[89])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[89])),
+            144)
       << "incorrect value for rle_list[89], expected 144, is "
       << last_msg_->rle_list[89];
-  EXPECT_EQ(last_msg_->rle_list[90], 158)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[90])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[90])),
+            158)
       << "incorrect value for rle_list[90], expected 158, is "
       << last_msg_->rle_list[90];
-  EXPECT_EQ(last_msg_->rle_list[91], 31)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[91])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[91])),
+            31)
       << "incorrect value for rle_list[91], expected 31, is "
       << last_msg_->rle_list[91];
-  EXPECT_EQ(last_msg_->rle_list[92], 214)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[92])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[92])),
+            214)
       << "incorrect value for rle_list[92], expected 214, is "
       << last_msg_->rle_list[92];
-  EXPECT_EQ(last_msg_->rle_list[93], 241)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[93])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[93])),
+            241)
       << "incorrect value for rle_list[93], expected 241, is "
       << last_msg_->rle_list[93];
-  EXPECT_EQ(last_msg_->rle_list[94], 254)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[94])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[94])),
+            254)
       << "incorrect value for rle_list[94], expected 254, is "
       << last_msg_->rle_list[94];
-  EXPECT_EQ(last_msg_->rle_list[95], 200)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[95])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[95])),
+            200)
       << "incorrect value for rle_list[95], expected 200, is "
       << last_msg_->rle_list[95];
-  EXPECT_EQ(last_msg_->rle_list[96], 86)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[96])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[96])),
+            86)
       << "incorrect value for rle_list[96], expected 86, is "
       << last_msg_->rle_list[96];
-  EXPECT_EQ(last_msg_->rle_list[97], 142)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[97])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[97])),
+            142)
       << "incorrect value for rle_list[97], expected 142, is "
       << last_msg_->rle_list[97];
-  EXPECT_EQ(last_msg_->rle_list[98], 89)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[98])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[98])),
+            89)
       << "incorrect value for rle_list[98], expected 89, is "
       << last_msg_->rle_list[98];
-  EXPECT_EQ(last_msg_->rle_list[99], 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[99])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[99])),
+            12)
       << "incorrect value for rle_list[99], expected 12, is "
       << last_msg_->rle_list[99];
-  EXPECT_EQ(last_msg_->rle_list[100], 121)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[100])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[100])),
+            121)
       << "incorrect value for rle_list[100], expected 121, is "
       << last_msg_->rle_list[100];
-  EXPECT_EQ(last_msg_->rle_list[101], 29)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[101])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[101])),
+            29)
       << "incorrect value for rle_list[101], expected 29, is "
       << last_msg_->rle_list[101];
-  EXPECT_EQ(last_msg_->rle_list[102], 124)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[102])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[102])),
+            124)
       << "incorrect value for rle_list[102], expected 124, is "
       << last_msg_->rle_list[102];
-  EXPECT_EQ(last_msg_->rle_list[103], 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[103])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[103])),
+            9)
       << "incorrect value for rle_list[103], expected 9, is "
       << last_msg_->rle_list[103];
-  EXPECT_EQ(last_msg_->rle_list[104], 19)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[104])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[104])),
+            19)
       << "incorrect value for rle_list[104], expected 19, is "
       << last_msg_->rle_list[104];
-  EXPECT_EQ(last_msg_->rle_list[105], 153)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[105])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[105])),
+            153)
       << "incorrect value for rle_list[105], expected 153, is "
       << last_msg_->rle_list[105];
-  EXPECT_EQ(last_msg_->rle_list[106], 44)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[106])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[106])),
+            44)
       << "incorrect value for rle_list[106], expected 44, is "
       << last_msg_->rle_list[106];
-  EXPECT_EQ(last_msg_->rle_list[107], 35)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[107])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[107])),
+            35)
       << "incorrect value for rle_list[107], expected 35, is "
       << last_msg_->rle_list[107];
-  EXPECT_EQ(last_msg_->rle_list[108], 126)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[108])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[108])),
+            126)
       << "incorrect value for rle_list[108], expected 126, is "
       << last_msg_->rle_list[108];
-  EXPECT_EQ(last_msg_->rle_list[109], 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[109])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[109])),
+            14)
       << "incorrect value for rle_list[109], expected 14, is "
       << last_msg_->rle_list[109];
-  EXPECT_EQ(last_msg_->rle_list[110], 217)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[110])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[110])),
+            217)
       << "incorrect value for rle_list[110], expected 217, is "
       << last_msg_->rle_list[110];
-  EXPECT_EQ(last_msg_->rle_list[111], 65)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[111])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[111])),
+            65)
       << "incorrect value for rle_list[111], expected 65, is "
       << last_msg_->rle_list[111];
-  EXPECT_EQ(last_msg_->rle_list[112], 116)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[112])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[112])),
+            116)
       << "incorrect value for rle_list[112], expected 116, is "
       << last_msg_->rle_list[112];
-  EXPECT_EQ(last_msg_->rle_list[113], 26)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[113])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[113])),
+            26)
       << "incorrect value for rle_list[113], expected 26, is "
       << last_msg_->rle_list[113];
-  EXPECT_EQ(last_msg_->rle_list[114], 139)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[114])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[114])),
+            139)
       << "incorrect value for rle_list[114], expected 139, is "
       << last_msg_->rle_list[114];
-  EXPECT_EQ(last_msg_->rle_list[115], 122)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[115])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[115])),
+            122)
       << "incorrect value for rle_list[115], expected 122, is "
       << last_msg_->rle_list[115];
-  EXPECT_EQ(last_msg_->rle_list[116], 114)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[116])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[116])),
+            114)
       << "incorrect value for rle_list[116], expected 114, is "
       << last_msg_->rle_list[116];
-  EXPECT_EQ(last_msg_->rle_list[117], 90)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[117])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[117])),
+            90)
       << "incorrect value for rle_list[117], expected 90, is "
       << last_msg_->rle_list[117];
-  EXPECT_EQ(last_msg_->rle_list[118], 124)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[118])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[118])),
+            124)
       << "incorrect value for rle_list[118], expected 124, is "
       << last_msg_->rle_list[118];
-  EXPECT_EQ(last_msg_->rle_list[119], 81)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[119])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[119])),
+            81)
       << "incorrect value for rle_list[119], expected 81, is "
       << last_msg_->rle_list[119];
-  EXPECT_EQ(last_msg_->rle_list[120], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[120])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[120])),
+            0)
       << "incorrect value for rle_list[120], expected 0, is "
       << last_msg_->rle_list[120];
-  EXPECT_EQ(last_msg_->rle_list[121], 186)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[121])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[121])),
+            186)
       << "incorrect value for rle_list[121], expected 186, is "
       << last_msg_->rle_list[121];
-  EXPECT_EQ(last_msg_->rle_list[122], 246)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[122])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[122])),
+            246)
       << "incorrect value for rle_list[122], expected 246, is "
       << last_msg_->rle_list[122];
-  EXPECT_EQ(last_msg_->rle_list[123], 46)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[123])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[123])),
+            46)
       << "incorrect value for rle_list[123], expected 46, is "
       << last_msg_->rle_list[123];
-  EXPECT_EQ(last_msg_->rle_list[124], 98)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[124])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[124])),
+            98)
       << "incorrect value for rle_list[124], expected 98, is "
       << last_msg_->rle_list[124];
-  EXPECT_EQ(last_msg_->rle_list[125], 179)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[125])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[125])),
+            179)
       << "incorrect value for rle_list[125], expected 179, is "
       << last_msg_->rle_list[125];
-  EXPECT_EQ(last_msg_->rle_list[126], 243)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[126])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[126])),
+            243)
       << "incorrect value for rle_list[126], expected 243, is "
       << last_msg_->rle_list[126];
-  EXPECT_EQ(last_msg_->rle_list[127], 198)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[127])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[127])),
+            198)
       << "incorrect value for rle_list[127], expected 198, is "
       << last_msg_->rle_list[127];
-  EXPECT_EQ(last_msg_->rle_list[128], 217)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[128])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[128])),
+            217)
       << "incorrect value for rle_list[128], expected 217, is "
       << last_msg_->rle_list[128];
-  EXPECT_EQ(last_msg_->rle_list[129], 36)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[129])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[129])),
+            36)
       << "incorrect value for rle_list[129], expected 36, is "
       << last_msg_->rle_list[129];
-  EXPECT_EQ(last_msg_->rle_list[130], 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[130])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[130])),
+            30)
       << "incorrect value for rle_list[130], expected 30, is "
       << last_msg_->rle_list[130];
-  EXPECT_EQ(last_msg_->rle_list[131], 202)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[131])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[131])),
+            202)
       << "incorrect value for rle_list[131], expected 202, is "
       << last_msg_->rle_list[131];
-  EXPECT_EQ(last_msg_->rle_list[132], 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[132])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[132])),
+            12)
       << "incorrect value for rle_list[132], expected 12, is "
       << last_msg_->rle_list[132];
-  EXPECT_EQ(last_msg_->rle_list[133], 135)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[133])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[133])),
+            135)
       << "incorrect value for rle_list[133], expected 135, is "
       << last_msg_->rle_list[133];
-  EXPECT_EQ(last_msg_->rle_list[134], 61)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[134])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[134])),
+            61)
       << "incorrect value for rle_list[134], expected 61, is "
       << last_msg_->rle_list[134];
-  EXPECT_EQ(last_msg_->rle_list[135], 42)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[135])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[135])),
+            42)
       << "incorrect value for rle_list[135], expected 42, is "
       << last_msg_->rle_list[135];
-  EXPECT_EQ(last_msg_->rle_list[136], 150)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[136])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[136])),
+            150)
       << "incorrect value for rle_list[136], expected 150, is "
       << last_msg_->rle_list[136];
-  EXPECT_EQ(last_msg_->rle_list[137], 221)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[137])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[137])),
+            221)
       << "incorrect value for rle_list[137], expected 221, is "
       << last_msg_->rle_list[137];
-  EXPECT_EQ(last_msg_->rle_list[138], 102)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[138])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[138])),
+            102)
       << "incorrect value for rle_list[138], expected 102, is "
       << last_msg_->rle_list[138];
-  EXPECT_EQ(last_msg_->rle_list[139], 83)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[139])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[139])),
+            83)
       << "incorrect value for rle_list[139], expected 83, is "
       << last_msg_->rle_list[139];
-  EXPECT_EQ(last_msg_->rle_list[140], 179)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[140])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[140])),
+            179)
       << "incorrect value for rle_list[140], expected 179, is "
       << last_msg_->rle_list[140];
-  EXPECT_EQ(last_msg_->rle_list[141], 43)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[141])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[141])),
+            43)
       << "incorrect value for rle_list[141], expected 43, is "
       << last_msg_->rle_list[141];
-  EXPECT_EQ(last_msg_->rle_list[142], 252)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[142])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[142])),
+            252)
       << "incorrect value for rle_list[142], expected 252, is "
       << last_msg_->rle_list[142];
-  EXPECT_EQ(last_msg_->rle_list[143], 81)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[143])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[143])),
+            81)
       << "incorrect value for rle_list[143], expected 81, is "
       << last_msg_->rle_list[143];
-  EXPECT_EQ(last_msg_->rle_list[144], 62)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[144])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[144])),
+            62)
       << "incorrect value for rle_list[144], expected 62, is "
       << last_msg_->rle_list[144];
-  EXPECT_EQ(last_msg_->rle_list[145], 126)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[145])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[145])),
+            126)
       << "incorrect value for rle_list[145], expected 126, is "
       << last_msg_->rle_list[145];
-  EXPECT_EQ(last_msg_->rle_list[146], 204)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[146])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[146])),
+            204)
       << "incorrect value for rle_list[146], expected 204, is "
       << last_msg_->rle_list[146];
-  EXPECT_EQ(last_msg_->rle_list[147], 195)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[147])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[147])),
+            195)
       << "incorrect value for rle_list[147], expected 195, is "
       << last_msg_->rle_list[147];
-  EXPECT_EQ(last_msg_->rle_list[148], 238)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[148])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[148])),
+            238)
       << "incorrect value for rle_list[148], expected 238, is "
       << last_msg_->rle_list[148];
-  EXPECT_EQ(last_msg_->rle_list[149], 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[149])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[149])),
+            18)
       << "incorrect value for rle_list[149], expected 18, is "
       << last_msg_->rle_list[149];
-  EXPECT_EQ(last_msg_->rle_list[150], 128)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[150])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[150])),
+            128)
       << "incorrect value for rle_list[150], expected 128, is "
       << last_msg_->rle_list[150];
-  EXPECT_EQ(last_msg_->rle_list[151], 193)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[151])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[151])),
+            193)
       << "incorrect value for rle_list[151], expected 193, is "
       << last_msg_->rle_list[151];
-  EXPECT_EQ(last_msg_->rle_list[152], 53)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[152])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[152])),
+            53)
       << "incorrect value for rle_list[152], expected 53, is "
       << last_msg_->rle_list[152];
-  EXPECT_EQ(last_msg_->rle_list[153], 94)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[153])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[153])),
+            94)
       << "incorrect value for rle_list[153], expected 94, is "
       << last_msg_->rle_list[153];
-  EXPECT_EQ(last_msg_->rle_list[154], 99)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[154])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[154])),
+            99)
       << "incorrect value for rle_list[154], expected 99, is "
       << last_msg_->rle_list[154];
-  EXPECT_EQ(last_msg_->rle_list[155], 63)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[155])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[155])),
+            63)
       << "incorrect value for rle_list[155], expected 63, is "
       << last_msg_->rle_list[155];
-  EXPECT_EQ(last_msg_->rle_list[156], 182)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[156])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[156])),
+            182)
       << "incorrect value for rle_list[156], expected 182, is "
       << last_msg_->rle_list[156];
-  EXPECT_EQ(last_msg_->rle_list[157], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[157])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[157])),
+            2)
       << "incorrect value for rle_list[157], expected 2, is "
       << last_msg_->rle_list[157];
-  EXPECT_EQ(last_msg_->rle_list[158], 186)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[158])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[158])),
+            186)
       << "incorrect value for rle_list[158], expected 186, is "
       << last_msg_->rle_list[158];
-  EXPECT_EQ(last_msg_->rle_list[159], 220)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[159])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[159])),
+            220)
       << "incorrect value for rle_list[159], expected 220, is "
       << last_msg_->rle_list[159];
-  EXPECT_EQ(last_msg_->rle_list[160], 77)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[160])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[160])),
+            77)
       << "incorrect value for rle_list[160], expected 77, is "
       << last_msg_->rle_list[160];
-  EXPECT_EQ(last_msg_->rle_list[161], 186)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[161])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[161])),
+            186)
       << "incorrect value for rle_list[161], expected 186, is "
       << last_msg_->rle_list[161];
-  EXPECT_EQ(last_msg_->rle_list[162], 224)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[162])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[162])),
+            224)
       << "incorrect value for rle_list[162], expected 224, is "
       << last_msg_->rle_list[162];
-  EXPECT_EQ(last_msg_->rle_list[163], 220)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[163])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[163])),
+            220)
       << "incorrect value for rle_list[163], expected 220, is "
       << last_msg_->rle_list[163];
-  EXPECT_EQ(last_msg_->rle_list[164], 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[164])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[164])),
+            13)
       << "incorrect value for rle_list[164], expected 13, is "
       << last_msg_->rle_list[164];
-  EXPECT_EQ(last_msg_->rle_list[165], 212)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[165])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[165])),
+            212)
       << "incorrect value for rle_list[165], expected 212, is "
       << last_msg_->rle_list[165];
-  EXPECT_EQ(last_msg_->rle_list[166], 182)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[166])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[166])),
+            182)
       << "incorrect value for rle_list[166], expected 182, is "
       << last_msg_->rle_list[166];
-  EXPECT_EQ(last_msg_->rle_list[167], 88)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[167])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[167])),
+            88)
       << "incorrect value for rle_list[167], expected 88, is "
       << last_msg_->rle_list[167];
-  EXPECT_EQ(last_msg_->rle_list[168], 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[168])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[168])),
+            15)
       << "incorrect value for rle_list[168], expected 15, is "
       << last_msg_->rle_list[168];
-  EXPECT_EQ(last_msg_->rle_list[169], 151)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[169])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[169])),
+            151)
       << "incorrect value for rle_list[169], expected 151, is "
       << last_msg_->rle_list[169];
-  EXPECT_EQ(last_msg_->rle_list[170], 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[170])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[170])),
+            5)
       << "incorrect value for rle_list[170], expected 5, is "
       << last_msg_->rle_list[170];
-  EXPECT_EQ(last_msg_->rle_list[171], 93)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[171])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[171])),
+            93)
       << "incorrect value for rle_list[171], expected 93, is "
       << last_msg_->rle_list[171];
-  EXPECT_EQ(last_msg_->rle_list[172], 251)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[172])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[172])),
+            251)
       << "incorrect value for rle_list[172], expected 251, is "
       << last_msg_->rle_list[172];
-  EXPECT_EQ(last_msg_->rle_list[173], 164)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[173])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[173])),
+            164)
       << "incorrect value for rle_list[173], expected 164, is "
       << last_msg_->rle_list[173];
-  EXPECT_EQ(last_msg_->rle_list[174], 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[174])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[174])),
+            18)
       << "incorrect value for rle_list[174], expected 18, is "
       << last_msg_->rle_list[174];
-  EXPECT_EQ(last_msg_->rle_list[175], 228)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[175])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[175])),
+            228)
       << "incorrect value for rle_list[175], expected 228, is "
       << last_msg_->rle_list[175];
-  EXPECT_EQ(last_msg_->rle_list[176], 168)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[176])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[176])),
+            168)
       << "incorrect value for rle_list[176], expected 168, is "
       << last_msg_->rle_list[176];
-  EXPECT_EQ(last_msg_->rle_list[177], 226)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[177])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[177])),
+            226)
       << "incorrect value for rle_list[177], expected 226, is "
       << last_msg_->rle_list[177];
-  EXPECT_EQ(last_msg_->rle_list[178], 195)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[178])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[178])),
+            195)
       << "incorrect value for rle_list[178], expected 195, is "
       << last_msg_->rle_list[178];
-  EXPECT_EQ(last_msg_->rle_list[179], 44)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[179])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[179])),
+            44)
       << "incorrect value for rle_list[179], expected 44, is "
       << last_msg_->rle_list[179];
-  EXPECT_EQ(last_msg_->rle_list[180], 170)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[180])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[180])),
+            170)
       << "incorrect value for rle_list[180], expected 170, is "
       << last_msg_->rle_list[180];
-  EXPECT_EQ(last_msg_->rle_list[181], 145)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[181])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[181])),
+            145)
       << "incorrect value for rle_list[181], expected 145, is "
       << last_msg_->rle_list[181];
-  EXPECT_EQ(last_msg_->rle_list[182], 36)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[182])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[182])),
+            36)
       << "incorrect value for rle_list[182], expected 36, is "
       << last_msg_->rle_list[182];
-  EXPECT_EQ(last_msg_->rle_list[183], 58)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[183])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[183])),
+            58)
       << "incorrect value for rle_list[183], expected 58, is "
       << last_msg_->rle_list[183];
-  EXPECT_EQ(last_msg_->rle_list[184], 96)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[184])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[184])),
+            96)
       << "incorrect value for rle_list[184], expected 96, is "
       << last_msg_->rle_list[184];
-  EXPECT_EQ(last_msg_->rle_list[185], 107)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[185])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[185])),
+            107)
       << "incorrect value for rle_list[185], expected 107, is "
       << last_msg_->rle_list[185];
-  EXPECT_EQ(last_msg_->rle_list[186], 144)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[186])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[186])),
+            144)
       << "incorrect value for rle_list[186], expected 144, is "
       << last_msg_->rle_list[186];
-  EXPECT_EQ(last_msg_->rle_list[187], 11)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[187])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[187])),
+            11)
       << "incorrect value for rle_list[187], expected 11, is "
       << last_msg_->rle_list[187];
-  EXPECT_EQ(last_msg_->rle_list[188], 228)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[188])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[188])),
+            228)
       << "incorrect value for rle_list[188], expected 228, is "
       << last_msg_->rle_list[188];
-  EXPECT_EQ(last_msg_->rle_list[189], 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[189])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[189])),
+            12)
       << "incorrect value for rle_list[189], expected 12, is "
       << last_msg_->rle_list[189];
-  EXPECT_EQ(last_msg_->rle_list[190], 163)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[190])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[190])),
+            163)
       << "incorrect value for rle_list[190], expected 163, is "
       << last_msg_->rle_list[190];
-  EXPECT_EQ(last_msg_->rle_list[191], 238)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[191])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[191])),
+            238)
       << "incorrect value for rle_list[191], expected 238, is "
       << last_msg_->rle_list[191];
-  EXPECT_EQ(last_msg_->rle_list[192], 247)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[192])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[192])),
+            247)
       << "incorrect value for rle_list[192], expected 247, is "
       << last_msg_->rle_list[192];
-  EXPECT_EQ(last_msg_->rle_list[193], 159)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[193])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[193])),
+            159)
       << "incorrect value for rle_list[193], expected 159, is "
       << last_msg_->rle_list[193];
-  EXPECT_EQ(last_msg_->rle_list[194], 189)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[194])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[194])),
+            189)
       << "incorrect value for rle_list[194], expected 189, is "
       << last_msg_->rle_list[194];
-  EXPECT_EQ(last_msg_->rle_list[195], 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[195])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[195])),
+            1)
       << "incorrect value for rle_list[195], expected 1, is "
       << last_msg_->rle_list[195];
-  EXPECT_EQ(last_msg_->rle_list[196], 115)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[196])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[196])),
+            115)
       << "incorrect value for rle_list[196], expected 115, is "
       << last_msg_->rle_list[196];
-  EXPECT_EQ(last_msg_->rle_list[197], 65)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[197])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[197])),
+            65)
       << "incorrect value for rle_list[197], expected 65, is "
       << last_msg_->rle_list[197];
-  EXPECT_EQ(last_msg_->rle_list[198], 202)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[198])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[198])),
+            202)
       << "incorrect value for rle_list[198], expected 202, is "
       << last_msg_->rle_list[198];
-  EXPECT_EQ(last_msg_->rle_list[199], 121)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[199])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[199])),
+            121)
       << "incorrect value for rle_list[199], expected 121, is "
       << last_msg_->rle_list[199];
-  EXPECT_EQ(last_msg_->rle_list[200], 47)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[200])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[200])),
+            47)
       << "incorrect value for rle_list[200], expected 47, is "
       << last_msg_->rle_list[200];
-  EXPECT_EQ(last_msg_->rle_list[201], 193)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[201])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[201])),
+            193)
       << "incorrect value for rle_list[201], expected 193, is "
       << last_msg_->rle_list[201];
-  EXPECT_EQ(last_msg_->rle_list[202], 11)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[202])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[202])),
+            11)
       << "incorrect value for rle_list[202], expected 11, is "
       << last_msg_->rle_list[202];
-  EXPECT_EQ(last_msg_->rle_list[203], 96)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[203])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[203])),
+            96)
       << "incorrect value for rle_list[203], expected 96, is "
       << last_msg_->rle_list[203];
-  EXPECT_EQ(last_msg_->rle_list[204], 93)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[204])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[204])),
+            93)
       << "incorrect value for rle_list[204], expected 93, is "
       << last_msg_->rle_list[204];
-  EXPECT_EQ(last_msg_->rle_list[205], 72)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[205])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[205])),
+            72)
       << "incorrect value for rle_list[205], expected 72, is "
       << last_msg_->rle_list[205];
-  EXPECT_EQ(last_msg_->rle_list[206], 81)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[206])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[206])),
+            81)
       << "incorrect value for rle_list[206], expected 81, is "
       << last_msg_->rle_list[206];
-  EXPECT_EQ(last_msg_->rle_list[207], 207)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[207])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[207])),
+            207)
       << "incorrect value for rle_list[207], expected 207, is "
       << last_msg_->rle_list[207];
-  EXPECT_EQ(last_msg_->rle_list[208], 121)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[208])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[208])),
+            121)
       << "incorrect value for rle_list[208], expected 121, is "
       << last_msg_->rle_list[208];
-  EXPECT_EQ(last_msg_->rle_list[209], 19)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[209])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[209])),
+            19)
       << "incorrect value for rle_list[209], expected 19, is "
       << last_msg_->rle_list[209];
-  EXPECT_EQ(last_msg_->rle_list[210], 151)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[210])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[210])),
+            151)
       << "incorrect value for rle_list[210], expected 151, is "
       << last_msg_->rle_list[210];
-  EXPECT_EQ(last_msg_->rle_list[211], 136)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[211])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[211])),
+            136)
       << "incorrect value for rle_list[211], expected 136, is "
       << last_msg_->rle_list[211];
-  EXPECT_EQ(last_msg_->rle_list[212], 233)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[212])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[212])),
+            233)
       << "incorrect value for rle_list[212], expected 233, is "
       << last_msg_->rle_list[212];
-  EXPECT_EQ(last_msg_->rle_list[213], 51)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[213])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[213])),
+            51)
       << "incorrect value for rle_list[213], expected 51, is "
       << last_msg_->rle_list[213];
-  EXPECT_EQ(last_msg_->rle_list[214], 133)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[214])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[214])),
+            133)
       << "incorrect value for rle_list[214], expected 133, is "
       << last_msg_->rle_list[214];
-  EXPECT_EQ(last_msg_->rle_list[215], 195)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[215])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[215])),
+            195)
       << "incorrect value for rle_list[215], expected 195, is "
       << last_msg_->rle_list[215];
-  EXPECT_EQ(last_msg_->rle_list[216], 77)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[216])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[216])),
+            77)
       << "incorrect value for rle_list[216], expected 77, is "
       << last_msg_->rle_list[216];
-  EXPECT_EQ(last_msg_->rle_list[217], 44)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[217])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[217])),
+            44)
       << "incorrect value for rle_list[217], expected 44, is "
       << last_msg_->rle_list[217];
-  EXPECT_EQ(last_msg_->rle_list[218], 147)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[218])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[218])),
+            147)
       << "incorrect value for rle_list[218], expected 147, is "
       << last_msg_->rle_list[218];
-  EXPECT_EQ(last_msg_->rle_list[219], 206)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[219])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[219])),
+            206)
       << "incorrect value for rle_list[219], expected 206, is "
       << last_msg_->rle_list[219];
-  EXPECT_EQ(last_msg_->rle_list[220], 120)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[220])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[220])),
+            120)
       << "incorrect value for rle_list[220], expected 120, is "
       << last_msg_->rle_list[220];
-  EXPECT_EQ(last_msg_->rle_list[221], 252)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[221])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[221])),
+            252)
       << "incorrect value for rle_list[221], expected 252, is "
       << last_msg_->rle_list[221];
-  EXPECT_EQ(last_msg_->rle_list[222], 77)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[222])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[222])),
+            77)
       << "incorrect value for rle_list[222], expected 77, is "
       << last_msg_->rle_list[222];
-  EXPECT_EQ(last_msg_->rle_list[223], 212)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[223])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[223])),
+            212)
       << "incorrect value for rle_list[223], expected 212, is "
       << last_msg_->rle_list[223];
-  EXPECT_EQ(last_msg_->rle_list[224], 68)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[224])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[224])),
+            68)
       << "incorrect value for rle_list[224], expected 68, is "
       << last_msg_->rle_list[224];
-  EXPECT_EQ(last_msg_->rle_list[225], 60)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[225])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[225])),
+            60)
       << "incorrect value for rle_list[225], expected 60, is "
       << last_msg_->rle_list[225];
-  EXPECT_EQ(last_msg_->rle_list[226], 206)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[226])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[226])),
+            206)
       << "incorrect value for rle_list[226], expected 206, is "
       << last_msg_->rle_list[226];
-  EXPECT_EQ(last_msg_->rle_list[227], 106)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[227])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[227])),
+            106)
       << "incorrect value for rle_list[227], expected 106, is "
       << last_msg_->rle_list[227];
-  EXPECT_EQ(last_msg_->rle_list[228], 207)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[228])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[228])),
+            207)
       << "incorrect value for rle_list[228], expected 207, is "
       << last_msg_->rle_list[228];
-  EXPECT_EQ(last_msg_->rle_list[229], 243)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[229])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[229])),
+            243)
       << "incorrect value for rle_list[229], expected 243, is "
       << last_msg_->rle_list[229];
-  EXPECT_EQ(last_msg_->rle_list[230], 158)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[230])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[230])),
+            158)
       << "incorrect value for rle_list[230], expected 158, is "
       << last_msg_->rle_list[230];
-  EXPECT_EQ(last_msg_->rle_list[231], 94)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[231])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[231])),
+            94)
       << "incorrect value for rle_list[231], expected 94, is "
       << last_msg_->rle_list[231];
-  EXPECT_EQ(last_msg_->rle_list[232], 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[232])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[232])),
+            6)
       << "incorrect value for rle_list[232], expected 6, is "
       << last_msg_->rle_list[232];
-  EXPECT_EQ(last_msg_->rle_list[233], 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[233])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[233])),
+            3)
       << "incorrect value for rle_list[233], expected 3, is "
       << last_msg_->rle_list[233];
-  EXPECT_EQ(last_msg_->rle_list[234], 205)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[234])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[234])),
+            205)
       << "incorrect value for rle_list[234], expected 205, is "
       << last_msg_->rle_list[234];
-  EXPECT_EQ(last_msg_->rle_list[235], 92)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[235])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[235])),
+            92)
       << "incorrect value for rle_list[235], expected 92, is "
       << last_msg_->rle_list[235];
-  EXPECT_EQ(last_msg_->rle_list[236], 84)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[236])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[236])),
+            84)
       << "incorrect value for rle_list[236], expected 84, is "
       << last_msg_->rle_list[236];
-  EXPECT_EQ(last_msg_->rle_list[237], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[237])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[237])),
+            2)
       << "incorrect value for rle_list[237], expected 2, is "
       << last_msg_->rle_list[237];
-  EXPECT_EQ(last_msg_->rle_list[238], 220)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[238])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[238])),
+            220)
       << "incorrect value for rle_list[238], expected 220, is "
       << last_msg_->rle_list[238];
-  EXPECT_EQ(last_msg_->rle_list[239], 50)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[239])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[239])),
+            50)
       << "incorrect value for rle_list[239], expected 50, is "
       << last_msg_->rle_list[239];
-  EXPECT_EQ(last_msg_->rle_list[240], 61)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[240])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[240])),
+            61)
       << "incorrect value for rle_list[240], expected 61, is "
       << last_msg_->rle_list[240];
-  EXPECT_EQ(last_msg_->rle_list[241], 38)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[241])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[241])),
+            38)
       << "incorrect value for rle_list[241], expected 38, is "
       << last_msg_->rle_list[241];
-  EXPECT_EQ(last_msg_->rle_list[242], 141)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[242])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[242])),
+            141)
       << "incorrect value for rle_list[242], expected 141, is "
       << last_msg_->rle_list[242];
-  EXPECT_EQ(last_msg_->rle_list[243], 117)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[243])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[243])),
+            117)
       << "incorrect value for rle_list[243], expected 117, is "
       << last_msg_->rle_list[243];
-  EXPECT_EQ(last_msg_->rle_list[244], 108)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[244])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[244])),
+            108)
       << "incorrect value for rle_list[244], expected 108, is "
       << last_msg_->rle_list[244];
-  EXPECT_EQ(last_msg_->rle_list[245], 101)
+  EXPECT_EQ(get_as<decltype(last_msg_->rle_list[245])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rle_list[245])),
+            101)
       << "incorrect value for rle_list[245], expected 101, is "
       << last_msg_->rle_list[245];
 }

--- a/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrGriddedCorrection.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrGriddedCorrection.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/ssr.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_ssr_MsgSsrGriddedCorrection0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -555,640 +562,1224 @@ TEST_F(Test_legacy_auto_check_sbp_ssr_MsgSsrGriddedCorrection0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 63940);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->header.iod_atmo, 170)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.iod_atmo)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.iod_atmo)),
+            170)
       << "incorrect value for header.iod_atmo, expected 170, is "
       << last_msg_->header.iod_atmo;
-  EXPECT_EQ(last_msg_->header.num_msgs, 48535)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.num_msgs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.num_msgs)),
+            48535)
       << "incorrect value for header.num_msgs, expected 48535, is "
       << last_msg_->header.num_msgs;
-  EXPECT_EQ(last_msg_->header.seq_num, 50380)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.seq_num)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.seq_num)),
+            50380)
       << "incorrect value for header.seq_num, expected 50380, is "
       << last_msg_->header.seq_num;
-  EXPECT_EQ(last_msg_->header.tile_id, 12951)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.tile_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.tile_id)),
+            12951)
       << "incorrect value for header.tile_id, expected 12951, is "
       << last_msg_->header.tile_id;
-  EXPECT_EQ(last_msg_->header.tile_set_id, 3605)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->header.tile_set_id)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->header.tile_set_id)),
+      3605)
       << "incorrect value for header.tile_set_id, expected 3605, is "
       << last_msg_->header.tile_set_id;
-  EXPECT_EQ(last_msg_->header.time.tow, 2535294328)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.time.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.time.tow)),
+            2535294328)
       << "incorrect value for header.time.tow, expected 2535294328, is "
       << last_msg_->header.time.tow;
-  EXPECT_EQ(last_msg_->header.time.wn, 58798)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.time.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.time.wn)),
+            58798)
       << "incorrect value for header.time.wn, expected 58798, is "
       << last_msg_->header.time.wn;
-  EXPECT_EQ(last_msg_->header.tropo_quality_indicator, 120)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.tropo_quality_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->header.tropo_quality_indicator)),
+            120)
       << "incorrect value for header.tropo_quality_indicator, expected 120, is "
       << last_msg_->header.tropo_quality_indicator;
-  EXPECT_EQ(last_msg_->header.update_interval, 105)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.update_interval)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->header.update_interval)),
+            105)
       << "incorrect value for header.update_interval, expected 105, is "
       << last_msg_->header.update_interval;
-  EXPECT_EQ(last_msg_->index, 43413)
+  EXPECT_EQ(get_as<decltype(last_msg_->index)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->index)),
+            43413)
       << "incorrect value for index, expected 43413, is " << last_msg_->index;
-  EXPECT_EQ(last_msg_->stec_residuals[0].residual, -21246)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[0].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[0].residual)),
+            -21246)
       << "incorrect value for stec_residuals[0].residual, expected -21246, is "
       << last_msg_->stec_residuals[0].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[0].stddev, 88)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[0].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[0].stddev)),
+            88)
       << "incorrect value for stec_residuals[0].stddev, expected 88, is "
       << last_msg_->stec_residuals[0].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[0].sv_id.constellation, 101)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[0].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[0].sv_id.constellation)),
+            101)
       << "incorrect value for stec_residuals[0].sv_id.constellation, expected "
          "101, is "
       << last_msg_->stec_residuals[0].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[0].sv_id.satId, 140)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[0].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[0].sv_id.satId)),
+            140)
       << "incorrect value for stec_residuals[0].sv_id.satId, expected 140, is "
       << last_msg_->stec_residuals[0].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[1].residual, -26570)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[1].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[1].residual)),
+            -26570)
       << "incorrect value for stec_residuals[1].residual, expected -26570, is "
       << last_msg_->stec_residuals[1].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[1].stddev, 115)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[1].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[1].stddev)),
+            115)
       << "incorrect value for stec_residuals[1].stddev, expected 115, is "
       << last_msg_->stec_residuals[1].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[1].sv_id.constellation, 180)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[1].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[1].sv_id.constellation)),
+            180)
       << "incorrect value for stec_residuals[1].sv_id.constellation, expected "
          "180, is "
       << last_msg_->stec_residuals[1].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[1].sv_id.satId, 70)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[1].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[1].sv_id.satId)),
+            70)
       << "incorrect value for stec_residuals[1].sv_id.satId, expected 70, is "
       << last_msg_->stec_residuals[1].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[2].residual, 6049)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[2].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[2].residual)),
+            6049)
       << "incorrect value for stec_residuals[2].residual, expected 6049, is "
       << last_msg_->stec_residuals[2].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[2].stddev, 135)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[2].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[2].stddev)),
+            135)
       << "incorrect value for stec_residuals[2].stddev, expected 135, is "
       << last_msg_->stec_residuals[2].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[2].sv_id.constellation, 201)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[2].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[2].sv_id.constellation)),
+            201)
       << "incorrect value for stec_residuals[2].sv_id.constellation, expected "
          "201, is "
       << last_msg_->stec_residuals[2].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[2].sv_id.satId, 78)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[2].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[2].sv_id.satId)),
+            78)
       << "incorrect value for stec_residuals[2].sv_id.satId, expected 78, is "
       << last_msg_->stec_residuals[2].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[3].residual, 19261)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[3].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[3].residual)),
+            19261)
       << "incorrect value for stec_residuals[3].residual, expected 19261, is "
       << last_msg_->stec_residuals[3].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[3].stddev, 178)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[3].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[3].stddev)),
+            178)
       << "incorrect value for stec_residuals[3].stddev, expected 178, is "
       << last_msg_->stec_residuals[3].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[3].sv_id.constellation, 98)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[3].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[3].sv_id.constellation)),
+            98)
       << "incorrect value for stec_residuals[3].sv_id.constellation, expected "
          "98, is "
       << last_msg_->stec_residuals[3].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[3].sv_id.satId, 152)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[3].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[3].sv_id.satId)),
+            152)
       << "incorrect value for stec_residuals[3].sv_id.satId, expected 152, is "
       << last_msg_->stec_residuals[3].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[4].residual, 14226)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[4].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[4].residual)),
+            14226)
       << "incorrect value for stec_residuals[4].residual, expected 14226, is "
       << last_msg_->stec_residuals[4].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[4].stddev, 58)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[4].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[4].stddev)),
+            58)
       << "incorrect value for stec_residuals[4].stddev, expected 58, is "
       << last_msg_->stec_residuals[4].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[4].sv_id.constellation, 229)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[4].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[4].sv_id.constellation)),
+            229)
       << "incorrect value for stec_residuals[4].sv_id.constellation, expected "
          "229, is "
       << last_msg_->stec_residuals[4].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[4].sv_id.satId, 120)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[4].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[4].sv_id.satId)),
+            120)
       << "incorrect value for stec_residuals[4].sv_id.satId, expected 120, is "
       << last_msg_->stec_residuals[4].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[5].residual, 17894)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[5].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[5].residual)),
+            17894)
       << "incorrect value for stec_residuals[5].residual, expected 17894, is "
       << last_msg_->stec_residuals[5].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[5].stddev, 172)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[5].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[5].stddev)),
+            172)
       << "incorrect value for stec_residuals[5].stddev, expected 172, is "
       << last_msg_->stec_residuals[5].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[5].sv_id.constellation, 234)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[5].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[5].sv_id.constellation)),
+            234)
       << "incorrect value for stec_residuals[5].sv_id.constellation, expected "
          "234, is "
       << last_msg_->stec_residuals[5].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[5].sv_id.satId, 169)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[5].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[5].sv_id.satId)),
+            169)
       << "incorrect value for stec_residuals[5].sv_id.satId, expected 169, is "
       << last_msg_->stec_residuals[5].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[6].residual, 22930)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[6].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[6].residual)),
+            22930)
       << "incorrect value for stec_residuals[6].residual, expected 22930, is "
       << last_msg_->stec_residuals[6].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[6].stddev, 150)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[6].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[6].stddev)),
+            150)
       << "incorrect value for stec_residuals[6].stddev, expected 150, is "
       << last_msg_->stec_residuals[6].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[6].sv_id.constellation, 127)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[6].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[6].sv_id.constellation)),
+            127)
       << "incorrect value for stec_residuals[6].sv_id.constellation, expected "
          "127, is "
       << last_msg_->stec_residuals[6].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[6].sv_id.satId, 191)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[6].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[6].sv_id.satId)),
+            191)
       << "incorrect value for stec_residuals[6].sv_id.satId, expected 191, is "
       << last_msg_->stec_residuals[6].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[7].residual, 10721)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[7].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[7].residual)),
+            10721)
       << "incorrect value for stec_residuals[7].residual, expected 10721, is "
       << last_msg_->stec_residuals[7].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[7].stddev, 17)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[7].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[7].stddev)),
+            17)
       << "incorrect value for stec_residuals[7].stddev, expected 17, is "
       << last_msg_->stec_residuals[7].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[7].sv_id.constellation, 111)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[7].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[7].sv_id.constellation)),
+            111)
       << "incorrect value for stec_residuals[7].sv_id.constellation, expected "
          "111, is "
       << last_msg_->stec_residuals[7].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[7].sv_id.satId, 91)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[7].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[7].sv_id.satId)),
+            91)
       << "incorrect value for stec_residuals[7].sv_id.satId, expected 91, is "
       << last_msg_->stec_residuals[7].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[8].residual, -22874)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[8].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[8].residual)),
+            -22874)
       << "incorrect value for stec_residuals[8].residual, expected -22874, is "
       << last_msg_->stec_residuals[8].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[8].stddev, 120)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[8].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[8].stddev)),
+            120)
       << "incorrect value for stec_residuals[8].stddev, expected 120, is "
       << last_msg_->stec_residuals[8].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[8].sv_id.constellation, 52)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[8].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[8].sv_id.constellation)),
+            52)
       << "incorrect value for stec_residuals[8].sv_id.constellation, expected "
          "52, is "
       << last_msg_->stec_residuals[8].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[8].sv_id.satId, 119)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[8].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[8].sv_id.satId)),
+            119)
       << "incorrect value for stec_residuals[8].sv_id.satId, expected 119, is "
       << last_msg_->stec_residuals[8].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[9].residual, 780)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[9].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[9].residual)),
+            780)
       << "incorrect value for stec_residuals[9].residual, expected 780, is "
       << last_msg_->stec_residuals[9].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[9].stddev, 156)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[9].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[9].stddev)),
+            156)
       << "incorrect value for stec_residuals[9].stddev, expected 156, is "
       << last_msg_->stec_residuals[9].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[9].sv_id.constellation, 221)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[9].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[9].sv_id.constellation)),
+            221)
       << "incorrect value for stec_residuals[9].sv_id.constellation, expected "
          "221, is "
       << last_msg_->stec_residuals[9].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[9].sv_id.satId, 57)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[9].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[9].sv_id.satId)),
+            57)
       << "incorrect value for stec_residuals[9].sv_id.satId, expected 57, is "
       << last_msg_->stec_residuals[9].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[10].residual, 32547)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[10].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[10].residual)),
+            32547)
       << "incorrect value for stec_residuals[10].residual, expected 32547, is "
       << last_msg_->stec_residuals[10].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[10].stddev, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[10].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[10].stddev)),
+            8)
       << "incorrect value for stec_residuals[10].stddev, expected 8, is "
       << last_msg_->stec_residuals[10].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[10].sv_id.constellation, 156)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[10].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[10].sv_id.constellation)),
+            156)
       << "incorrect value for stec_residuals[10].sv_id.constellation, expected "
          "156, is "
       << last_msg_->stec_residuals[10].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[10].sv_id.satId, 70)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[10].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[10].sv_id.satId)),
+            70)
       << "incorrect value for stec_residuals[10].sv_id.satId, expected 70, is "
       << last_msg_->stec_residuals[10].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[11].residual, 14208)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[11].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[11].residual)),
+            14208)
       << "incorrect value for stec_residuals[11].residual, expected 14208, is "
       << last_msg_->stec_residuals[11].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[11].stddev, 115)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[11].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[11].stddev)),
+            115)
       << "incorrect value for stec_residuals[11].stddev, expected 115, is "
       << last_msg_->stec_residuals[11].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[11].sv_id.constellation, 58)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[11].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[11].sv_id.constellation)),
+            58)
       << "incorrect value for stec_residuals[11].sv_id.constellation, expected "
          "58, is "
       << last_msg_->stec_residuals[11].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[11].sv_id.satId, 127)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[11].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[11].sv_id.satId)),
+            127)
       << "incorrect value for stec_residuals[11].sv_id.satId, expected 127, is "
       << last_msg_->stec_residuals[11].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[12].residual, -26246)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[12].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[12].residual)),
+            -26246)
       << "incorrect value for stec_residuals[12].residual, expected -26246, is "
       << last_msg_->stec_residuals[12].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[12].stddev, 124)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[12].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[12].stddev)),
+            124)
       << "incorrect value for stec_residuals[12].stddev, expected 124, is "
       << last_msg_->stec_residuals[12].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[12].sv_id.constellation, 157)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[12].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[12].sv_id.constellation)),
+            157)
       << "incorrect value for stec_residuals[12].sv_id.constellation, expected "
          "157, is "
       << last_msg_->stec_residuals[12].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[12].sv_id.satId, 80)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[12].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[12].sv_id.satId)),
+            80)
       << "incorrect value for stec_residuals[12].sv_id.satId, expected 80, is "
       << last_msg_->stec_residuals[12].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[13].residual, 26466)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[13].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[13].residual)),
+            26466)
       << "incorrect value for stec_residuals[13].residual, expected 26466, is "
       << last_msg_->stec_residuals[13].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[13].stddev, 204)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[13].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[13].stddev)),
+            204)
       << "incorrect value for stec_residuals[13].stddev, expected 204, is "
       << last_msg_->stec_residuals[13].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[13].sv_id.constellation, 128)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[13].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[13].sv_id.constellation)),
+            128)
       << "incorrect value for stec_residuals[13].sv_id.constellation, expected "
          "128, is "
       << last_msg_->stec_residuals[13].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[13].sv_id.satId, 27)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[13].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[13].sv_id.satId)),
+            27)
       << "incorrect value for stec_residuals[13].sv_id.satId, expected 27, is "
       << last_msg_->stec_residuals[13].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[14].residual, -7552)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[14].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[14].residual)),
+            -7552)
       << "incorrect value for stec_residuals[14].residual, expected -7552, is "
       << last_msg_->stec_residuals[14].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[14].stddev, 148)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[14].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[14].stddev)),
+            148)
       << "incorrect value for stec_residuals[14].stddev, expected 148, is "
       << last_msg_->stec_residuals[14].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[14].sv_id.constellation, 238)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[14].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[14].sv_id.constellation)),
+            238)
       << "incorrect value for stec_residuals[14].sv_id.constellation, expected "
          "238, is "
       << last_msg_->stec_residuals[14].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[14].sv_id.satId, 75)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[14].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[14].sv_id.satId)),
+            75)
       << "incorrect value for stec_residuals[14].sv_id.satId, expected 75, is "
       << last_msg_->stec_residuals[14].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[15].residual, -12072)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[15].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[15].residual)),
+            -12072)
       << "incorrect value for stec_residuals[15].residual, expected -12072, is "
       << last_msg_->stec_residuals[15].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[15].stddev, 149)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[15].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[15].stddev)),
+            149)
       << "incorrect value for stec_residuals[15].stddev, expected 149, is "
       << last_msg_->stec_residuals[15].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[15].sv_id.constellation, 61)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[15].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[15].sv_id.constellation)),
+            61)
       << "incorrect value for stec_residuals[15].sv_id.constellation, expected "
          "61, is "
       << last_msg_->stec_residuals[15].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[15].sv_id.satId, 248)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[15].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[15].sv_id.satId)),
+            248)
       << "incorrect value for stec_residuals[15].sv_id.satId, expected 248, is "
       << last_msg_->stec_residuals[15].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[16].residual, -28632)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[16].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[16].residual)),
+            -28632)
       << "incorrect value for stec_residuals[16].residual, expected -28632, is "
       << last_msg_->stec_residuals[16].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[16].stddev, 186)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[16].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[16].stddev)),
+            186)
       << "incorrect value for stec_residuals[16].stddev, expected 186, is "
       << last_msg_->stec_residuals[16].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[16].sv_id.constellation, 224)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[16].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[16].sv_id.constellation)),
+            224)
       << "incorrect value for stec_residuals[16].sv_id.constellation, expected "
          "224, is "
       << last_msg_->stec_residuals[16].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[16].sv_id.satId, 167)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[16].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[16].sv_id.satId)),
+            167)
       << "incorrect value for stec_residuals[16].sv_id.satId, expected 167, is "
       << last_msg_->stec_residuals[16].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[17].residual, -4024)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[17].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[17].residual)),
+            -4024)
       << "incorrect value for stec_residuals[17].residual, expected -4024, is "
       << last_msg_->stec_residuals[17].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[17].stddev, 100)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[17].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[17].stddev)),
+            100)
       << "incorrect value for stec_residuals[17].stddev, expected 100, is "
       << last_msg_->stec_residuals[17].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[17].sv_id.constellation, 227)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[17].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[17].sv_id.constellation)),
+            227)
       << "incorrect value for stec_residuals[17].sv_id.constellation, expected "
          "227, is "
       << last_msg_->stec_residuals[17].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[17].sv_id.satId, 157)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[17].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[17].sv_id.satId)),
+            157)
       << "incorrect value for stec_residuals[17].sv_id.satId, expected 157, is "
       << last_msg_->stec_residuals[17].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[18].residual, 2004)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[18].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[18].residual)),
+            2004)
       << "incorrect value for stec_residuals[18].residual, expected 2004, is "
       << last_msg_->stec_residuals[18].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[18].stddev, 59)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[18].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[18].stddev)),
+            59)
       << "incorrect value for stec_residuals[18].stddev, expected 59, is "
       << last_msg_->stec_residuals[18].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[18].sv_id.constellation, 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[18].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[18].sv_id.constellation)),
+            12)
       << "incorrect value for stec_residuals[18].sv_id.constellation, expected "
          "12, is "
       << last_msg_->stec_residuals[18].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[18].sv_id.satId, 35)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[18].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[18].sv_id.satId)),
+            35)
       << "incorrect value for stec_residuals[18].sv_id.satId, expected 35, is "
       << last_msg_->stec_residuals[18].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[19].residual, 6998)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[19].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[19].residual)),
+            6998)
       << "incorrect value for stec_residuals[19].residual, expected 6998, is "
       << last_msg_->stec_residuals[19].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[19].stddev, 24)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[19].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[19].stddev)),
+            24)
       << "incorrect value for stec_residuals[19].stddev, expected 24, is "
       << last_msg_->stec_residuals[19].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[19].sv_id.constellation, 81)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[19].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[19].sv_id.constellation)),
+            81)
       << "incorrect value for stec_residuals[19].sv_id.constellation, expected "
          "81, is "
       << last_msg_->stec_residuals[19].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[19].sv_id.satId, 176)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[19].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[19].sv_id.satId)),
+            176)
       << "incorrect value for stec_residuals[19].sv_id.satId, expected 176, is "
       << last_msg_->stec_residuals[19].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[20].residual, -31701)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[20].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[20].residual)),
+            -31701)
       << "incorrect value for stec_residuals[20].residual, expected -31701, is "
       << last_msg_->stec_residuals[20].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[20].stddev, 45)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[20].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[20].stddev)),
+            45)
       << "incorrect value for stec_residuals[20].stddev, expected 45, is "
       << last_msg_->stec_residuals[20].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[20].sv_id.constellation, 67)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[20].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[20].sv_id.constellation)),
+            67)
       << "incorrect value for stec_residuals[20].sv_id.constellation, expected "
          "67, is "
       << last_msg_->stec_residuals[20].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[20].sv_id.satId, 155)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[20].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[20].sv_id.satId)),
+            155)
       << "incorrect value for stec_residuals[20].sv_id.satId, expected 155, is "
       << last_msg_->stec_residuals[20].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[21].residual, 28678)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[21].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[21].residual)),
+            28678)
       << "incorrect value for stec_residuals[21].residual, expected 28678, is "
       << last_msg_->stec_residuals[21].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[21].stddev, 183)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[21].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[21].stddev)),
+            183)
       << "incorrect value for stec_residuals[21].stddev, expected 183, is "
       << last_msg_->stec_residuals[21].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[21].sv_id.constellation, 44)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[21].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[21].sv_id.constellation)),
+            44)
       << "incorrect value for stec_residuals[21].sv_id.constellation, expected "
          "44, is "
       << last_msg_->stec_residuals[21].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[21].sv_id.satId, 203)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[21].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[21].sv_id.satId)),
+            203)
       << "incorrect value for stec_residuals[21].sv_id.satId, expected 203, is "
       << last_msg_->stec_residuals[21].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[22].residual, -15793)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[22].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[22].residual)),
+            -15793)
       << "incorrect value for stec_residuals[22].residual, expected -15793, is "
       << last_msg_->stec_residuals[22].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[22].stddev, 253)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[22].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[22].stddev)),
+            253)
       << "incorrect value for stec_residuals[22].stddev, expected 253, is "
       << last_msg_->stec_residuals[22].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[22].sv_id.constellation, 176)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[22].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[22].sv_id.constellation)),
+            176)
       << "incorrect value for stec_residuals[22].sv_id.constellation, expected "
          "176, is "
       << last_msg_->stec_residuals[22].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[22].sv_id.satId, 231)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[22].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[22].sv_id.satId)),
+            231)
       << "incorrect value for stec_residuals[22].sv_id.satId, expected 231, is "
       << last_msg_->stec_residuals[22].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[23].residual, -7589)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[23].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[23].residual)),
+            -7589)
       << "incorrect value for stec_residuals[23].residual, expected -7589, is "
       << last_msg_->stec_residuals[23].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[23].stddev, 116)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[23].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[23].stddev)),
+            116)
       << "incorrect value for stec_residuals[23].stddev, expected 116, is "
       << last_msg_->stec_residuals[23].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[23].sv_id.constellation, 103)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[23].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[23].sv_id.constellation)),
+            103)
       << "incorrect value for stec_residuals[23].sv_id.constellation, expected "
          "103, is "
       << last_msg_->stec_residuals[23].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[23].sv_id.satId, 247)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[23].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[23].sv_id.satId)),
+            247)
       << "incorrect value for stec_residuals[23].sv_id.satId, expected 247, is "
       << last_msg_->stec_residuals[23].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[24].residual, -7362)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[24].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[24].residual)),
+            -7362)
       << "incorrect value for stec_residuals[24].residual, expected -7362, is "
       << last_msg_->stec_residuals[24].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[24].stddev, 240)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[24].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[24].stddev)),
+            240)
       << "incorrect value for stec_residuals[24].stddev, expected 240, is "
       << last_msg_->stec_residuals[24].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[24].sv_id.constellation, 23)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[24].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[24].sv_id.constellation)),
+            23)
       << "incorrect value for stec_residuals[24].sv_id.constellation, expected "
          "23, is "
       << last_msg_->stec_residuals[24].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[24].sv_id.satId, 148)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[24].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[24].sv_id.satId)),
+            148)
       << "incorrect value for stec_residuals[24].sv_id.satId, expected 148, is "
       << last_msg_->stec_residuals[24].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[25].residual, 4813)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[25].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[25].residual)),
+            4813)
       << "incorrect value for stec_residuals[25].residual, expected 4813, is "
       << last_msg_->stec_residuals[25].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[25].stddev, 242)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[25].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[25].stddev)),
+            242)
       << "incorrect value for stec_residuals[25].stddev, expected 242, is "
       << last_msg_->stec_residuals[25].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[25].sv_id.constellation, 219)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[25].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[25].sv_id.constellation)),
+            219)
       << "incorrect value for stec_residuals[25].sv_id.constellation, expected "
          "219, is "
       << last_msg_->stec_residuals[25].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[25].sv_id.satId, 29)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[25].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[25].sv_id.satId)),
+            29)
       << "incorrect value for stec_residuals[25].sv_id.satId, expected 29, is "
       << last_msg_->stec_residuals[25].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[26].residual, 20295)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[26].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[26].residual)),
+            20295)
       << "incorrect value for stec_residuals[26].residual, expected 20295, is "
       << last_msg_->stec_residuals[26].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[26].stddev, 37)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[26].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[26].stddev)),
+            37)
       << "incorrect value for stec_residuals[26].stddev, expected 37, is "
       << last_msg_->stec_residuals[26].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[26].sv_id.constellation, 72)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[26].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[26].sv_id.constellation)),
+            72)
       << "incorrect value for stec_residuals[26].sv_id.constellation, expected "
          "72, is "
       << last_msg_->stec_residuals[26].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[26].sv_id.satId, 207)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[26].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[26].sv_id.satId)),
+            207)
       << "incorrect value for stec_residuals[26].sv_id.satId, expected 207, is "
       << last_msg_->stec_residuals[26].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[27].residual, -13623)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[27].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[27].residual)),
+            -13623)
       << "incorrect value for stec_residuals[27].residual, expected -13623, is "
       << last_msg_->stec_residuals[27].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[27].stddev, 91)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[27].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[27].stddev)),
+            91)
       << "incorrect value for stec_residuals[27].stddev, expected 91, is "
       << last_msg_->stec_residuals[27].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[27].sv_id.constellation, 176)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[27].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[27].sv_id.constellation)),
+            176)
       << "incorrect value for stec_residuals[27].sv_id.constellation, expected "
          "176, is "
       << last_msg_->stec_residuals[27].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[27].sv_id.satId, 42)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[27].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[27].sv_id.satId)),
+            42)
       << "incorrect value for stec_residuals[27].sv_id.satId, expected 42, is "
       << last_msg_->stec_residuals[27].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[28].residual, 15250)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[28].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[28].residual)),
+            15250)
       << "incorrect value for stec_residuals[28].residual, expected 15250, is "
       << last_msg_->stec_residuals[28].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[28].stddev, 110)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[28].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[28].stddev)),
+            110)
       << "incorrect value for stec_residuals[28].stddev, expected 110, is "
       << last_msg_->stec_residuals[28].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[28].sv_id.constellation, 115)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[28].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[28].sv_id.constellation)),
+            115)
       << "incorrect value for stec_residuals[28].sv_id.constellation, expected "
          "115, is "
       << last_msg_->stec_residuals[28].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[28].sv_id.satId, 105)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[28].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[28].sv_id.satId)),
+            105)
       << "incorrect value for stec_residuals[28].sv_id.satId, expected 105, is "
       << last_msg_->stec_residuals[28].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[29].residual, -18560)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[29].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[29].residual)),
+            -18560)
       << "incorrect value for stec_residuals[29].residual, expected -18560, is "
       << last_msg_->stec_residuals[29].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[29].stddev, 185)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[29].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[29].stddev)),
+            185)
       << "incorrect value for stec_residuals[29].stddev, expected 185, is "
       << last_msg_->stec_residuals[29].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[29].sv_id.constellation, 109)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[29].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[29].sv_id.constellation)),
+            109)
       << "incorrect value for stec_residuals[29].sv_id.constellation, expected "
          "109, is "
       << last_msg_->stec_residuals[29].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[29].sv_id.satId, 44)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[29].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[29].sv_id.satId)),
+            44)
       << "incorrect value for stec_residuals[29].sv_id.satId, expected 44, is "
       << last_msg_->stec_residuals[29].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[30].residual, 23717)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[30].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[30].residual)),
+            23717)
       << "incorrect value for stec_residuals[30].residual, expected 23717, is "
       << last_msg_->stec_residuals[30].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[30].stddev, 79)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[30].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[30].stddev)),
+            79)
       << "incorrect value for stec_residuals[30].stddev, expected 79, is "
       << last_msg_->stec_residuals[30].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[30].sv_id.constellation, 31)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[30].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[30].sv_id.constellation)),
+            31)
       << "incorrect value for stec_residuals[30].sv_id.constellation, expected "
          "31, is "
       << last_msg_->stec_residuals[30].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[30].sv_id.satId, 67)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[30].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[30].sv_id.satId)),
+            67)
       << "incorrect value for stec_residuals[30].sv_id.satId, expected 67, is "
       << last_msg_->stec_residuals[30].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[31].residual, 1886)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[31].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[31].residual)),
+            1886)
       << "incorrect value for stec_residuals[31].residual, expected 1886, is "
       << last_msg_->stec_residuals[31].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[31].stddev, 162)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[31].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[31].stddev)),
+            162)
       << "incorrect value for stec_residuals[31].stddev, expected 162, is "
       << last_msg_->stec_residuals[31].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[31].sv_id.constellation, 180)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[31].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[31].sv_id.constellation)),
+            180)
       << "incorrect value for stec_residuals[31].sv_id.constellation, expected "
          "180, is "
       << last_msg_->stec_residuals[31].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[31].sv_id.satId, 189)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[31].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[31].sv_id.satId)),
+            189)
       << "incorrect value for stec_residuals[31].sv_id.satId, expected 189, is "
       << last_msg_->stec_residuals[31].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[32].residual, 12242)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[32].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[32].residual)),
+            12242)
       << "incorrect value for stec_residuals[32].residual, expected 12242, is "
       << last_msg_->stec_residuals[32].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[32].stddev, 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[32].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[32].stddev)),
+            7)
       << "incorrect value for stec_residuals[32].stddev, expected 7, is "
       << last_msg_->stec_residuals[32].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[32].sv_id.constellation, 156)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[32].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[32].sv_id.constellation)),
+            156)
       << "incorrect value for stec_residuals[32].sv_id.constellation, expected "
          "156, is "
       << last_msg_->stec_residuals[32].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[32].sv_id.satId, 121)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[32].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[32].sv_id.satId)),
+            121)
       << "incorrect value for stec_residuals[32].sv_id.satId, expected 121, is "
       << last_msg_->stec_residuals[32].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[33].residual, 10670)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[33].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[33].residual)),
+            10670)
       << "incorrect value for stec_residuals[33].residual, expected 10670, is "
       << last_msg_->stec_residuals[33].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[33].stddev, 241)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[33].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[33].stddev)),
+            241)
       << "incorrect value for stec_residuals[33].stddev, expected 241, is "
       << last_msg_->stec_residuals[33].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[33].sv_id.constellation, 205)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[33].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[33].sv_id.constellation)),
+            205)
       << "incorrect value for stec_residuals[33].sv_id.constellation, expected "
          "205, is "
       << last_msg_->stec_residuals[33].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[33].sv_id.satId, 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[33].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[33].sv_id.satId)),
+            7)
       << "incorrect value for stec_residuals[33].sv_id.satId, expected 7, is "
       << last_msg_->stec_residuals[33].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[34].residual, 25899)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[34].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[34].residual)),
+            25899)
       << "incorrect value for stec_residuals[34].residual, expected 25899, is "
       << last_msg_->stec_residuals[34].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[34].stddev, 186)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[34].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[34].stddev)),
+            186)
       << "incorrect value for stec_residuals[34].stddev, expected 186, is "
       << last_msg_->stec_residuals[34].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[34].sv_id.constellation, 210)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[34].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[34].sv_id.constellation)),
+            210)
       << "incorrect value for stec_residuals[34].sv_id.constellation, expected "
          "210, is "
       << last_msg_->stec_residuals[34].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[34].sv_id.satId, 129)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[34].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[34].sv_id.satId)),
+            129)
       << "incorrect value for stec_residuals[34].sv_id.satId, expected 129, is "
       << last_msg_->stec_residuals[34].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[35].residual, -2078)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[35].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[35].residual)),
+            -2078)
       << "incorrect value for stec_residuals[35].residual, expected -2078, is "
       << last_msg_->stec_residuals[35].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[35].stddev, 187)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[35].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[35].stddev)),
+            187)
       << "incorrect value for stec_residuals[35].stddev, expected 187, is "
       << last_msg_->stec_residuals[35].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[35].sv_id.constellation, 195)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[35].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[35].sv_id.constellation)),
+            195)
       << "incorrect value for stec_residuals[35].sv_id.constellation, expected "
          "195, is "
       << last_msg_->stec_residuals[35].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[35].sv_id.satId, 208)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[35].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[35].sv_id.satId)),
+            208)
       << "incorrect value for stec_residuals[35].sv_id.satId, expected 208, is "
       << last_msg_->stec_residuals[35].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[36].residual, -16264)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[36].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[36].residual)),
+            -16264)
       << "incorrect value for stec_residuals[36].residual, expected -16264, is "
       << last_msg_->stec_residuals[36].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[36].stddev, 102)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[36].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[36].stddev)),
+            102)
       << "incorrect value for stec_residuals[36].stddev, expected 102, is "
       << last_msg_->stec_residuals[36].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[36].sv_id.constellation, 160)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[36].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[36].sv_id.constellation)),
+            160)
       << "incorrect value for stec_residuals[36].sv_id.constellation, expected "
          "160, is "
       << last_msg_->stec_residuals[36].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[36].sv_id.satId, 219)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[36].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[36].sv_id.satId)),
+            219)
       << "incorrect value for stec_residuals[36].sv_id.satId, expected 219, is "
       << last_msg_->stec_residuals[36].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[37].residual, -21002)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[37].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[37].residual)),
+            -21002)
       << "incorrect value for stec_residuals[37].residual, expected -21002, is "
       << last_msg_->stec_residuals[37].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[37].stddev, 94)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[37].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[37].stddev)),
+            94)
       << "incorrect value for stec_residuals[37].stddev, expected 94, is "
       << last_msg_->stec_residuals[37].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[37].sv_id.constellation, 42)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[37].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[37].sv_id.constellation)),
+            42)
       << "incorrect value for stec_residuals[37].sv_id.constellation, expected "
          "42, is "
       << last_msg_->stec_residuals[37].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[37].sv_id.satId, 166)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[37].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[37].sv_id.satId)),
+            166)
       << "incorrect value for stec_residuals[37].sv_id.satId, expected 166, is "
       << last_msg_->stec_residuals[37].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[38].residual, 7902)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[38].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[38].residual)),
+            7902)
       << "incorrect value for stec_residuals[38].residual, expected 7902, is "
       << last_msg_->stec_residuals[38].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[38].stddev, 35)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[38].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[38].stddev)),
+            35)
       << "incorrect value for stec_residuals[38].stddev, expected 35, is "
       << last_msg_->stec_residuals[38].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[38].sv_id.constellation, 156)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[38].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[38].sv_id.constellation)),
+            156)
       << "incorrect value for stec_residuals[38].sv_id.constellation, expected "
          "156, is "
       << last_msg_->stec_residuals[38].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[38].sv_id.satId, 102)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[38].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[38].sv_id.satId)),
+            102)
       << "incorrect value for stec_residuals[38].sv_id.satId, expected 102, is "
       << last_msg_->stec_residuals[38].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[39].residual, -30275)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[39].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[39].residual)),
+            -30275)
       << "incorrect value for stec_residuals[39].residual, expected -30275, is "
       << last_msg_->stec_residuals[39].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[39].stddev, 204)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[39].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[39].stddev)),
+            204)
       << "incorrect value for stec_residuals[39].stddev, expected 204, is "
       << last_msg_->stec_residuals[39].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[39].sv_id.constellation, 64)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[39].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[39].sv_id.constellation)),
+            64)
       << "incorrect value for stec_residuals[39].sv_id.constellation, expected "
          "64, is "
       << last_msg_->stec_residuals[39].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[39].sv_id.satId, 247)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[39].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[39].sv_id.satId)),
+            247)
       << "incorrect value for stec_residuals[39].sv_id.satId, expected 247, is "
       << last_msg_->stec_residuals[39].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[40].residual, -8633)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[40].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[40].residual)),
+            -8633)
       << "incorrect value for stec_residuals[40].residual, expected -8633, is "
       << last_msg_->stec_residuals[40].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[40].stddev, 222)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[40].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[40].stddev)),
+            222)
       << "incorrect value for stec_residuals[40].stddev, expected 222, is "
       << last_msg_->stec_residuals[40].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[40].sv_id.constellation, 32)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[40].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[40].sv_id.constellation)),
+            32)
       << "incorrect value for stec_residuals[40].sv_id.constellation, expected "
          "32, is "
       << last_msg_->stec_residuals[40].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[40].sv_id.satId, 220)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[40].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[40].sv_id.satId)),
+            220)
       << "incorrect value for stec_residuals[40].sv_id.satId, expected 220, is "
       << last_msg_->stec_residuals[40].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[41].residual, 6403)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[41].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[41].residual)),
+            6403)
       << "incorrect value for stec_residuals[41].residual, expected 6403, is "
       << last_msg_->stec_residuals[41].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[41].stddev, 45)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[41].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[41].stddev)),
+            45)
       << "incorrect value for stec_residuals[41].stddev, expected 45, is "
       << last_msg_->stec_residuals[41].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[41].sv_id.constellation, 246)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[41].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[41].sv_id.constellation)),
+            246)
       << "incorrect value for stec_residuals[41].sv_id.constellation, expected "
          "246, is "
       << last_msg_->stec_residuals[41].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[41].sv_id.satId, 201)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[41].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[41].sv_id.satId)),
+            201)
       << "incorrect value for stec_residuals[41].sv_id.satId, expected 201, is "
       << last_msg_->stec_residuals[41].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[42].residual, 22643)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[42].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[42].residual)),
+            22643)
       << "incorrect value for stec_residuals[42].residual, expected 22643, is "
       << last_msg_->stec_residuals[42].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[42].stddev, 218)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[42].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[42].stddev)),
+            218)
       << "incorrect value for stec_residuals[42].stddev, expected 218, is "
       << last_msg_->stec_residuals[42].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[42].sv_id.constellation, 239)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[42].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[42].sv_id.constellation)),
+            239)
       << "incorrect value for stec_residuals[42].sv_id.constellation, expected "
          "239, is "
       << last_msg_->stec_residuals[42].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[42].sv_id.satId, 251)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[42].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[42].sv_id.satId)),
+            251)
       << "incorrect value for stec_residuals[42].sv_id.satId, expected 251, is "
       << last_msg_->stec_residuals[42].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[43].residual, 16760)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[43].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[43].residual)),
+            16760)
       << "incorrect value for stec_residuals[43].residual, expected 16760, is "
       << last_msg_->stec_residuals[43].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[43].stddev, 175)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[43].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[43].stddev)),
+            175)
       << "incorrect value for stec_residuals[43].stddev, expected 175, is "
       << last_msg_->stec_residuals[43].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[43].sv_id.constellation, 209)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[43].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[43].sv_id.constellation)),
+            209)
       << "incorrect value for stec_residuals[43].sv_id.constellation, expected "
          "209, is "
       << last_msg_->stec_residuals[43].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[43].sv_id.satId, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[43].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[43].sv_id.satId)),
+            10)
       << "incorrect value for stec_residuals[43].sv_id.satId, expected 10, is "
       << last_msg_->stec_residuals[43].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[44].residual, -20951)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[44].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[44].residual)),
+            -20951)
       << "incorrect value for stec_residuals[44].residual, expected -20951, is "
       << last_msg_->stec_residuals[44].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[44].stddev, 137)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[44].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[44].stddev)),
+            137)
       << "incorrect value for stec_residuals[44].stddev, expected 137, is "
       << last_msg_->stec_residuals[44].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[44].sv_id.constellation, 194)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[44].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[44].sv_id.constellation)),
+            194)
       << "incorrect value for stec_residuals[44].sv_id.constellation, expected "
          "194, is "
       << last_msg_->stec_residuals[44].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[44].sv_id.satId, 131)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[44].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[44].sv_id.satId)),
+            131)
       << "incorrect value for stec_residuals[44].sv_id.satId, expected 131, is "
       << last_msg_->stec_residuals[44].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[45].residual, -740)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[45].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[45].residual)),
+            -740)
       << "incorrect value for stec_residuals[45].residual, expected -740, is "
       << last_msg_->stec_residuals[45].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[45].stddev, 42)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[45].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[45].stddev)),
+            42)
       << "incorrect value for stec_residuals[45].stddev, expected 42, is "
       << last_msg_->stec_residuals[45].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[45].sv_id.constellation, 68)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[45].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[45].sv_id.constellation)),
+            68)
       << "incorrect value for stec_residuals[45].sv_id.constellation, expected "
          "68, is "
       << last_msg_->stec_residuals[45].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[45].sv_id.satId, 17)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[45].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[45].sv_id.satId)),
+            17)
       << "incorrect value for stec_residuals[45].sv_id.satId, expected 17, is "
       << last_msg_->stec_residuals[45].sv_id.satId;
-  EXPECT_EQ(last_msg_->tropo_delay_correction.hydro, -3035)
+  EXPECT_EQ(get_as<decltype(last_msg_->tropo_delay_correction.hydro)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->tropo_delay_correction.hydro)),
+            -3035)
       << "incorrect value for tropo_delay_correction.hydro, expected -3035, is "
       << last_msg_->tropo_delay_correction.hydro;
-  EXPECT_EQ(last_msg_->tropo_delay_correction.stddev, 72)
+  EXPECT_EQ(get_as<decltype(last_msg_->tropo_delay_correction.stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->tropo_delay_correction.stddev)),
+            72)
       << "incorrect value for tropo_delay_correction.stddev, expected 72, is "
       << last_msg_->tropo_delay_correction.stddev;
-  EXPECT_EQ(last_msg_->tropo_delay_correction.wet, 78)
+  EXPECT_EQ(get_as<decltype(last_msg_->tropo_delay_correction.wet)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->tropo_delay_correction.wet)),
+            78)
       << "incorrect value for tropo_delay_correction.wet, expected 78, is "
       << last_msg_->tropo_delay_correction.wet;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrGriddedCorrectionBounds.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrGriddedCorrectionBounds.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/ssr.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_ssr_MsgSsrGriddedCorrectionBounds0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -157,119 +164,221 @@ TEST_F(Test_legacy_auto_check_sbp_ssr_MsgSsrGriddedCorrectionBounds0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->grid_point_id, 1000)
+  EXPECT_EQ(get_as<decltype(last_msg_->grid_point_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->grid_point_id)),
+            1000)
       << "incorrect value for grid_point_id, expected 1000, is "
       << last_msg_->grid_point_id;
-  EXPECT_EQ(last_msg_->header.num_msgs, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.num_msgs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.num_msgs)),
+            1)
       << "incorrect value for header.num_msgs, expected 1, is "
       << last_msg_->header.num_msgs;
-  EXPECT_EQ(last_msg_->header.seq_num, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.seq_num)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.seq_num)),
+            0)
       << "incorrect value for header.seq_num, expected 0, is "
       << last_msg_->header.seq_num;
-  EXPECT_EQ(last_msg_->header.sol_id, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.sol_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.sol_id)),
+            0)
       << "incorrect value for header.sol_id, expected 0, is "
       << last_msg_->header.sol_id;
-  EXPECT_EQ(last_msg_->header.time.tow, 180)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.time.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.time.tow)),
+            180)
       << "incorrect value for header.time.tow, expected 180, is "
       << last_msg_->header.time.tow;
-  EXPECT_EQ(last_msg_->header.time.wn, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.time.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.time.wn)),
+            3)
       << "incorrect value for header.time.wn, expected 3, is "
       << last_msg_->header.time.wn;
-  EXPECT_EQ(last_msg_->header.update_interval, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.update_interval)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->header.update_interval)),
+            10)
       << "incorrect value for header.update_interval, expected 10, is "
       << last_msg_->header.update_interval;
-  EXPECT_EQ(last_msg_->n_sats, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            2)
       << "incorrect value for n_sats, expected 2, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->ssr_iod_atmo, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->ssr_iod_atmo)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ssr_iod_atmo)),
+            15)
       << "incorrect value for ssr_iod_atmo, expected 15, is "
       << last_msg_->ssr_iod_atmo;
-  EXPECT_EQ(last_msg_->stec_sat_list[0].stec_bound_mu, 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[0].stec_bound_mu)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[0].stec_bound_mu)),
+            18)
       << "incorrect value for stec_sat_list[0].stec_bound_mu, expected 18, is "
       << last_msg_->stec_sat_list[0].stec_bound_mu;
-  EXPECT_EQ(last_msg_->stec_sat_list[0].stec_bound_mu_dot, 20)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[0].stec_bound_mu_dot)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[0].stec_bound_mu_dot)),
+            20)
       << "incorrect value for stec_sat_list[0].stec_bound_mu_dot, expected 20, "
          "is "
       << last_msg_->stec_sat_list[0].stec_bound_mu_dot;
-  EXPECT_EQ(last_msg_->stec_sat_list[0].stec_bound_sig, 19)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[0].stec_bound_sig)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[0].stec_bound_sig)),
+            19)
       << "incorrect value for stec_sat_list[0].stec_bound_sig, expected 19, is "
       << last_msg_->stec_sat_list[0].stec_bound_sig;
-  EXPECT_EQ(last_msg_->stec_sat_list[0].stec_bound_sig_dot, 21)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[0].stec_bound_sig_dot)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[0].stec_bound_sig_dot)),
+            21)
       << "incorrect value for stec_sat_list[0].stec_bound_sig_dot, expected "
          "21, is "
       << last_msg_->stec_sat_list[0].stec_bound_sig_dot;
-  EXPECT_EQ(last_msg_->stec_sat_list[0].stec_residual.residual, 16)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[0].stec_residual.residual)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[0].stec_residual.residual)),
+      16)
       << "incorrect value for stec_sat_list[0].stec_residual.residual, "
          "expected 16, is "
       << last_msg_->stec_sat_list[0].stec_residual.residual;
-  EXPECT_EQ(last_msg_->stec_sat_list[0].stec_residual.stddev, 17)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[0].stec_residual.stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[0].stec_residual.stddev)),
+            17)
       << "incorrect value for stec_sat_list[0].stec_residual.stddev, expected "
          "17, is "
       << last_msg_->stec_sat_list[0].stec_residual.stddev;
-  EXPECT_EQ(last_msg_->stec_sat_list[0].stec_residual.sv_id.constellation, 10)
+  EXPECT_EQ(
+      get_as<decltype(
+          last_msg_->stec_sat_list[0].stec_residual.sv_id.constellation)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[0].stec_residual.sv_id.constellation)),
+      10)
       << "incorrect value for "
          "stec_sat_list[0].stec_residual.sv_id.constellation, expected 10, is "
       << last_msg_->stec_sat_list[0].stec_residual.sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[0].stec_residual.sv_id.satId, 5)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[0].stec_residual.sv_id.satId)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[0].stec_residual.sv_id.satId)),
+      5)
       << "incorrect value for stec_sat_list[0].stec_residual.sv_id.satId, "
          "expected 5, is "
       << last_msg_->stec_sat_list[0].stec_residual.sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[1].stec_bound_mu, 24)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[1].stec_bound_mu)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[1].stec_bound_mu)),
+            24)
       << "incorrect value for stec_sat_list[1].stec_bound_mu, expected 24, is "
       << last_msg_->stec_sat_list[1].stec_bound_mu;
-  EXPECT_EQ(last_msg_->stec_sat_list[1].stec_bound_mu_dot, 26)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[1].stec_bound_mu_dot)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[1].stec_bound_mu_dot)),
+            26)
       << "incorrect value for stec_sat_list[1].stec_bound_mu_dot, expected 26, "
          "is "
       << last_msg_->stec_sat_list[1].stec_bound_mu_dot;
-  EXPECT_EQ(last_msg_->stec_sat_list[1].stec_bound_sig, 25)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[1].stec_bound_sig)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[1].stec_bound_sig)),
+            25)
       << "incorrect value for stec_sat_list[1].stec_bound_sig, expected 25, is "
       << last_msg_->stec_sat_list[1].stec_bound_sig;
-  EXPECT_EQ(last_msg_->stec_sat_list[1].stec_bound_sig_dot, 27)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[1].stec_bound_sig_dot)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[1].stec_bound_sig_dot)),
+            27)
       << "incorrect value for stec_sat_list[1].stec_bound_sig_dot, expected "
          "27, is "
       << last_msg_->stec_sat_list[1].stec_bound_sig_dot;
-  EXPECT_EQ(last_msg_->stec_sat_list[1].stec_residual.residual, 22)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[1].stec_residual.residual)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[1].stec_residual.residual)),
+      22)
       << "incorrect value for stec_sat_list[1].stec_residual.residual, "
          "expected 22, is "
       << last_msg_->stec_sat_list[1].stec_residual.residual;
-  EXPECT_EQ(last_msg_->stec_sat_list[1].stec_residual.stddev, 23)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[1].stec_residual.stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[1].stec_residual.stddev)),
+            23)
       << "incorrect value for stec_sat_list[1].stec_residual.stddev, expected "
          "23, is "
       << last_msg_->stec_sat_list[1].stec_residual.stddev;
-  EXPECT_EQ(last_msg_->stec_sat_list[1].stec_residual.sv_id.constellation, 10)
+  EXPECT_EQ(
+      get_as<decltype(
+          last_msg_->stec_sat_list[1].stec_residual.sv_id.constellation)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[1].stec_residual.sv_id.constellation)),
+      10)
       << "incorrect value for "
          "stec_sat_list[1].stec_residual.sv_id.constellation, expected 10, is "
       << last_msg_->stec_sat_list[1].stec_residual.sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[1].stec_residual.sv_id.satId, 6)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[1].stec_residual.sv_id.satId)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[1].stec_residual.sv_id.satId)),
+      6)
       << "incorrect value for stec_sat_list[1].stec_residual.sv_id.satId, "
          "expected 6, is "
       << last_msg_->stec_sat_list[1].stec_residual.sv_id.satId;
-  EXPECT_EQ(last_msg_->tile_id, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->tile_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tile_id)),
+            10)
       << "incorrect value for tile_id, expected 10, is " << last_msg_->tile_id;
-  EXPECT_EQ(last_msg_->tile_set_id, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->tile_set_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tile_set_id)),
+            1)
       << "incorrect value for tile_set_id, expected 1, is "
       << last_msg_->tile_set_id;
-  EXPECT_EQ(last_msg_->tropo_delay_correction.hydro, 500)
+  EXPECT_EQ(get_as<decltype(last_msg_->tropo_delay_correction.hydro)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->tropo_delay_correction.hydro)),
+            500)
       << "incorrect value for tropo_delay_correction.hydro, expected 500, is "
       << last_msg_->tropo_delay_correction.hydro;
-  EXPECT_EQ(last_msg_->tropo_delay_correction.stddev, 200)
+  EXPECT_EQ(get_as<decltype(last_msg_->tropo_delay_correction.stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->tropo_delay_correction.stddev)),
+            200)
       << "incorrect value for tropo_delay_correction.stddev, expected 200, is "
       << last_msg_->tropo_delay_correction.stddev;
-  EXPECT_EQ(last_msg_->tropo_delay_correction.wet, 100)
+  EXPECT_EQ(get_as<decltype(last_msg_->tropo_delay_correction.wet)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->tropo_delay_correction.wet)),
+            100)
       << "incorrect value for tropo_delay_correction.wet, expected 100, is "
       << last_msg_->tropo_delay_correction.wet;
-  EXPECT_EQ(last_msg_->tropo_qi, 39)
+  EXPECT_EQ(get_as<decltype(last_msg_->tropo_qi)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tropo_qi)),
+            39)
       << "incorrect value for tropo_qi, expected 39, is "
       << last_msg_->tropo_qi;
-  EXPECT_EQ(last_msg_->tropo_v_hydro_bound_mu, 150)
+  EXPECT_EQ(get_as<decltype(last_msg_->tropo_v_hydro_bound_mu)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->tropo_v_hydro_bound_mu)),
+            150)
       << "incorrect value for tropo_v_hydro_bound_mu, expected 150, is "
       << last_msg_->tropo_v_hydro_bound_mu;
-  EXPECT_EQ(last_msg_->tropo_v_hydro_bound_sig, 100)
+  EXPECT_EQ(get_as<decltype(last_msg_->tropo_v_hydro_bound_sig)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->tropo_v_hydro_bound_sig)),
+            100)
       << "incorrect value for tropo_v_hydro_bound_sig, expected 100, is "
       << last_msg_->tropo_v_hydro_bound_sig;
-  EXPECT_EQ(last_msg_->tropo_v_wet_bound_mu, 150)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->tropo_v_wet_bound_mu)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->tropo_v_wet_bound_mu)),
+      150)
       << "incorrect value for tropo_v_wet_bound_mu, expected 150, is "
       << last_msg_->tropo_v_wet_bound_mu;
-  EXPECT_EQ(last_msg_->tropo_v_wet_bound_sig, 100)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->tropo_v_wet_bound_sig)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->tropo_v_wet_bound_sig)),
+      100)
       << "incorrect value for tropo_v_wet_bound_sig, expected 100, is "
       << last_msg_->tropo_v_wet_bound_sig;
 }
@@ -376,59 +485,105 @@ TEST_F(Test_legacy_auto_check_sbp_ssr_MsgSsrGriddedCorrectionBounds1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->grid_point_id, 1000)
+  EXPECT_EQ(get_as<decltype(last_msg_->grid_point_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->grid_point_id)),
+            1000)
       << "incorrect value for grid_point_id, expected 1000, is "
       << last_msg_->grid_point_id;
-  EXPECT_EQ(last_msg_->header.num_msgs, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.num_msgs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.num_msgs)),
+            1)
       << "incorrect value for header.num_msgs, expected 1, is "
       << last_msg_->header.num_msgs;
-  EXPECT_EQ(last_msg_->header.seq_num, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.seq_num)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.seq_num)),
+            0)
       << "incorrect value for header.seq_num, expected 0, is "
       << last_msg_->header.seq_num;
-  EXPECT_EQ(last_msg_->header.sol_id, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.sol_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.sol_id)),
+            0)
       << "incorrect value for header.sol_id, expected 0, is "
       << last_msg_->header.sol_id;
-  EXPECT_EQ(last_msg_->header.time.tow, 180)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.time.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.time.tow)),
+            180)
       << "incorrect value for header.time.tow, expected 180, is "
       << last_msg_->header.time.tow;
-  EXPECT_EQ(last_msg_->header.time.wn, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.time.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.time.wn)),
+            3)
       << "incorrect value for header.time.wn, expected 3, is "
       << last_msg_->header.time.wn;
-  EXPECT_EQ(last_msg_->header.update_interval, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.update_interval)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->header.update_interval)),
+            10)
       << "incorrect value for header.update_interval, expected 10, is "
       << last_msg_->header.update_interval;
-  EXPECT_EQ(last_msg_->n_sats, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            0)
       << "incorrect value for n_sats, expected 0, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->ssr_iod_atmo, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->ssr_iod_atmo)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ssr_iod_atmo)),
+            15)
       << "incorrect value for ssr_iod_atmo, expected 15, is "
       << last_msg_->ssr_iod_atmo;
-  EXPECT_EQ(last_msg_->tile_id, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->tile_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tile_id)),
+            10)
       << "incorrect value for tile_id, expected 10, is " << last_msg_->tile_id;
-  EXPECT_EQ(last_msg_->tile_set_id, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->tile_set_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tile_set_id)),
+            1)
       << "incorrect value for tile_set_id, expected 1, is "
       << last_msg_->tile_set_id;
-  EXPECT_EQ(last_msg_->tropo_delay_correction.hydro, 500)
+  EXPECT_EQ(get_as<decltype(last_msg_->tropo_delay_correction.hydro)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->tropo_delay_correction.hydro)),
+            500)
       << "incorrect value for tropo_delay_correction.hydro, expected 500, is "
       << last_msg_->tropo_delay_correction.hydro;
-  EXPECT_EQ(last_msg_->tropo_delay_correction.stddev, 200)
+  EXPECT_EQ(get_as<decltype(last_msg_->tropo_delay_correction.stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->tropo_delay_correction.stddev)),
+            200)
       << "incorrect value for tropo_delay_correction.stddev, expected 200, is "
       << last_msg_->tropo_delay_correction.stddev;
-  EXPECT_EQ(last_msg_->tropo_delay_correction.wet, 100)
+  EXPECT_EQ(get_as<decltype(last_msg_->tropo_delay_correction.wet)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->tropo_delay_correction.wet)),
+            100)
       << "incorrect value for tropo_delay_correction.wet, expected 100, is "
       << last_msg_->tropo_delay_correction.wet;
-  EXPECT_EQ(last_msg_->tropo_qi, 39)
+  EXPECT_EQ(get_as<decltype(last_msg_->tropo_qi)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tropo_qi)),
+            39)
       << "incorrect value for tropo_qi, expected 39, is "
       << last_msg_->tropo_qi;
-  EXPECT_EQ(last_msg_->tropo_v_hydro_bound_mu, 150)
+  EXPECT_EQ(get_as<decltype(last_msg_->tropo_v_hydro_bound_mu)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->tropo_v_hydro_bound_mu)),
+            150)
       << "incorrect value for tropo_v_hydro_bound_mu, expected 150, is "
       << last_msg_->tropo_v_hydro_bound_mu;
-  EXPECT_EQ(last_msg_->tropo_v_hydro_bound_sig, 100)
+  EXPECT_EQ(get_as<decltype(last_msg_->tropo_v_hydro_bound_sig)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->tropo_v_hydro_bound_sig)),
+            100)
       << "incorrect value for tropo_v_hydro_bound_sig, expected 100, is "
       << last_msg_->tropo_v_hydro_bound_sig;
-  EXPECT_EQ(last_msg_->tropo_v_wet_bound_mu, 150)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->tropo_v_wet_bound_mu)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->tropo_v_wet_bound_mu)),
+      150)
       << "incorrect value for tropo_v_wet_bound_mu, expected 150, is "
       << last_msg_->tropo_v_wet_bound_mu;
-  EXPECT_EQ(last_msg_->tropo_v_wet_bound_sig, 100)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->tropo_v_wet_bound_sig)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->tropo_v_wet_bound_sig)),
+      100)
       << "incorrect value for tropo_v_wet_bound_sig, expected 100, is "
       << last_msg_->tropo_v_wet_bound_sig;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrGriddedCorrectionDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrGriddedCorrectionDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/ssr.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_ssr_MsgSsrGriddedCorrectionDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -562,647 +569,1238 @@ TEST_F(Test_legacy_auto_check_sbp_ssr_MsgSsrGriddedCorrectionDepA0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 27244);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->header.iod_atmo, 245)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.iod_atmo)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.iod_atmo)),
+            245)
       << "incorrect value for header.iod_atmo, expected 245, is "
       << last_msg_->header.iod_atmo;
-  EXPECT_EQ(last_msg_->header.num_msgs, 37695)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.num_msgs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.num_msgs)),
+            37695)
       << "incorrect value for header.num_msgs, expected 37695, is "
       << last_msg_->header.num_msgs;
-  EXPECT_EQ(last_msg_->header.seq_num, 64616)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.seq_num)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.seq_num)),
+            64616)
       << "incorrect value for header.seq_num, expected 64616, is "
       << last_msg_->header.seq_num;
-  EXPECT_EQ(last_msg_->header.time.tow, 892131748)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.time.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.time.tow)),
+            892131748)
       << "incorrect value for header.time.tow, expected 892131748, is "
       << last_msg_->header.time.tow;
-  EXPECT_EQ(last_msg_->header.time.wn, 23906)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.time.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.time.wn)),
+            23906)
       << "incorrect value for header.time.wn, expected 23906, is "
       << last_msg_->header.time.wn;
-  EXPECT_EQ(last_msg_->header.tropo_quality_indicator, 28)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.tropo_quality_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->header.tropo_quality_indicator)),
+            28)
       << "incorrect value for header.tropo_quality_indicator, expected 28, is "
       << last_msg_->header.tropo_quality_indicator;
-  EXPECT_EQ(last_msg_->header.update_interval, 133)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.update_interval)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->header.update_interval)),
+            133)
       << "incorrect value for header.update_interval, expected 133, is "
       << last_msg_->header.update_interval;
-  EXPECT_EQ(last_msg_->index, 25695)
+  EXPECT_EQ(get_as<decltype(last_msg_->index)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->index)),
+            25695)
       << "incorrect value for index, expected 25695, is " << last_msg_->index;
-  EXPECT_EQ(last_msg_->stec_residuals[0].residual, -26738)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[0].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[0].residual)),
+            -26738)
       << "incorrect value for stec_residuals[0].residual, expected -26738, is "
       << last_msg_->stec_residuals[0].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[0].stddev, 74)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[0].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[0].stddev)),
+            74)
       << "incorrect value for stec_residuals[0].stddev, expected 74, is "
       << last_msg_->stec_residuals[0].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[0].sv_id.constellation, 25)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[0].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[0].sv_id.constellation)),
+            25)
       << "incorrect value for stec_residuals[0].sv_id.constellation, expected "
          "25, is "
       << last_msg_->stec_residuals[0].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[0].sv_id.satId, 87)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[0].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[0].sv_id.satId)),
+            87)
       << "incorrect value for stec_residuals[0].sv_id.satId, expected 87, is "
       << last_msg_->stec_residuals[0].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[1].residual, 1886)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[1].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[1].residual)),
+            1886)
       << "incorrect value for stec_residuals[1].residual, expected 1886, is "
       << last_msg_->stec_residuals[1].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[1].stddev, 146)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[1].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[1].stddev)),
+            146)
       << "incorrect value for stec_residuals[1].stddev, expected 146, is "
       << last_msg_->stec_residuals[1].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[1].sv_id.constellation, 95)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[1].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[1].sv_id.constellation)),
+            95)
       << "incorrect value for stec_residuals[1].sv_id.constellation, expected "
          "95, is "
       << last_msg_->stec_residuals[1].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[1].sv_id.satId, 151)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[1].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[1].sv_id.satId)),
+            151)
       << "incorrect value for stec_residuals[1].sv_id.satId, expected 151, is "
       << last_msg_->stec_residuals[1].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[2].residual, 22183)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[2].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[2].residual)),
+            22183)
       << "incorrect value for stec_residuals[2].residual, expected 22183, is "
       << last_msg_->stec_residuals[2].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[2].stddev, 42)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[2].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[2].stddev)),
+            42)
       << "incorrect value for stec_residuals[2].stddev, expected 42, is "
       << last_msg_->stec_residuals[2].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[2].sv_id.constellation, 45)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[2].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[2].sv_id.constellation)),
+            45)
       << "incorrect value for stec_residuals[2].sv_id.constellation, expected "
          "45, is "
       << last_msg_->stec_residuals[2].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[2].sv_id.satId, 237)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[2].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[2].sv_id.satId)),
+            237)
       << "incorrect value for stec_residuals[2].sv_id.satId, expected 237, is "
       << last_msg_->stec_residuals[2].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[3].residual, -5463)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[3].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[3].residual)),
+            -5463)
       << "incorrect value for stec_residuals[3].residual, expected -5463, is "
       << last_msg_->stec_residuals[3].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[3].stddev, 220)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[3].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[3].stddev)),
+            220)
       << "incorrect value for stec_residuals[3].stddev, expected 220, is "
       << last_msg_->stec_residuals[3].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[3].sv_id.constellation, 224)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[3].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[3].sv_id.constellation)),
+            224)
       << "incorrect value for stec_residuals[3].sv_id.constellation, expected "
          "224, is "
       << last_msg_->stec_residuals[3].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[3].sv_id.satId, 116)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[3].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[3].sv_id.satId)),
+            116)
       << "incorrect value for stec_residuals[3].sv_id.satId, expected 116, is "
       << last_msg_->stec_residuals[3].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[4].residual, 3346)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[4].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[4].residual)),
+            3346)
       << "incorrect value for stec_residuals[4].residual, expected 3346, is "
       << last_msg_->stec_residuals[4].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[4].stddev, 178)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[4].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[4].stddev)),
+            178)
       << "incorrect value for stec_residuals[4].stddev, expected 178, is "
       << last_msg_->stec_residuals[4].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[4].sv_id.constellation, 176)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[4].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[4].sv_id.constellation)),
+            176)
       << "incorrect value for stec_residuals[4].sv_id.constellation, expected "
          "176, is "
       << last_msg_->stec_residuals[4].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[4].sv_id.satId, 23)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[4].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[4].sv_id.satId)),
+            23)
       << "incorrect value for stec_residuals[4].sv_id.satId, expected 23, is "
       << last_msg_->stec_residuals[4].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[5].residual, 28320)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[5].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[5].residual)),
+            28320)
       << "incorrect value for stec_residuals[5].residual, expected 28320, is "
       << last_msg_->stec_residuals[5].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[5].stddev, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[5].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[5].stddev)),
+            15)
       << "incorrect value for stec_residuals[5].stddev, expected 15, is "
       << last_msg_->stec_residuals[5].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[5].sv_id.constellation, 160)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[5].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[5].sv_id.constellation)),
+            160)
       << "incorrect value for stec_residuals[5].sv_id.constellation, expected "
          "160, is "
       << last_msg_->stec_residuals[5].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[5].sv_id.satId, 79)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[5].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[5].sv_id.satId)),
+            79)
       << "incorrect value for stec_residuals[5].sv_id.satId, expected 79, is "
       << last_msg_->stec_residuals[5].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[6].residual, -24937)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[6].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[6].residual)),
+            -24937)
       << "incorrect value for stec_residuals[6].residual, expected -24937, is "
       << last_msg_->stec_residuals[6].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[6].stddev, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[6].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[6].stddev)),
+            22)
       << "incorrect value for stec_residuals[6].stddev, expected 22, is "
       << last_msg_->stec_residuals[6].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[6].sv_id.constellation, 206)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[6].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[6].sv_id.constellation)),
+            206)
       << "incorrect value for stec_residuals[6].sv_id.constellation, expected "
          "206, is "
       << last_msg_->stec_residuals[6].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[6].sv_id.satId, 53)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[6].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[6].sv_id.satId)),
+            53)
       << "incorrect value for stec_residuals[6].sv_id.satId, expected 53, is "
       << last_msg_->stec_residuals[6].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[7].residual, -21968)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[7].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[7].residual)),
+            -21968)
       << "incorrect value for stec_residuals[7].residual, expected -21968, is "
       << last_msg_->stec_residuals[7].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[7].stddev, 82)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[7].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[7].stddev)),
+            82)
       << "incorrect value for stec_residuals[7].stddev, expected 82, is "
       << last_msg_->stec_residuals[7].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[7].sv_id.constellation, 184)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[7].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[7].sv_id.constellation)),
+            184)
       << "incorrect value for stec_residuals[7].sv_id.constellation, expected "
          "184, is "
       << last_msg_->stec_residuals[7].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[7].sv_id.satId, 117)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[7].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[7].sv_id.satId)),
+            117)
       << "incorrect value for stec_residuals[7].sv_id.satId, expected 117, is "
       << last_msg_->stec_residuals[7].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[8].residual, 17786)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[8].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[8].residual)),
+            17786)
       << "incorrect value for stec_residuals[8].residual, expected 17786, is "
       << last_msg_->stec_residuals[8].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[8].stddev, 180)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[8].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[8].stddev)),
+            180)
       << "incorrect value for stec_residuals[8].stddev, expected 180, is "
       << last_msg_->stec_residuals[8].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[8].sv_id.constellation, 53)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[8].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[8].sv_id.constellation)),
+            53)
       << "incorrect value for stec_residuals[8].sv_id.constellation, expected "
          "53, is "
       << last_msg_->stec_residuals[8].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[8].sv_id.satId, 40)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[8].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[8].sv_id.satId)),
+            40)
       << "incorrect value for stec_residuals[8].sv_id.satId, expected 40, is "
       << last_msg_->stec_residuals[8].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[9].residual, 26689)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[9].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[9].residual)),
+            26689)
       << "incorrect value for stec_residuals[9].residual, expected 26689, is "
       << last_msg_->stec_residuals[9].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[9].stddev, 244)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[9].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[9].stddev)),
+            244)
       << "incorrect value for stec_residuals[9].stddev, expected 244, is "
       << last_msg_->stec_residuals[9].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[9].sv_id.constellation, 38)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[9].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[9].sv_id.constellation)),
+            38)
       << "incorrect value for stec_residuals[9].sv_id.constellation, expected "
          "38, is "
       << last_msg_->stec_residuals[9].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[9].sv_id.satId, 110)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[9].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[9].sv_id.satId)),
+            110)
       << "incorrect value for stec_residuals[9].sv_id.satId, expected 110, is "
       << last_msg_->stec_residuals[9].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[10].residual, 22755)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[10].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[10].residual)),
+            22755)
       << "incorrect value for stec_residuals[10].residual, expected 22755, is "
       << last_msg_->stec_residuals[10].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[10].stddev, 169)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[10].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[10].stddev)),
+            169)
       << "incorrect value for stec_residuals[10].stddev, expected 169, is "
       << last_msg_->stec_residuals[10].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[10].sv_id.constellation, 238)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[10].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[10].sv_id.constellation)),
+            238)
       << "incorrect value for stec_residuals[10].sv_id.constellation, expected "
          "238, is "
       << last_msg_->stec_residuals[10].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[10].sv_id.satId, 19)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[10].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[10].sv_id.satId)),
+            19)
       << "incorrect value for stec_residuals[10].sv_id.satId, expected 19, is "
       << last_msg_->stec_residuals[10].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[11].residual, 9535)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[11].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[11].residual)),
+            9535)
       << "incorrect value for stec_residuals[11].residual, expected 9535, is "
       << last_msg_->stec_residuals[11].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[11].stddev, 183)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[11].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[11].stddev)),
+            183)
       << "incorrect value for stec_residuals[11].stddev, expected 183, is "
       << last_msg_->stec_residuals[11].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[11].sv_id.constellation, 146)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[11].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[11].sv_id.constellation)),
+            146)
       << "incorrect value for stec_residuals[11].sv_id.constellation, expected "
          "146, is "
       << last_msg_->stec_residuals[11].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[11].sv_id.satId, 164)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[11].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[11].sv_id.satId)),
+            164)
       << "incorrect value for stec_residuals[11].sv_id.satId, expected 164, is "
       << last_msg_->stec_residuals[11].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[12].residual, -22293)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[12].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[12].residual)),
+            -22293)
       << "incorrect value for stec_residuals[12].residual, expected -22293, is "
       << last_msg_->stec_residuals[12].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[12].stddev, 114)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[12].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[12].stddev)),
+            114)
       << "incorrect value for stec_residuals[12].stddev, expected 114, is "
       << last_msg_->stec_residuals[12].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[12].sv_id.constellation, 71)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[12].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[12].sv_id.constellation)),
+            71)
       << "incorrect value for stec_residuals[12].sv_id.constellation, expected "
          "71, is "
       << last_msg_->stec_residuals[12].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[12].sv_id.satId, 85)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[12].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[12].sv_id.satId)),
+            85)
       << "incorrect value for stec_residuals[12].sv_id.satId, expected 85, is "
       << last_msg_->stec_residuals[12].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[13].residual, -25379)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[13].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[13].residual)),
+            -25379)
       << "incorrect value for stec_residuals[13].residual, expected -25379, is "
       << last_msg_->stec_residuals[13].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[13].stddev, 60)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[13].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[13].stddev)),
+            60)
       << "incorrect value for stec_residuals[13].stddev, expected 60, is "
       << last_msg_->stec_residuals[13].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[13].sv_id.constellation, 105)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[13].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[13].sv_id.constellation)),
+            105)
       << "incorrect value for stec_residuals[13].sv_id.constellation, expected "
          "105, is "
       << last_msg_->stec_residuals[13].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[13].sv_id.satId, 211)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[13].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[13].sv_id.satId)),
+            211)
       << "incorrect value for stec_residuals[13].sv_id.satId, expected 211, is "
       << last_msg_->stec_residuals[13].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[14].residual, -29182)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[14].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[14].residual)),
+            -29182)
       << "incorrect value for stec_residuals[14].residual, expected -29182, is "
       << last_msg_->stec_residuals[14].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[14].stddev, 172)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[14].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[14].stddev)),
+            172)
       << "incorrect value for stec_residuals[14].stddev, expected 172, is "
       << last_msg_->stec_residuals[14].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[14].sv_id.constellation, 230)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[14].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[14].sv_id.constellation)),
+            230)
       << "incorrect value for stec_residuals[14].sv_id.constellation, expected "
          "230, is "
       << last_msg_->stec_residuals[14].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[14].sv_id.satId, 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[14].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[14].sv_id.satId)),
+            18)
       << "incorrect value for stec_residuals[14].sv_id.satId, expected 18, is "
       << last_msg_->stec_residuals[14].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[15].residual, 32289)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[15].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[15].residual)),
+            32289)
       << "incorrect value for stec_residuals[15].residual, expected 32289, is "
       << last_msg_->stec_residuals[15].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[15].stddev, 106)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[15].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[15].stddev)),
+            106)
       << "incorrect value for stec_residuals[15].stddev, expected 106, is "
       << last_msg_->stec_residuals[15].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[15].sv_id.constellation, 39)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[15].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[15].sv_id.constellation)),
+            39)
       << "incorrect value for stec_residuals[15].sv_id.constellation, expected "
          "39, is "
       << last_msg_->stec_residuals[15].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[15].sv_id.satId, 16)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[15].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[15].sv_id.satId)),
+            16)
       << "incorrect value for stec_residuals[15].sv_id.satId, expected 16, is "
       << last_msg_->stec_residuals[15].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[16].residual, 10730)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[16].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[16].residual)),
+            10730)
       << "incorrect value for stec_residuals[16].residual, expected 10730, is "
       << last_msg_->stec_residuals[16].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[16].stddev, 162)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[16].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[16].stddev)),
+            162)
       << "incorrect value for stec_residuals[16].stddev, expected 162, is "
       << last_msg_->stec_residuals[16].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[16].sv_id.constellation, 188)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[16].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[16].sv_id.constellation)),
+            188)
       << "incorrect value for stec_residuals[16].sv_id.constellation, expected "
          "188, is "
       << last_msg_->stec_residuals[16].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[16].sv_id.satId, 99)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[16].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[16].sv_id.satId)),
+            99)
       << "incorrect value for stec_residuals[16].sv_id.satId, expected 99, is "
       << last_msg_->stec_residuals[16].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[17].residual, 20707)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[17].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[17].residual)),
+            20707)
       << "incorrect value for stec_residuals[17].residual, expected 20707, is "
       << last_msg_->stec_residuals[17].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[17].stddev, 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[17].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[17].stddev)),
+            12)
       << "incorrect value for stec_residuals[17].stddev, expected 12, is "
       << last_msg_->stec_residuals[17].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[17].sv_id.constellation, 138)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[17].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[17].sv_id.constellation)),
+            138)
       << "incorrect value for stec_residuals[17].sv_id.constellation, expected "
          "138, is "
       << last_msg_->stec_residuals[17].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[17].sv_id.satId, 197)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[17].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[17].sv_id.satId)),
+            197)
       << "incorrect value for stec_residuals[17].sv_id.satId, expected 197, is "
       << last_msg_->stec_residuals[17].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[18].residual, 1518)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[18].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[18].residual)),
+            1518)
       << "incorrect value for stec_residuals[18].residual, expected 1518, is "
       << last_msg_->stec_residuals[18].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[18].stddev, 93)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[18].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[18].stddev)),
+            93)
       << "incorrect value for stec_residuals[18].stddev, expected 93, is "
       << last_msg_->stec_residuals[18].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[18].sv_id.constellation, 67)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[18].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[18].sv_id.constellation)),
+            67)
       << "incorrect value for stec_residuals[18].sv_id.constellation, expected "
          "67, is "
       << last_msg_->stec_residuals[18].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[18].sv_id.satId, 54)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[18].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[18].sv_id.satId)),
+            54)
       << "incorrect value for stec_residuals[18].sv_id.satId, expected 54, is "
       << last_msg_->stec_residuals[18].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[19].residual, 3457)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[19].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[19].residual)),
+            3457)
       << "incorrect value for stec_residuals[19].residual, expected 3457, is "
       << last_msg_->stec_residuals[19].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[19].stddev, 46)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[19].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[19].stddev)),
+            46)
       << "incorrect value for stec_residuals[19].stddev, expected 46, is "
       << last_msg_->stec_residuals[19].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[19].sv_id.constellation, 207)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[19].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[19].sv_id.constellation)),
+            207)
       << "incorrect value for stec_residuals[19].sv_id.constellation, expected "
          "207, is "
       << last_msg_->stec_residuals[19].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[19].sv_id.satId, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[19].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[19].sv_id.satId)),
+            1)
       << "incorrect value for stec_residuals[19].sv_id.satId, expected 1, is "
       << last_msg_->stec_residuals[19].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[20].residual, -18118)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[20].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[20].residual)),
+            -18118)
       << "incorrect value for stec_residuals[20].residual, expected -18118, is "
       << last_msg_->stec_residuals[20].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[20].stddev, 127)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[20].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[20].stddev)),
+            127)
       << "incorrect value for stec_residuals[20].stddev, expected 127, is "
       << last_msg_->stec_residuals[20].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[20].sv_id.constellation, 49)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[20].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[20].sv_id.constellation)),
+            49)
       << "incorrect value for stec_residuals[20].sv_id.constellation, expected "
          "49, is "
       << last_msg_->stec_residuals[20].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[20].sv_id.satId, 115)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[20].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[20].sv_id.satId)),
+            115)
       << "incorrect value for stec_residuals[20].sv_id.satId, expected 115, is "
       << last_msg_->stec_residuals[20].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[21].residual, -9888)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[21].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[21].residual)),
+            -9888)
       << "incorrect value for stec_residuals[21].residual, expected -9888, is "
       << last_msg_->stec_residuals[21].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[21].stddev, 202)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[21].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[21].stddev)),
+            202)
       << "incorrect value for stec_residuals[21].stddev, expected 202, is "
       << last_msg_->stec_residuals[21].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[21].sv_id.constellation, 200)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[21].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[21].sv_id.constellation)),
+            200)
       << "incorrect value for stec_residuals[21].sv_id.constellation, expected "
          "200, is "
       << last_msg_->stec_residuals[21].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[21].sv_id.satId, 156)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[21].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[21].sv_id.satId)),
+            156)
       << "incorrect value for stec_residuals[21].sv_id.satId, expected 156, is "
       << last_msg_->stec_residuals[21].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[22].residual, -14793)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[22].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[22].residual)),
+            -14793)
       << "incorrect value for stec_residuals[22].residual, expected -14793, is "
       << last_msg_->stec_residuals[22].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[22].stddev, 81)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[22].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[22].stddev)),
+            81)
       << "incorrect value for stec_residuals[22].stddev, expected 81, is "
       << last_msg_->stec_residuals[22].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[22].sv_id.constellation, 245)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[22].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[22].sv_id.constellation)),
+            245)
       << "incorrect value for stec_residuals[22].sv_id.constellation, expected "
          "245, is "
       << last_msg_->stec_residuals[22].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[22].sv_id.satId, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[22].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[22].sv_id.satId)),
+            15)
       << "incorrect value for stec_residuals[22].sv_id.satId, expected 15, is "
       << last_msg_->stec_residuals[22].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[23].residual, 18758)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[23].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[23].residual)),
+            18758)
       << "incorrect value for stec_residuals[23].residual, expected 18758, is "
       << last_msg_->stec_residuals[23].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[23].stddev, 82)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[23].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[23].stddev)),
+            82)
       << "incorrect value for stec_residuals[23].stddev, expected 82, is "
       << last_msg_->stec_residuals[23].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[23].sv_id.constellation, 132)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[23].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[23].sv_id.constellation)),
+            132)
       << "incorrect value for stec_residuals[23].sv_id.constellation, expected "
          "132, is "
       << last_msg_->stec_residuals[23].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[23].sv_id.satId, 218)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[23].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[23].sv_id.satId)),
+            218)
       << "incorrect value for stec_residuals[23].sv_id.satId, expected 218, is "
       << last_msg_->stec_residuals[23].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[24].residual, 3839)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[24].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[24].residual)),
+            3839)
       << "incorrect value for stec_residuals[24].residual, expected 3839, is "
       << last_msg_->stec_residuals[24].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[24].stddev, 134)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[24].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[24].stddev)),
+            134)
       << "incorrect value for stec_residuals[24].stddev, expected 134, is "
       << last_msg_->stec_residuals[24].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[24].sv_id.constellation, 26)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[24].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[24].sv_id.constellation)),
+            26)
       << "incorrect value for stec_residuals[24].sv_id.constellation, expected "
          "26, is "
       << last_msg_->stec_residuals[24].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[24].sv_id.satId, 147)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[24].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[24].sv_id.satId)),
+            147)
       << "incorrect value for stec_residuals[24].sv_id.satId, expected 147, is "
       << last_msg_->stec_residuals[24].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[25].residual, -10697)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[25].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[25].residual)),
+            -10697)
       << "incorrect value for stec_residuals[25].residual, expected -10697, is "
       << last_msg_->stec_residuals[25].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[25].stddev, 83)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[25].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[25].stddev)),
+            83)
       << "incorrect value for stec_residuals[25].stddev, expected 83, is "
       << last_msg_->stec_residuals[25].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[25].sv_id.constellation, 138)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[25].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[25].sv_id.constellation)),
+            138)
       << "incorrect value for stec_residuals[25].sv_id.constellation, expected "
          "138, is "
       << last_msg_->stec_residuals[25].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[25].sv_id.satId, 96)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[25].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[25].sv_id.satId)),
+            96)
       << "incorrect value for stec_residuals[25].sv_id.satId, expected 96, is "
       << last_msg_->stec_residuals[25].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[26].residual, 20387)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[26].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[26].residual)),
+            20387)
       << "incorrect value for stec_residuals[26].residual, expected 20387, is "
       << last_msg_->stec_residuals[26].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[26].stddev, 173)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[26].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[26].stddev)),
+            173)
       << "incorrect value for stec_residuals[26].stddev, expected 173, is "
       << last_msg_->stec_residuals[26].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[26].sv_id.constellation, 170)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[26].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[26].sv_id.constellation)),
+            170)
       << "incorrect value for stec_residuals[26].sv_id.constellation, expected "
          "170, is "
       << last_msg_->stec_residuals[26].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[26].sv_id.satId, 156)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[26].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[26].sv_id.satId)),
+            156)
       << "incorrect value for stec_residuals[26].sv_id.satId, expected 156, is "
       << last_msg_->stec_residuals[26].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[27].residual, -3789)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[27].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[27].residual)),
+            -3789)
       << "incorrect value for stec_residuals[27].residual, expected -3789, is "
       << last_msg_->stec_residuals[27].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[27].stddev, 107)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[27].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[27].stddev)),
+            107)
       << "incorrect value for stec_residuals[27].stddev, expected 107, is "
       << last_msg_->stec_residuals[27].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[27].sv_id.constellation, 115)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[27].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[27].sv_id.constellation)),
+            115)
       << "incorrect value for stec_residuals[27].sv_id.constellation, expected "
          "115, is "
       << last_msg_->stec_residuals[27].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[27].sv_id.satId, 228)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[27].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[27].sv_id.satId)),
+            228)
       << "incorrect value for stec_residuals[27].sv_id.satId, expected 228, is "
       << last_msg_->stec_residuals[27].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[28].residual, -11608)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[28].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[28].residual)),
+            -11608)
       << "incorrect value for stec_residuals[28].residual, expected -11608, is "
       << last_msg_->stec_residuals[28].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[28].stddev, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[28].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[28].stddev)),
+            10)
       << "incorrect value for stec_residuals[28].stddev, expected 10, is "
       << last_msg_->stec_residuals[28].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[28].sv_id.constellation, 112)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[28].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[28].sv_id.constellation)),
+            112)
       << "incorrect value for stec_residuals[28].sv_id.constellation, expected "
          "112, is "
       << last_msg_->stec_residuals[28].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[28].sv_id.satId, 245)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[28].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[28].sv_id.satId)),
+            245)
       << "incorrect value for stec_residuals[28].sv_id.satId, expected 245, is "
       << last_msg_->stec_residuals[28].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[29].residual, 14593)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[29].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[29].residual)),
+            14593)
       << "incorrect value for stec_residuals[29].residual, expected 14593, is "
       << last_msg_->stec_residuals[29].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[29].stddev, 108)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[29].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[29].stddev)),
+            108)
       << "incorrect value for stec_residuals[29].stddev, expected 108, is "
       << last_msg_->stec_residuals[29].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[29].sv_id.constellation, 117)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[29].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[29].sv_id.constellation)),
+            117)
       << "incorrect value for stec_residuals[29].sv_id.constellation, expected "
          "117, is "
       << last_msg_->stec_residuals[29].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[29].sv_id.satId, 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[29].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[29].sv_id.satId)),
+            5)
       << "incorrect value for stec_residuals[29].sv_id.satId, expected 5, is "
       << last_msg_->stec_residuals[29].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[30].residual, 30609)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[30].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[30].residual)),
+            30609)
       << "incorrect value for stec_residuals[30].residual, expected 30609, is "
       << last_msg_->stec_residuals[30].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[30].stddev, 226)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[30].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[30].stddev)),
+            226)
       << "incorrect value for stec_residuals[30].stddev, expected 226, is "
       << last_msg_->stec_residuals[30].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[30].sv_id.constellation, 212)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[30].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[30].sv_id.constellation)),
+            212)
       << "incorrect value for stec_residuals[30].sv_id.constellation, expected "
          "212, is "
       << last_msg_->stec_residuals[30].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[30].sv_id.satId, 248)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[30].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[30].sv_id.satId)),
+            248)
       << "incorrect value for stec_residuals[30].sv_id.satId, expected 248, is "
       << last_msg_->stec_residuals[30].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[31].residual, -13683)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[31].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[31].residual)),
+            -13683)
       << "incorrect value for stec_residuals[31].residual, expected -13683, is "
       << last_msg_->stec_residuals[31].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[31].stddev, 106)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[31].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[31].stddev)),
+            106)
       << "incorrect value for stec_residuals[31].stddev, expected 106, is "
       << last_msg_->stec_residuals[31].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[31].sv_id.constellation, 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[31].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[31].sv_id.constellation)),
+            5)
       << "incorrect value for stec_residuals[31].sv_id.constellation, expected "
          "5, is "
       << last_msg_->stec_residuals[31].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[31].sv_id.satId, 165)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[31].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[31].sv_id.satId)),
+            165)
       << "incorrect value for stec_residuals[31].sv_id.satId, expected 165, is "
       << last_msg_->stec_residuals[31].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[32].residual, 15652)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[32].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[32].residual)),
+            15652)
       << "incorrect value for stec_residuals[32].residual, expected 15652, is "
       << last_msg_->stec_residuals[32].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[32].stddev, 243)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[32].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[32].stddev)),
+            243)
       << "incorrect value for stec_residuals[32].stddev, expected 243, is "
       << last_msg_->stec_residuals[32].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[32].sv_id.constellation, 60)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[32].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[32].sv_id.constellation)),
+            60)
       << "incorrect value for stec_residuals[32].sv_id.constellation, expected "
          "60, is "
       << last_msg_->stec_residuals[32].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[32].sv_id.satId, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[32].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[32].sv_id.satId)),
+            0)
       << "incorrect value for stec_residuals[32].sv_id.satId, expected 0, is "
       << last_msg_->stec_residuals[32].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[33].residual, 3287)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[33].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[33].residual)),
+            3287)
       << "incorrect value for stec_residuals[33].residual, expected 3287, is "
       << last_msg_->stec_residuals[33].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[33].stddev, 137)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[33].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[33].stddev)),
+            137)
       << "incorrect value for stec_residuals[33].stddev, expected 137, is "
       << last_msg_->stec_residuals[33].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[33].sv_id.constellation, 216)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[33].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[33].sv_id.constellation)),
+            216)
       << "incorrect value for stec_residuals[33].sv_id.constellation, expected "
          "216, is "
       << last_msg_->stec_residuals[33].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[33].sv_id.satId, 203)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[33].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[33].sv_id.satId)),
+            203)
       << "incorrect value for stec_residuals[33].sv_id.satId, expected 203, is "
       << last_msg_->stec_residuals[33].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[34].residual, 29687)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[34].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[34].residual)),
+            29687)
       << "incorrect value for stec_residuals[34].residual, expected 29687, is "
       << last_msg_->stec_residuals[34].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[34].stddev, 152)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[34].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[34].stddev)),
+            152)
       << "incorrect value for stec_residuals[34].stddev, expected 152, is "
       << last_msg_->stec_residuals[34].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[34].sv_id.constellation, 28)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[34].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[34].sv_id.constellation)),
+            28)
       << "incorrect value for stec_residuals[34].sv_id.constellation, expected "
          "28, is "
       << last_msg_->stec_residuals[34].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[34].sv_id.satId, 16)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[34].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[34].sv_id.satId)),
+            16)
       << "incorrect value for stec_residuals[34].sv_id.satId, expected 16, is "
       << last_msg_->stec_residuals[34].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[35].residual, -6960)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[35].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[35].residual)),
+            -6960)
       << "incorrect value for stec_residuals[35].residual, expected -6960, is "
       << last_msg_->stec_residuals[35].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[35].stddev, 203)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[35].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[35].stddev)),
+            203)
       << "incorrect value for stec_residuals[35].stddev, expected 203, is "
       << last_msg_->stec_residuals[35].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[35].sv_id.constellation, 119)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[35].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[35].sv_id.constellation)),
+            119)
       << "incorrect value for stec_residuals[35].sv_id.constellation, expected "
          "119, is "
       << last_msg_->stec_residuals[35].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[35].sv_id.satId, 181)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[35].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[35].sv_id.satId)),
+            181)
       << "incorrect value for stec_residuals[35].sv_id.satId, expected 181, is "
       << last_msg_->stec_residuals[35].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[36].residual, -15193)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[36].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[36].residual)),
+            -15193)
       << "incorrect value for stec_residuals[36].residual, expected -15193, is "
       << last_msg_->stec_residuals[36].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[36].stddev, 32)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[36].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[36].stddev)),
+            32)
       << "incorrect value for stec_residuals[36].stddev, expected 32, is "
       << last_msg_->stec_residuals[36].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[36].sv_id.constellation, 34)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[36].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[36].sv_id.constellation)),
+            34)
       << "incorrect value for stec_residuals[36].sv_id.constellation, expected "
          "34, is "
       << last_msg_->stec_residuals[36].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[36].sv_id.satId, 236)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[36].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[36].sv_id.satId)),
+            236)
       << "incorrect value for stec_residuals[36].sv_id.satId, expected 236, is "
       << last_msg_->stec_residuals[36].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[37].residual, 25873)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[37].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[37].residual)),
+            25873)
       << "incorrect value for stec_residuals[37].residual, expected 25873, is "
       << last_msg_->stec_residuals[37].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[37].stddev, 200)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[37].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[37].stddev)),
+            200)
       << "incorrect value for stec_residuals[37].stddev, expected 200, is "
       << last_msg_->stec_residuals[37].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[37].sv_id.constellation, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[37].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[37].sv_id.constellation)),
+            1)
       << "incorrect value for stec_residuals[37].sv_id.constellation, expected "
          "1, is "
       << last_msg_->stec_residuals[37].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[37].sv_id.satId, 109)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[37].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[37].sv_id.satId)),
+            109)
       << "incorrect value for stec_residuals[37].sv_id.satId, expected 109, is "
       << last_msg_->stec_residuals[37].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[38].residual, -22403)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[38].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[38].residual)),
+            -22403)
       << "incorrect value for stec_residuals[38].residual, expected -22403, is "
       << last_msg_->stec_residuals[38].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[38].stddev, 137)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[38].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[38].stddev)),
+            137)
       << "incorrect value for stec_residuals[38].stddev, expected 137, is "
       << last_msg_->stec_residuals[38].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[38].sv_id.constellation, 94)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[38].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[38].sv_id.constellation)),
+            94)
       << "incorrect value for stec_residuals[38].sv_id.constellation, expected "
          "94, is "
       << last_msg_->stec_residuals[38].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[38].sv_id.satId, 25)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[38].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[38].sv_id.satId)),
+            25)
       << "incorrect value for stec_residuals[38].sv_id.satId, expected 25, is "
       << last_msg_->stec_residuals[38].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[39].residual, 7588)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[39].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[39].residual)),
+            7588)
       << "incorrect value for stec_residuals[39].residual, expected 7588, is "
       << last_msg_->stec_residuals[39].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[39].stddev, 31)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[39].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[39].stddev)),
+            31)
       << "incorrect value for stec_residuals[39].stddev, expected 31, is "
       << last_msg_->stec_residuals[39].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[39].sv_id.constellation, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[39].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[39].sv_id.constellation)),
+            4)
       << "incorrect value for stec_residuals[39].sv_id.constellation, expected "
          "4, is "
       << last_msg_->stec_residuals[39].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[39].sv_id.satId, 157)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[39].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[39].sv_id.satId)),
+            157)
       << "incorrect value for stec_residuals[39].sv_id.satId, expected 157, is "
       << last_msg_->stec_residuals[39].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[40].residual, -6840)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[40].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[40].residual)),
+            -6840)
       << "incorrect value for stec_residuals[40].residual, expected -6840, is "
       << last_msg_->stec_residuals[40].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[40].stddev, 126)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[40].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[40].stddev)),
+            126)
       << "incorrect value for stec_residuals[40].stddev, expected 126, is "
       << last_msg_->stec_residuals[40].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[40].sv_id.constellation, 132)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[40].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[40].sv_id.constellation)),
+            132)
       << "incorrect value for stec_residuals[40].sv_id.constellation, expected "
          "132, is "
       << last_msg_->stec_residuals[40].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[40].sv_id.satId, 48)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[40].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[40].sv_id.satId)),
+            48)
       << "incorrect value for stec_residuals[40].sv_id.satId, expected 48, is "
       << last_msg_->stec_residuals[40].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[41].residual, -31412)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[41].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[41].residual)),
+            -31412)
       << "incorrect value for stec_residuals[41].residual, expected -31412, is "
       << last_msg_->stec_residuals[41].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[41].stddev, 21)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[41].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[41].stddev)),
+            21)
       << "incorrect value for stec_residuals[41].stddev, expected 21, is "
       << last_msg_->stec_residuals[41].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[41].sv_id.constellation, 68)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[41].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[41].sv_id.constellation)),
+            68)
       << "incorrect value for stec_residuals[41].sv_id.constellation, expected "
          "68, is "
       << last_msg_->stec_residuals[41].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[41].sv_id.satId, 186)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[41].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[41].sv_id.satId)),
+            186)
       << "incorrect value for stec_residuals[41].sv_id.satId, expected 186, is "
       << last_msg_->stec_residuals[41].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[42].residual, -23413)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[42].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[42].residual)),
+            -23413)
       << "incorrect value for stec_residuals[42].residual, expected -23413, is "
       << last_msg_->stec_residuals[42].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[42].stddev, 148)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[42].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[42].stddev)),
+            148)
       << "incorrect value for stec_residuals[42].stddev, expected 148, is "
       << last_msg_->stec_residuals[42].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[42].sv_id.constellation, 180)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[42].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[42].sv_id.constellation)),
+            180)
       << "incorrect value for stec_residuals[42].sv_id.constellation, expected "
          "180, is "
       << last_msg_->stec_residuals[42].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[42].sv_id.satId, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[42].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[42].sv_id.satId)),
+            0)
       << "incorrect value for stec_residuals[42].sv_id.satId, expected 0, is "
       << last_msg_->stec_residuals[42].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[43].residual, 30934)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[43].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[43].residual)),
+            30934)
       << "incorrect value for stec_residuals[43].residual, expected 30934, is "
       << last_msg_->stec_residuals[43].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[43].stddev, 177)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[43].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[43].stddev)),
+            177)
       << "incorrect value for stec_residuals[43].stddev, expected 177, is "
       << last_msg_->stec_residuals[43].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[43].sv_id.constellation, 149)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[43].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[43].sv_id.constellation)),
+            149)
       << "incorrect value for stec_residuals[43].sv_id.constellation, expected "
          "149, is "
       << last_msg_->stec_residuals[43].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[43].sv_id.satId, 119)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[43].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[43].sv_id.satId)),
+            119)
       << "incorrect value for stec_residuals[43].sv_id.satId, expected 119, is "
       << last_msg_->stec_residuals[43].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[44].residual, 26960)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[44].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[44].residual)),
+            26960)
       << "incorrect value for stec_residuals[44].residual, expected 26960, is "
       << last_msg_->stec_residuals[44].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[44].stddev, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[44].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[44].stddev)),
+            10)
       << "incorrect value for stec_residuals[44].stddev, expected 10, is "
       << last_msg_->stec_residuals[44].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[44].sv_id.constellation, 80)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[44].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[44].sv_id.constellation)),
+            80)
       << "incorrect value for stec_residuals[44].sv_id.constellation, expected "
          "80, is "
       << last_msg_->stec_residuals[44].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[44].sv_id.satId, 201)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[44].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[44].sv_id.satId)),
+            201)
       << "incorrect value for stec_residuals[44].sv_id.satId, expected 201, is "
       << last_msg_->stec_residuals[44].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[45].residual, 11853)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[45].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[45].residual)),
+            11853)
       << "incorrect value for stec_residuals[45].residual, expected 11853, is "
       << last_msg_->stec_residuals[45].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[45].stddev, 233)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[45].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[45].stddev)),
+            233)
       << "incorrect value for stec_residuals[45].stddev, expected 233, is "
       << last_msg_->stec_residuals[45].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[45].sv_id.constellation, 118)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[45].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[45].sv_id.constellation)),
+            118)
       << "incorrect value for stec_residuals[45].sv_id.constellation, expected "
          "118, is "
       << last_msg_->stec_residuals[45].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[45].sv_id.satId, 136)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[45].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[45].sv_id.satId)),
+            136)
       << "incorrect value for stec_residuals[45].sv_id.satId, expected 136, is "
       << last_msg_->stec_residuals[45].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[46].residual, -25077)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[46].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[46].residual)),
+            -25077)
       << "incorrect value for stec_residuals[46].residual, expected -25077, is "
       << last_msg_->stec_residuals[46].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[46].stddev, 103)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[46].stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[46].stddev)),
+            103)
       << "incorrect value for stec_residuals[46].stddev, expected 103, is "
       << last_msg_->stec_residuals[46].stddev;
-  EXPECT_EQ(last_msg_->stec_residuals[46].sv_id.constellation, 227)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[46].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[46].sv_id.constellation)),
+            227)
       << "incorrect value for stec_residuals[46].sv_id.constellation, expected "
          "227, is "
       << last_msg_->stec_residuals[46].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[46].sv_id.satId, 233)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[46].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[46].sv_id.satId)),
+            233)
       << "incorrect value for stec_residuals[46].sv_id.satId, expected 233, is "
       << last_msg_->stec_residuals[46].sv_id.satId;
-  EXPECT_EQ(last_msg_->tropo_delay_correction.hydro, 10643)
+  EXPECT_EQ(get_as<decltype(last_msg_->tropo_delay_correction.hydro)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->tropo_delay_correction.hydro)),
+            10643)
       << "incorrect value for tropo_delay_correction.hydro, expected 10643, is "
       << last_msg_->tropo_delay_correction.hydro;
-  EXPECT_EQ(last_msg_->tropo_delay_correction.stddev, 92)
+  EXPECT_EQ(get_as<decltype(last_msg_->tropo_delay_correction.stddev)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->tropo_delay_correction.stddev)),
+            92)
       << "incorrect value for tropo_delay_correction.stddev, expected 92, is "
       << last_msg_->tropo_delay_correction.stddev;
-  EXPECT_EQ(last_msg_->tropo_delay_correction.wet, 33)
+  EXPECT_EQ(get_as<decltype(last_msg_->tropo_delay_correction.wet)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->tropo_delay_correction.wet)),
+            33)
       << "incorrect value for tropo_delay_correction.wet, expected 33, is "
       << last_msg_->tropo_delay_correction.wet;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrGriddedCorrectionNoStdDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrGriddedCorrectionNoStdDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/ssr.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_ssr_MsgSsrGriddedCorrectionNoStdDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -611,623 +618,1178 @@ TEST_F(Test_legacy_auto_check_sbp_ssr_MsgSsrGriddedCorrectionNoStdDepA0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 7270);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->header.iod_atmo, 236)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.iod_atmo)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.iod_atmo)),
+            236)
       << "incorrect value for header.iod_atmo, expected 236, is "
       << last_msg_->header.iod_atmo;
-  EXPECT_EQ(last_msg_->header.num_msgs, 62837)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.num_msgs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.num_msgs)),
+            62837)
       << "incorrect value for header.num_msgs, expected 62837, is "
       << last_msg_->header.num_msgs;
-  EXPECT_EQ(last_msg_->header.seq_num, 63555)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.seq_num)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.seq_num)),
+            63555)
       << "incorrect value for header.seq_num, expected 63555, is "
       << last_msg_->header.seq_num;
-  EXPECT_EQ(last_msg_->header.time.tow, 2837573811)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.time.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.time.tow)),
+            2837573811)
       << "incorrect value for header.time.tow, expected 2837573811, is "
       << last_msg_->header.time.tow;
-  EXPECT_EQ(last_msg_->header.time.wn, 8940)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.time.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.time.wn)),
+            8940)
       << "incorrect value for header.time.wn, expected 8940, is "
       << last_msg_->header.time.wn;
-  EXPECT_EQ(last_msg_->header.tropo_quality_indicator, 230)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.tropo_quality_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->header.tropo_quality_indicator)),
+            230)
       << "incorrect value for header.tropo_quality_indicator, expected 230, is "
       << last_msg_->header.tropo_quality_indicator;
-  EXPECT_EQ(last_msg_->header.update_interval, 233)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.update_interval)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->header.update_interval)),
+            233)
       << "incorrect value for header.update_interval, expected 233, is "
       << last_msg_->header.update_interval;
-  EXPECT_EQ(last_msg_->index, 26598)
+  EXPECT_EQ(get_as<decltype(last_msg_->index)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->index)),
+            26598)
       << "incorrect value for index, expected 26598, is " << last_msg_->index;
-  EXPECT_EQ(last_msg_->stec_residuals[0].residual, -23949)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[0].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[0].residual)),
+            -23949)
       << "incorrect value for stec_residuals[0].residual, expected -23949, is "
       << last_msg_->stec_residuals[0].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[0].sv_id.constellation, 157)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[0].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[0].sv_id.constellation)),
+            157)
       << "incorrect value for stec_residuals[0].sv_id.constellation, expected "
          "157, is "
       << last_msg_->stec_residuals[0].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[0].sv_id.satId, 231)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[0].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[0].sv_id.satId)),
+            231)
       << "incorrect value for stec_residuals[0].sv_id.satId, expected 231, is "
       << last_msg_->stec_residuals[0].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[1].residual, 27427)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[1].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[1].residual)),
+            27427)
       << "incorrect value for stec_residuals[1].residual, expected 27427, is "
       << last_msg_->stec_residuals[1].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[1].sv_id.constellation, 146)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[1].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[1].sv_id.constellation)),
+            146)
       << "incorrect value for stec_residuals[1].sv_id.constellation, expected "
          "146, is "
       << last_msg_->stec_residuals[1].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[1].sv_id.satId, 197)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[1].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[1].sv_id.satId)),
+            197)
       << "incorrect value for stec_residuals[1].sv_id.satId, expected 197, is "
       << last_msg_->stec_residuals[1].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[2].residual, 10548)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[2].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[2].residual)),
+            10548)
       << "incorrect value for stec_residuals[2].residual, expected 10548, is "
       << last_msg_->stec_residuals[2].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[2].sv_id.constellation, 109)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[2].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[2].sv_id.constellation)),
+            109)
       << "incorrect value for stec_residuals[2].sv_id.constellation, expected "
          "109, is "
       << last_msg_->stec_residuals[2].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[2].sv_id.satId, 222)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[2].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[2].sv_id.satId)),
+            222)
       << "incorrect value for stec_residuals[2].sv_id.satId, expected 222, is "
       << last_msg_->stec_residuals[2].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[3].residual, -18195)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[3].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[3].residual)),
+            -18195)
       << "incorrect value for stec_residuals[3].residual, expected -18195, is "
       << last_msg_->stec_residuals[3].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[3].sv_id.constellation, 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[3].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[3].sv_id.constellation)),
+            12)
       << "incorrect value for stec_residuals[3].sv_id.constellation, expected "
          "12, is "
       << last_msg_->stec_residuals[3].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[3].sv_id.satId, 86)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[3].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[3].sv_id.satId)),
+            86)
       << "incorrect value for stec_residuals[3].sv_id.satId, expected 86, is "
       << last_msg_->stec_residuals[3].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[4].residual, -27511)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[4].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[4].residual)),
+            -27511)
       << "incorrect value for stec_residuals[4].residual, expected -27511, is "
       << last_msg_->stec_residuals[4].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[4].sv_id.constellation, 204)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[4].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[4].sv_id.constellation)),
+            204)
       << "incorrect value for stec_residuals[4].sv_id.constellation, expected "
          "204, is "
       << last_msg_->stec_residuals[4].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[4].sv_id.satId, 65)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[4].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[4].sv_id.satId)),
+            65)
       << "incorrect value for stec_residuals[4].sv_id.satId, expected 65, is "
       << last_msg_->stec_residuals[4].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[5].residual, 11)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[5].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[5].residual)),
+            11)
       << "incorrect value for stec_residuals[5].residual, expected 11, is "
       << last_msg_->stec_residuals[5].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[5].sv_id.constellation, 183)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[5].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[5].sv_id.constellation)),
+            183)
       << "incorrect value for stec_residuals[5].sv_id.constellation, expected "
          "183, is "
       << last_msg_->stec_residuals[5].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[5].sv_id.satId, 171)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[5].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[5].sv_id.satId)),
+            171)
       << "incorrect value for stec_residuals[5].sv_id.satId, expected 171, is "
       << last_msg_->stec_residuals[5].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[6].residual, 13740)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[6].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[6].residual)),
+            13740)
       << "incorrect value for stec_residuals[6].residual, expected 13740, is "
       << last_msg_->stec_residuals[6].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[6].sv_id.constellation, 203)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[6].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[6].sv_id.constellation)),
+            203)
       << "incorrect value for stec_residuals[6].sv_id.constellation, expected "
          "203, is "
       << last_msg_->stec_residuals[6].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[6].sv_id.satId, 180)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[6].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[6].sv_id.satId)),
+            180)
       << "incorrect value for stec_residuals[6].sv_id.satId, expected 180, is "
       << last_msg_->stec_residuals[6].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[7].residual, 29626)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[7].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[7].residual)),
+            29626)
       << "incorrect value for stec_residuals[7].residual, expected 29626, is "
       << last_msg_->stec_residuals[7].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[7].sv_id.constellation, 85)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[7].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[7].sv_id.constellation)),
+            85)
       << "incorrect value for stec_residuals[7].sv_id.constellation, expected "
          "85, is "
       << last_msg_->stec_residuals[7].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[7].sv_id.satId, 196)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[7].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[7].sv_id.satId)),
+            196)
       << "incorrect value for stec_residuals[7].sv_id.satId, expected 196, is "
       << last_msg_->stec_residuals[7].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[8].residual, 7846)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[8].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[8].residual)),
+            7846)
       << "incorrect value for stec_residuals[8].residual, expected 7846, is "
       << last_msg_->stec_residuals[8].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[8].sv_id.constellation, 92)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[8].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[8].sv_id.constellation)),
+            92)
       << "incorrect value for stec_residuals[8].sv_id.constellation, expected "
          "92, is "
       << last_msg_->stec_residuals[8].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[8].sv_id.satId, 203)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[8].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[8].sv_id.satId)),
+            203)
       << "incorrect value for stec_residuals[8].sv_id.satId, expected 203, is "
       << last_msg_->stec_residuals[8].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[9].residual, 18376)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[9].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[9].residual)),
+            18376)
       << "incorrect value for stec_residuals[9].residual, expected 18376, is "
       << last_msg_->stec_residuals[9].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[9].sv_id.constellation, 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[9].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[9].sv_id.constellation)),
+            13)
       << "incorrect value for stec_residuals[9].sv_id.constellation, expected "
          "13, is "
       << last_msg_->stec_residuals[9].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[9].sv_id.satId, 42)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[9].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[9].sv_id.satId)),
+            42)
       << "incorrect value for stec_residuals[9].sv_id.satId, expected 42, is "
       << last_msg_->stec_residuals[9].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[10].residual, -24357)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[10].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[10].residual)),
+            -24357)
       << "incorrect value for stec_residuals[10].residual, expected -24357, is "
       << last_msg_->stec_residuals[10].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[10].sv_id.constellation, 137)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[10].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[10].sv_id.constellation)),
+            137)
       << "incorrect value for stec_residuals[10].sv_id.constellation, expected "
          "137, is "
       << last_msg_->stec_residuals[10].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[10].sv_id.satId, 98)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[10].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[10].sv_id.satId)),
+            98)
       << "incorrect value for stec_residuals[10].sv_id.satId, expected 98, is "
       << last_msg_->stec_residuals[10].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[11].residual, -1441)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[11].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[11].residual)),
+            -1441)
       << "incorrect value for stec_residuals[11].residual, expected -1441, is "
       << last_msg_->stec_residuals[11].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[11].sv_id.constellation, 216)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[11].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[11].sv_id.constellation)),
+            216)
       << "incorrect value for stec_residuals[11].sv_id.constellation, expected "
          "216, is "
       << last_msg_->stec_residuals[11].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[11].sv_id.satId, 95)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[11].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[11].sv_id.satId)),
+            95)
       << "incorrect value for stec_residuals[11].sv_id.satId, expected 95, is "
       << last_msg_->stec_residuals[11].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[12].residual, -10660)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[12].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[12].residual)),
+            -10660)
       << "incorrect value for stec_residuals[12].residual, expected -10660, is "
       << last_msg_->stec_residuals[12].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[12].sv_id.constellation, 196)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[12].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[12].sv_id.constellation)),
+            196)
       << "incorrect value for stec_residuals[12].sv_id.constellation, expected "
          "196, is "
       << last_msg_->stec_residuals[12].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[12].sv_id.satId, 99)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[12].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[12].sv_id.satId)),
+            99)
       << "incorrect value for stec_residuals[12].sv_id.satId, expected 99, is "
       << last_msg_->stec_residuals[12].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[13].residual, -8509)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[13].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[13].residual)),
+            -8509)
       << "incorrect value for stec_residuals[13].residual, expected -8509, is "
       << last_msg_->stec_residuals[13].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[13].sv_id.constellation, 253)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[13].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[13].sv_id.constellation)),
+            253)
       << "incorrect value for stec_residuals[13].sv_id.constellation, expected "
          "253, is "
       << last_msg_->stec_residuals[13].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[13].sv_id.satId, 159)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[13].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[13].sv_id.satId)),
+            159)
       << "incorrect value for stec_residuals[13].sv_id.satId, expected 159, is "
       << last_msg_->stec_residuals[13].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[14].residual, 16361)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[14].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[14].residual)),
+            16361)
       << "incorrect value for stec_residuals[14].residual, expected 16361, is "
       << last_msg_->stec_residuals[14].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[14].sv_id.constellation, 146)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[14].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[14].sv_id.constellation)),
+            146)
       << "incorrect value for stec_residuals[14].sv_id.constellation, expected "
          "146, is "
       << last_msg_->stec_residuals[14].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[14].sv_id.satId, 233)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[14].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[14].sv_id.satId)),
+            233)
       << "incorrect value for stec_residuals[14].sv_id.satId, expected 233, is "
       << last_msg_->stec_residuals[14].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[15].residual, 10346)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[15].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[15].residual)),
+            10346)
       << "incorrect value for stec_residuals[15].residual, expected 10346, is "
       << last_msg_->stec_residuals[15].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[15].sv_id.constellation, 24)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[15].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[15].sv_id.constellation)),
+            24)
       << "incorrect value for stec_residuals[15].sv_id.constellation, expected "
          "24, is "
       << last_msg_->stec_residuals[15].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[15].sv_id.satId, 76)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[15].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[15].sv_id.satId)),
+            76)
       << "incorrect value for stec_residuals[15].sv_id.satId, expected 76, is "
       << last_msg_->stec_residuals[15].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[16].residual, -18679)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[16].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[16].residual)),
+            -18679)
       << "incorrect value for stec_residuals[16].residual, expected -18679, is "
       << last_msg_->stec_residuals[16].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[16].sv_id.constellation, 65)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[16].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[16].sv_id.constellation)),
+            65)
       << "incorrect value for stec_residuals[16].sv_id.constellation, expected "
          "65, is "
       << last_msg_->stec_residuals[16].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[16].sv_id.satId, 253)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[16].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[16].sv_id.satId)),
+            253)
       << "incorrect value for stec_residuals[16].sv_id.satId, expected 253, is "
       << last_msg_->stec_residuals[16].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[17].residual, 15292)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[17].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[17].residual)),
+            15292)
       << "incorrect value for stec_residuals[17].residual, expected 15292, is "
       << last_msg_->stec_residuals[17].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[17].sv_id.constellation, 215)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[17].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[17].sv_id.constellation)),
+            215)
       << "incorrect value for stec_residuals[17].sv_id.constellation, expected "
          "215, is "
       << last_msg_->stec_residuals[17].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[17].sv_id.satId, 40)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[17].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[17].sv_id.satId)),
+            40)
       << "incorrect value for stec_residuals[17].sv_id.satId, expected 40, is "
       << last_msg_->stec_residuals[17].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[18].residual, 29537)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[18].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[18].residual)),
+            29537)
       << "incorrect value for stec_residuals[18].residual, expected 29537, is "
       << last_msg_->stec_residuals[18].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[18].sv_id.constellation, 69)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[18].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[18].sv_id.constellation)),
+            69)
       << "incorrect value for stec_residuals[18].sv_id.constellation, expected "
          "69, is "
       << last_msg_->stec_residuals[18].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[18].sv_id.satId, 117)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[18].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[18].sv_id.satId)),
+            117)
       << "incorrect value for stec_residuals[18].sv_id.satId, expected 117, is "
       << last_msg_->stec_residuals[18].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[19].residual, -29440)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[19].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[19].residual)),
+            -29440)
       << "incorrect value for stec_residuals[19].residual, expected -29440, is "
       << last_msg_->stec_residuals[19].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[19].sv_id.constellation, 56)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[19].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[19].sv_id.constellation)),
+            56)
       << "incorrect value for stec_residuals[19].sv_id.constellation, expected "
          "56, is "
       << last_msg_->stec_residuals[19].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[19].sv_id.satId, 60)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[19].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[19].sv_id.satId)),
+            60)
       << "incorrect value for stec_residuals[19].sv_id.satId, expected 60, is "
       << last_msg_->stec_residuals[19].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[20].residual, -24266)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[20].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[20].residual)),
+            -24266)
       << "incorrect value for stec_residuals[20].residual, expected -24266, is "
       << last_msg_->stec_residuals[20].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[20].sv_id.constellation, 171)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[20].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[20].sv_id.constellation)),
+            171)
       << "incorrect value for stec_residuals[20].sv_id.constellation, expected "
          "171, is "
       << last_msg_->stec_residuals[20].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[20].sv_id.satId, 207)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[20].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[20].sv_id.satId)),
+            207)
       << "incorrect value for stec_residuals[20].sv_id.satId, expected 207, is "
       << last_msg_->stec_residuals[20].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[21].residual, 22272)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[21].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[21].residual)),
+            22272)
       << "incorrect value for stec_residuals[21].residual, expected 22272, is "
       << last_msg_->stec_residuals[21].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[21].sv_id.constellation, 61)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[21].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[21].sv_id.constellation)),
+            61)
       << "incorrect value for stec_residuals[21].sv_id.constellation, expected "
          "61, is "
       << last_msg_->stec_residuals[21].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[21].sv_id.satId, 23)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[21].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[21].sv_id.satId)),
+            23)
       << "incorrect value for stec_residuals[21].sv_id.satId, expected 23, is "
       << last_msg_->stec_residuals[21].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[22].residual, 9303)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[22].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[22].residual)),
+            9303)
       << "incorrect value for stec_residuals[22].residual, expected 9303, is "
       << last_msg_->stec_residuals[22].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[22].sv_id.constellation, 123)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[22].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[22].sv_id.constellation)),
+            123)
       << "incorrect value for stec_residuals[22].sv_id.constellation, expected "
          "123, is "
       << last_msg_->stec_residuals[22].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[22].sv_id.satId, 230)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[22].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[22].sv_id.satId)),
+            230)
       << "incorrect value for stec_residuals[22].sv_id.satId, expected 230, is "
       << last_msg_->stec_residuals[22].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[23].residual, -23794)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[23].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[23].residual)),
+            -23794)
       << "incorrect value for stec_residuals[23].residual, expected -23794, is "
       << last_msg_->stec_residuals[23].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[23].sv_id.constellation, 255)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[23].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[23].sv_id.constellation)),
+            255)
       << "incorrect value for stec_residuals[23].sv_id.constellation, expected "
          "255, is "
       << last_msg_->stec_residuals[23].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[23].sv_id.satId, 184)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[23].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[23].sv_id.satId)),
+            184)
       << "incorrect value for stec_residuals[23].sv_id.satId, expected 184, is "
       << last_msg_->stec_residuals[23].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[24].residual, -26837)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[24].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[24].residual)),
+            -26837)
       << "incorrect value for stec_residuals[24].residual, expected -26837, is "
       << last_msg_->stec_residuals[24].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[24].sv_id.constellation, 224)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[24].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[24].sv_id.constellation)),
+            224)
       << "incorrect value for stec_residuals[24].sv_id.constellation, expected "
          "224, is "
       << last_msg_->stec_residuals[24].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[24].sv_id.satId, 187)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[24].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[24].sv_id.satId)),
+            187)
       << "incorrect value for stec_residuals[24].sv_id.satId, expected 187, is "
       << last_msg_->stec_residuals[24].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[25].residual, 14631)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[25].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[25].residual)),
+            14631)
       << "incorrect value for stec_residuals[25].residual, expected 14631, is "
       << last_msg_->stec_residuals[25].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[25].sv_id.constellation, 104)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[25].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[25].sv_id.constellation)),
+            104)
       << "incorrect value for stec_residuals[25].sv_id.constellation, expected "
          "104, is "
       << last_msg_->stec_residuals[25].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[25].sv_id.satId, 151)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[25].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[25].sv_id.satId)),
+            151)
       << "incorrect value for stec_residuals[25].sv_id.satId, expected 151, is "
       << last_msg_->stec_residuals[25].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[26].residual, -8144)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[26].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[26].residual)),
+            -8144)
       << "incorrect value for stec_residuals[26].residual, expected -8144, is "
       << last_msg_->stec_residuals[26].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[26].sv_id.constellation, 54)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[26].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[26].sv_id.constellation)),
+            54)
       << "incorrect value for stec_residuals[26].sv_id.constellation, expected "
          "54, is "
       << last_msg_->stec_residuals[26].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[26].sv_id.satId, 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[26].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[26].sv_id.satId)),
+            5)
       << "incorrect value for stec_residuals[26].sv_id.satId, expected 5, is "
       << last_msg_->stec_residuals[26].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[27].residual, 23612)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[27].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[27].residual)),
+            23612)
       << "incorrect value for stec_residuals[27].residual, expected 23612, is "
       << last_msg_->stec_residuals[27].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[27].sv_id.constellation, 129)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[27].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[27].sv_id.constellation)),
+            129)
       << "incorrect value for stec_residuals[27].sv_id.constellation, expected "
          "129, is "
       << last_msg_->stec_residuals[27].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[27].sv_id.satId, 181)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[27].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[27].sv_id.satId)),
+            181)
       << "incorrect value for stec_residuals[27].sv_id.satId, expected 181, is "
       << last_msg_->stec_residuals[27].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[28].residual, 28013)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[28].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[28].residual)),
+            28013)
       << "incorrect value for stec_residuals[28].residual, expected 28013, is "
       << last_msg_->stec_residuals[28].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[28].sv_id.constellation, 114)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[28].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[28].sv_id.constellation)),
+            114)
       << "incorrect value for stec_residuals[28].sv_id.constellation, expected "
          "114, is "
       << last_msg_->stec_residuals[28].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[28].sv_id.satId, 171)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[28].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[28].sv_id.satId)),
+            171)
       << "incorrect value for stec_residuals[28].sv_id.satId, expected 171, is "
       << last_msg_->stec_residuals[28].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[29].residual, 2166)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[29].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[29].residual)),
+            2166)
       << "incorrect value for stec_residuals[29].residual, expected 2166, is "
       << last_msg_->stec_residuals[29].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[29].sv_id.constellation, 23)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[29].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[29].sv_id.constellation)),
+            23)
       << "incorrect value for stec_residuals[29].sv_id.constellation, expected "
          "23, is "
       << last_msg_->stec_residuals[29].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[29].sv_id.satId, 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[29].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[29].sv_id.satId)),
+            12)
       << "incorrect value for stec_residuals[29].sv_id.satId, expected 12, is "
       << last_msg_->stec_residuals[29].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[30].residual, -10186)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[30].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[30].residual)),
+            -10186)
       << "incorrect value for stec_residuals[30].residual, expected -10186, is "
       << last_msg_->stec_residuals[30].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[30].sv_id.constellation, 159)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[30].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[30].sv_id.constellation)),
+            159)
       << "incorrect value for stec_residuals[30].sv_id.constellation, expected "
          "159, is "
       << last_msg_->stec_residuals[30].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[30].sv_id.satId, 64)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[30].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[30].sv_id.satId)),
+            64)
       << "incorrect value for stec_residuals[30].sv_id.satId, expected 64, is "
       << last_msg_->stec_residuals[30].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[31].residual, 17432)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[31].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[31].residual)),
+            17432)
       << "incorrect value for stec_residuals[31].residual, expected 17432, is "
       << last_msg_->stec_residuals[31].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[31].sv_id.constellation, 20)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[31].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[31].sv_id.constellation)),
+            20)
       << "incorrect value for stec_residuals[31].sv_id.constellation, expected "
          "20, is "
       << last_msg_->stec_residuals[31].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[31].sv_id.satId, 33)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[31].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[31].sv_id.satId)),
+            33)
       << "incorrect value for stec_residuals[31].sv_id.satId, expected 33, is "
       << last_msg_->stec_residuals[31].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[32].residual, -8666)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[32].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[32].residual)),
+            -8666)
       << "incorrect value for stec_residuals[32].residual, expected -8666, is "
       << last_msg_->stec_residuals[32].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[32].sv_id.constellation, 36)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[32].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[32].sv_id.constellation)),
+            36)
       << "incorrect value for stec_residuals[32].sv_id.constellation, expected "
          "36, is "
       << last_msg_->stec_residuals[32].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[32].sv_id.satId, 160)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[32].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[32].sv_id.satId)),
+            160)
       << "incorrect value for stec_residuals[32].sv_id.satId, expected 160, is "
       << last_msg_->stec_residuals[32].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[33].residual, 25436)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[33].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[33].residual)),
+            25436)
       << "incorrect value for stec_residuals[33].residual, expected 25436, is "
       << last_msg_->stec_residuals[33].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[33].sv_id.constellation, 190)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[33].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[33].sv_id.constellation)),
+            190)
       << "incorrect value for stec_residuals[33].sv_id.constellation, expected "
          "190, is "
       << last_msg_->stec_residuals[33].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[33].sv_id.satId, 145)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[33].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[33].sv_id.satId)),
+            145)
       << "incorrect value for stec_residuals[33].sv_id.satId, expected 145, is "
       << last_msg_->stec_residuals[33].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[34].residual, -3864)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[34].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[34].residual)),
+            -3864)
       << "incorrect value for stec_residuals[34].residual, expected -3864, is "
       << last_msg_->stec_residuals[34].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[34].sv_id.constellation, 159)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[34].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[34].sv_id.constellation)),
+            159)
       << "incorrect value for stec_residuals[34].sv_id.constellation, expected "
          "159, is "
       << last_msg_->stec_residuals[34].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[34].sv_id.satId, 108)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[34].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[34].sv_id.satId)),
+            108)
       << "incorrect value for stec_residuals[34].sv_id.satId, expected 108, is "
       << last_msg_->stec_residuals[34].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[35].residual, 4093)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[35].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[35].residual)),
+            4093)
       << "incorrect value for stec_residuals[35].residual, expected 4093, is "
       << last_msg_->stec_residuals[35].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[35].sv_id.constellation, 221)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[35].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[35].sv_id.constellation)),
+            221)
       << "incorrect value for stec_residuals[35].sv_id.constellation, expected "
          "221, is "
       << last_msg_->stec_residuals[35].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[35].sv_id.satId, 227)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[35].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[35].sv_id.satId)),
+            227)
       << "incorrect value for stec_residuals[35].sv_id.satId, expected 227, is "
       << last_msg_->stec_residuals[35].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[36].residual, -18055)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[36].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[36].residual)),
+            -18055)
       << "incorrect value for stec_residuals[36].residual, expected -18055, is "
       << last_msg_->stec_residuals[36].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[36].sv_id.constellation, 23)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[36].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[36].sv_id.constellation)),
+            23)
       << "incorrect value for stec_residuals[36].sv_id.constellation, expected "
          "23, is "
       << last_msg_->stec_residuals[36].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[36].sv_id.satId, 62)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[36].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[36].sv_id.satId)),
+            62)
       << "incorrect value for stec_residuals[36].sv_id.satId, expected 62, is "
       << last_msg_->stec_residuals[36].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[37].residual, -27900)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[37].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[37].residual)),
+            -27900)
       << "incorrect value for stec_residuals[37].residual, expected -27900, is "
       << last_msg_->stec_residuals[37].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[37].sv_id.constellation, 116)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[37].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[37].sv_id.constellation)),
+            116)
       << "incorrect value for stec_residuals[37].sv_id.constellation, expected "
          "116, is "
       << last_msg_->stec_residuals[37].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[37].sv_id.satId, 168)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[37].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[37].sv_id.satId)),
+            168)
       << "incorrect value for stec_residuals[37].sv_id.satId, expected 168, is "
       << last_msg_->stec_residuals[37].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[38].residual, 30687)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[38].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[38].residual)),
+            30687)
       << "incorrect value for stec_residuals[38].residual, expected 30687, is "
       << last_msg_->stec_residuals[38].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[38].sv_id.constellation, 72)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[38].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[38].sv_id.constellation)),
+            72)
       << "incorrect value for stec_residuals[38].sv_id.constellation, expected "
          "72, is "
       << last_msg_->stec_residuals[38].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[38].sv_id.satId, 123)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[38].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[38].sv_id.satId)),
+            123)
       << "incorrect value for stec_residuals[38].sv_id.satId, expected 123, is "
       << last_msg_->stec_residuals[38].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[39].residual, -13151)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[39].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[39].residual)),
+            -13151)
       << "incorrect value for stec_residuals[39].residual, expected -13151, is "
       << last_msg_->stec_residuals[39].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[39].sv_id.constellation, 242)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[39].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[39].sv_id.constellation)),
+            242)
       << "incorrect value for stec_residuals[39].sv_id.constellation, expected "
          "242, is "
       << last_msg_->stec_residuals[39].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[39].sv_id.satId, 226)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[39].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[39].sv_id.satId)),
+            226)
       << "incorrect value for stec_residuals[39].sv_id.satId, expected 226, is "
       << last_msg_->stec_residuals[39].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[40].residual, -22903)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[40].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[40].residual)),
+            -22903)
       << "incorrect value for stec_residuals[40].residual, expected -22903, is "
       << last_msg_->stec_residuals[40].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[40].sv_id.constellation, 202)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[40].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[40].sv_id.constellation)),
+            202)
       << "incorrect value for stec_residuals[40].sv_id.constellation, expected "
          "202, is "
       << last_msg_->stec_residuals[40].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[40].sv_id.satId, 180)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[40].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[40].sv_id.satId)),
+            180)
       << "incorrect value for stec_residuals[40].sv_id.satId, expected 180, is "
       << last_msg_->stec_residuals[40].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[41].residual, 4988)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[41].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[41].residual)),
+            4988)
       << "incorrect value for stec_residuals[41].residual, expected 4988, is "
       << last_msg_->stec_residuals[41].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[41].sv_id.constellation, 24)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[41].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[41].sv_id.constellation)),
+            24)
       << "incorrect value for stec_residuals[41].sv_id.constellation, expected "
          "24, is "
       << last_msg_->stec_residuals[41].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[41].sv_id.satId, 58)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[41].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[41].sv_id.satId)),
+            58)
       << "incorrect value for stec_residuals[41].sv_id.satId, expected 58, is "
       << last_msg_->stec_residuals[41].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[42].residual, 27408)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[42].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[42].residual)),
+            27408)
       << "incorrect value for stec_residuals[42].residual, expected 27408, is "
       << last_msg_->stec_residuals[42].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[42].sv_id.constellation, 188)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[42].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[42].sv_id.constellation)),
+            188)
       << "incorrect value for stec_residuals[42].sv_id.constellation, expected "
          "188, is "
       << last_msg_->stec_residuals[42].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[42].sv_id.satId, 181)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[42].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[42].sv_id.satId)),
+            181)
       << "incorrect value for stec_residuals[42].sv_id.satId, expected 181, is "
       << last_msg_->stec_residuals[42].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[43].residual, 319)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[43].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[43].residual)),
+            319)
       << "incorrect value for stec_residuals[43].residual, expected 319, is "
       << last_msg_->stec_residuals[43].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[43].sv_id.constellation, 231)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[43].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[43].sv_id.constellation)),
+            231)
       << "incorrect value for stec_residuals[43].sv_id.constellation, expected "
          "231, is "
       << last_msg_->stec_residuals[43].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[43].sv_id.satId, 66)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[43].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[43].sv_id.satId)),
+            66)
       << "incorrect value for stec_residuals[43].sv_id.satId, expected 66, is "
       << last_msg_->stec_residuals[43].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[44].residual, 15987)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[44].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[44].residual)),
+            15987)
       << "incorrect value for stec_residuals[44].residual, expected 15987, is "
       << last_msg_->stec_residuals[44].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[44].sv_id.constellation, 252)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[44].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[44].sv_id.constellation)),
+            252)
       << "incorrect value for stec_residuals[44].sv_id.constellation, expected "
          "252, is "
       << last_msg_->stec_residuals[44].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[44].sv_id.satId, 64)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[44].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[44].sv_id.satId)),
+            64)
       << "incorrect value for stec_residuals[44].sv_id.satId, expected 64, is "
       << last_msg_->stec_residuals[44].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[45].residual, 22266)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[45].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[45].residual)),
+            22266)
       << "incorrect value for stec_residuals[45].residual, expected 22266, is "
       << last_msg_->stec_residuals[45].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[45].sv_id.constellation, 97)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[45].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[45].sv_id.constellation)),
+            97)
       << "incorrect value for stec_residuals[45].sv_id.constellation, expected "
          "97, is "
       << last_msg_->stec_residuals[45].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[45].sv_id.satId, 233)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[45].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[45].sv_id.satId)),
+            233)
       << "incorrect value for stec_residuals[45].sv_id.satId, expected 233, is "
       << last_msg_->stec_residuals[45].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[46].residual, -19919)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[46].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[46].residual)),
+            -19919)
       << "incorrect value for stec_residuals[46].residual, expected -19919, is "
       << last_msg_->stec_residuals[46].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[46].sv_id.constellation, 221)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[46].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[46].sv_id.constellation)),
+            221)
       << "incorrect value for stec_residuals[46].sv_id.constellation, expected "
          "221, is "
       << last_msg_->stec_residuals[46].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[46].sv_id.satId, 156)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[46].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[46].sv_id.satId)),
+            156)
       << "incorrect value for stec_residuals[46].sv_id.satId, expected 156, is "
       << last_msg_->stec_residuals[46].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[47].residual, 17350)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[47].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[47].residual)),
+            17350)
       << "incorrect value for stec_residuals[47].residual, expected 17350, is "
       << last_msg_->stec_residuals[47].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[47].sv_id.constellation, 73)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[47].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[47].sv_id.constellation)),
+            73)
       << "incorrect value for stec_residuals[47].sv_id.constellation, expected "
          "73, is "
       << last_msg_->stec_residuals[47].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[47].sv_id.satId, 32)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[47].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[47].sv_id.satId)),
+            32)
       << "incorrect value for stec_residuals[47].sv_id.satId, expected 32, is "
       << last_msg_->stec_residuals[47].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[48].residual, 14410)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[48].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[48].residual)),
+            14410)
       << "incorrect value for stec_residuals[48].residual, expected 14410, is "
       << last_msg_->stec_residuals[48].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[48].sv_id.constellation, 253)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[48].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[48].sv_id.constellation)),
+            253)
       << "incorrect value for stec_residuals[48].sv_id.constellation, expected "
          "253, is "
       << last_msg_->stec_residuals[48].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[48].sv_id.satId, 249)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[48].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[48].sv_id.satId)),
+            249)
       << "incorrect value for stec_residuals[48].sv_id.satId, expected 249, is "
       << last_msg_->stec_residuals[48].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[49].residual, 23671)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[49].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[49].residual)),
+            23671)
       << "incorrect value for stec_residuals[49].residual, expected 23671, is "
       << last_msg_->stec_residuals[49].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[49].sv_id.constellation, 165)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[49].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[49].sv_id.constellation)),
+            165)
       << "incorrect value for stec_residuals[49].sv_id.constellation, expected "
          "165, is "
       << last_msg_->stec_residuals[49].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[49].sv_id.satId, 38)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[49].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[49].sv_id.satId)),
+            38)
       << "incorrect value for stec_residuals[49].sv_id.satId, expected 38, is "
       << last_msg_->stec_residuals[49].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[50].residual, -31905)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[50].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[50].residual)),
+            -31905)
       << "incorrect value for stec_residuals[50].residual, expected -31905, is "
       << last_msg_->stec_residuals[50].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[50].sv_id.constellation, 44)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[50].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[50].sv_id.constellation)),
+            44)
       << "incorrect value for stec_residuals[50].sv_id.constellation, expected "
          "44, is "
       << last_msg_->stec_residuals[50].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[50].sv_id.satId, 99)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[50].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[50].sv_id.satId)),
+            99)
       << "incorrect value for stec_residuals[50].sv_id.satId, expected 99, is "
       << last_msg_->stec_residuals[50].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[51].residual, 14305)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[51].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[51].residual)),
+            14305)
       << "incorrect value for stec_residuals[51].residual, expected 14305, is "
       << last_msg_->stec_residuals[51].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[51].sv_id.constellation, 192)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[51].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[51].sv_id.constellation)),
+            192)
       << "incorrect value for stec_residuals[51].sv_id.constellation, expected "
          "192, is "
       << last_msg_->stec_residuals[51].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[51].sv_id.satId, 89)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[51].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[51].sv_id.satId)),
+            89)
       << "incorrect value for stec_residuals[51].sv_id.satId, expected 89, is "
       << last_msg_->stec_residuals[51].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[52].residual, -12968)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[52].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[52].residual)),
+            -12968)
       << "incorrect value for stec_residuals[52].residual, expected -12968, is "
       << last_msg_->stec_residuals[52].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[52].sv_id.constellation, 171)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[52].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[52].sv_id.constellation)),
+            171)
       << "incorrect value for stec_residuals[52].sv_id.constellation, expected "
          "171, is "
       << last_msg_->stec_residuals[52].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[52].sv_id.satId, 95)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[52].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[52].sv_id.satId)),
+            95)
       << "incorrect value for stec_residuals[52].sv_id.satId, expected 95, is "
       << last_msg_->stec_residuals[52].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[53].residual, 21479)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[53].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[53].residual)),
+            21479)
       << "incorrect value for stec_residuals[53].residual, expected 21479, is "
       << last_msg_->stec_residuals[53].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[53].sv_id.constellation, 116)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[53].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[53].sv_id.constellation)),
+            116)
       << "incorrect value for stec_residuals[53].sv_id.constellation, expected "
          "116, is "
       << last_msg_->stec_residuals[53].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[53].sv_id.satId, 21)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[53].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[53].sv_id.satId)),
+            21)
       << "incorrect value for stec_residuals[53].sv_id.satId, expected 21, is "
       << last_msg_->stec_residuals[53].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[54].residual, 28260)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[54].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[54].residual)),
+            28260)
       << "incorrect value for stec_residuals[54].residual, expected 28260, is "
       << last_msg_->stec_residuals[54].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[54].sv_id.constellation, 71)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[54].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[54].sv_id.constellation)),
+            71)
       << "incorrect value for stec_residuals[54].sv_id.constellation, expected "
          "71, is "
       << last_msg_->stec_residuals[54].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[54].sv_id.satId, 71)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[54].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[54].sv_id.satId)),
+            71)
       << "incorrect value for stec_residuals[54].sv_id.satId, expected 71, is "
       << last_msg_->stec_residuals[54].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[55].residual, -11112)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[55].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[55].residual)),
+            -11112)
       << "incorrect value for stec_residuals[55].residual, expected -11112, is "
       << last_msg_->stec_residuals[55].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[55].sv_id.constellation, 254)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[55].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[55].sv_id.constellation)),
+            254)
       << "incorrect value for stec_residuals[55].sv_id.constellation, expected "
          "254, is "
       << last_msg_->stec_residuals[55].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[55].sv_id.satId, 217)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[55].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[55].sv_id.satId)),
+            217)
       << "incorrect value for stec_residuals[55].sv_id.satId, expected 217, is "
       << last_msg_->stec_residuals[55].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[56].residual, -25304)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[56].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[56].residual)),
+            -25304)
       << "incorrect value for stec_residuals[56].residual, expected -25304, is "
       << last_msg_->stec_residuals[56].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[56].sv_id.constellation, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[56].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[56].sv_id.constellation)),
+            8)
       << "incorrect value for stec_residuals[56].sv_id.constellation, expected "
          "8, is "
       << last_msg_->stec_residuals[56].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[56].sv_id.satId, 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[56].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[56].sv_id.satId)),
+            18)
       << "incorrect value for stec_residuals[56].sv_id.satId, expected 18, is "
       << last_msg_->stec_residuals[56].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[57].residual, -4024)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[57].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[57].residual)),
+            -4024)
       << "incorrect value for stec_residuals[57].residual, expected -4024, is "
       << last_msg_->stec_residuals[57].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[57].sv_id.constellation, 54)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[57].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[57].sv_id.constellation)),
+            54)
       << "incorrect value for stec_residuals[57].sv_id.constellation, expected "
          "54, is "
       << last_msg_->stec_residuals[57].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[57].sv_id.satId, 244)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[57].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[57].sv_id.satId)),
+            244)
       << "incorrect value for stec_residuals[57].sv_id.satId, expected 244, is "
       << last_msg_->stec_residuals[57].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_residuals[58].residual, -15505)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[58].residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[58].residual)),
+            -15505)
       << "incorrect value for stec_residuals[58].residual, expected -15505, is "
       << last_msg_->stec_residuals[58].residual;
-  EXPECT_EQ(last_msg_->stec_residuals[58].sv_id.constellation, 189)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[58].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[58].sv_id.constellation)),
+            189)
       << "incorrect value for stec_residuals[58].sv_id.constellation, expected "
          "189, is "
       << last_msg_->stec_residuals[58].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_residuals[58].sv_id.satId, 231)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_residuals[58].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_residuals[58].sv_id.satId)),
+            231)
       << "incorrect value for stec_residuals[58].sv_id.satId, expected 231, is "
       << last_msg_->stec_residuals[58].sv_id.satId;
-  EXPECT_EQ(last_msg_->tropo_delay_correction.hydro, 16250)
+  EXPECT_EQ(get_as<decltype(last_msg_->tropo_delay_correction.hydro)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->tropo_delay_correction.hydro)),
+            16250)
       << "incorrect value for tropo_delay_correction.hydro, expected 16250, is "
       << last_msg_->tropo_delay_correction.hydro;
-  EXPECT_EQ(last_msg_->tropo_delay_correction.wet, 101)
+  EXPECT_EQ(get_as<decltype(last_msg_->tropo_delay_correction.wet)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->tropo_delay_correction.wet)),
+            101)
       << "incorrect value for tropo_delay_correction.wet, expected 101, is "
       << last_msg_->tropo_delay_correction.wet;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrOrbitClock.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrOrbitClock.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/ssr.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_ssr_MsgSsrOrbitClock0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -128,46 +135,78 @@ TEST_F(Test_legacy_auto_check_sbp_ssr_MsgSsrOrbitClock0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 58677);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->along, -1334502588)
+  EXPECT_EQ(get_as<decltype(last_msg_->along)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->along)),
+            -1334502588)
       << "incorrect value for along, expected -1334502588, is "
       << last_msg_->along;
-  EXPECT_EQ(last_msg_->c0, -174298703)
+  EXPECT_EQ(get_as<decltype(last_msg_->c0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->c0)),
+            -174298703)
       << "incorrect value for c0, expected -174298703, is " << last_msg_->c0;
-  EXPECT_EQ(last_msg_->c1, -630458102)
+  EXPECT_EQ(get_as<decltype(last_msg_->c1)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->c1)),
+            -630458102)
       << "incorrect value for c1, expected -630458102, is " << last_msg_->c1;
-  EXPECT_EQ(last_msg_->c2, 1211677201)
+  EXPECT_EQ(get_as<decltype(last_msg_->c2)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->c2)),
+            1211677201)
       << "incorrect value for c2, expected 1211677201, is " << last_msg_->c2;
-  EXPECT_EQ(last_msg_->cross, -197264530)
+  EXPECT_EQ(get_as<decltype(last_msg_->cross)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cross)),
+            -197264530)
       << "incorrect value for cross, expected -197264530, is "
       << last_msg_->cross;
-  EXPECT_EQ(last_msg_->dot_along, 169404560)
+  EXPECT_EQ(get_as<decltype(last_msg_->dot_along)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->dot_along)),
+            169404560)
       << "incorrect value for dot_along, expected 169404560, is "
       << last_msg_->dot_along;
-  EXPECT_EQ(last_msg_->dot_cross, 1118011173)
+  EXPECT_EQ(get_as<decltype(last_msg_->dot_cross)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->dot_cross)),
+            1118011173)
       << "incorrect value for dot_cross, expected 1118011173, is "
       << last_msg_->dot_cross;
-  EXPECT_EQ(last_msg_->dot_radial, 878654074)
+  EXPECT_EQ(get_as<decltype(last_msg_->dot_radial)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->dot_radial)),
+            878654074)
       << "incorrect value for dot_radial, expected 878654074, is "
       << last_msg_->dot_radial;
-  EXPECT_EQ(last_msg_->iod, 936372632)
+  EXPECT_EQ(get_as<decltype(last_msg_->iod)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iod)),
+            936372632)
       << "incorrect value for iod, expected 936372632, is " << last_msg_->iod;
-  EXPECT_EQ(last_msg_->iod_ssr, 255)
+  EXPECT_EQ(get_as<decltype(last_msg_->iod_ssr)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iod_ssr)),
+            255)
       << "incorrect value for iod_ssr, expected 255, is " << last_msg_->iod_ssr;
-  EXPECT_EQ(last_msg_->radial, -2143668642)
+  EXPECT_EQ(get_as<decltype(last_msg_->radial)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->radial)),
+            -2143668642)
       << "incorrect value for radial, expected -2143668642, is "
       << last_msg_->radial;
-  EXPECT_EQ(last_msg_->sid.code, 212)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.code)),
+            212)
       << "incorrect value for sid.code, expected 212, is "
       << last_msg_->sid.code;
-  EXPECT_EQ(last_msg_->sid.sat, 203)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.sat)),
+            203)
       << "incorrect value for sid.sat, expected 203, is " << last_msg_->sid.sat;
-  EXPECT_EQ(last_msg_->time.tow, 3479621715)
+  EXPECT_EQ(get_as<decltype(last_msg_->time.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->time.tow)),
+            3479621715)
       << "incorrect value for time.tow, expected 3479621715, is "
       << last_msg_->time.tow;
-  EXPECT_EQ(last_msg_->time.wn, 7588)
+  EXPECT_EQ(get_as<decltype(last_msg_->time.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->time.wn)),
+            7588)
       << "incorrect value for time.wn, expected 7588, is "
       << last_msg_->time.wn;
-  EXPECT_EQ(last_msg_->update_interval, 236)
+  EXPECT_EQ(get_as<decltype(last_msg_->update_interval)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->update_interval)),
+            236)
       << "incorrect value for update_interval, expected 236, is "
       << last_msg_->update_interval;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrOrbitClockBounds.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrOrbitClockBounds.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/ssr.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_ssr_MsgSsrOrbitClockBounds0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -150,98 +157,183 @@ TEST_F(Test_legacy_auto_check_sbp_ssr_MsgSsrOrbitClockBounds0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->const_id, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->const_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->const_id)),
+            1)
       << "incorrect value for const_id, expected 1, is " << last_msg_->const_id;
-  EXPECT_EQ(last_msg_->header.num_msgs, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.num_msgs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.num_msgs)),
+            1)
       << "incorrect value for header.num_msgs, expected 1, is "
       << last_msg_->header.num_msgs;
-  EXPECT_EQ(last_msg_->header.seq_num, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.seq_num)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.seq_num)),
+            2)
       << "incorrect value for header.seq_num, expected 2, is "
       << last_msg_->header.seq_num;
-  EXPECT_EQ(last_msg_->header.sol_id, 48)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.sol_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.sol_id)),
+            48)
       << "incorrect value for header.sol_id, expected 48, is "
       << last_msg_->header.sol_id;
-  EXPECT_EQ(last_msg_->header.time.tow, 180)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.time.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.time.tow)),
+            180)
       << "incorrect value for header.time.tow, expected 180, is "
       << last_msg_->header.time.tow;
-  EXPECT_EQ(last_msg_->header.time.wn, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.time.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.time.wn)),
+            3)
       << "incorrect value for header.time.wn, expected 3, is "
       << last_msg_->header.time.wn;
-  EXPECT_EQ(last_msg_->header.update_interval, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.update_interval)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->header.update_interval)),
+            3)
       << "incorrect value for header.update_interval, expected 3, is "
       << last_msg_->header.update_interval;
-  EXPECT_EQ(last_msg_->n_sats, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            2)
       << "incorrect value for n_sats, expected 2, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->orbit_clock_bounds[0].clock_bound_mu, 39)
+  EXPECT_EQ(get_as<decltype(last_msg_->orbit_clock_bounds[0].clock_bound_mu)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->orbit_clock_bounds[0].clock_bound_mu)),
+            39)
       << "incorrect value for orbit_clock_bounds[0].clock_bound_mu, expected "
          "39, is "
       << last_msg_->orbit_clock_bounds[0].clock_bound_mu;
-  EXPECT_EQ(last_msg_->orbit_clock_bounds[0].clock_bound_sig, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->orbit_clock_bounds[0].clock_bound_sig)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->orbit_clock_bounds[0].clock_bound_sig)),
+            1)
       << "incorrect value for orbit_clock_bounds[0].clock_bound_sig, expected "
          "1, is "
       << last_msg_->orbit_clock_bounds[0].clock_bound_sig;
-  EXPECT_EQ(last_msg_->orbit_clock_bounds[0].orb_along_bound_mu, 38)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->orbit_clock_bounds[0].orb_along_bound_mu)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->orbit_clock_bounds[0].orb_along_bound_mu)),
+      38)
       << "incorrect value for orbit_clock_bounds[0].orb_along_bound_mu, "
          "expected 38, is "
       << last_msg_->orbit_clock_bounds[0].orb_along_bound_mu;
-  EXPECT_EQ(last_msg_->orbit_clock_bounds[0].orb_along_bound_sig, 2)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->orbit_clock_bounds[0].orb_along_bound_sig)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->orbit_clock_bounds[0].orb_along_bound_sig)),
+      2)
       << "incorrect value for orbit_clock_bounds[0].orb_along_bound_sig, "
          "expected 2, is "
       << last_msg_->orbit_clock_bounds[0].orb_along_bound_sig;
-  EXPECT_EQ(last_msg_->orbit_clock_bounds[0].orb_cross_bound_mu, 37)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->orbit_clock_bounds[0].orb_cross_bound_mu)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->orbit_clock_bounds[0].orb_cross_bound_mu)),
+      37)
       << "incorrect value for orbit_clock_bounds[0].orb_cross_bound_mu, "
          "expected 37, is "
       << last_msg_->orbit_clock_bounds[0].orb_cross_bound_mu;
-  EXPECT_EQ(last_msg_->orbit_clock_bounds[0].orb_cross_bound_sig, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->orbit_clock_bounds[0].orb_cross_bound_sig)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->orbit_clock_bounds[0].orb_cross_bound_sig)),
+      3)
       << "incorrect value for orbit_clock_bounds[0].orb_cross_bound_sig, "
          "expected 3, is "
       << last_msg_->orbit_clock_bounds[0].orb_cross_bound_sig;
-  EXPECT_EQ(last_msg_->orbit_clock_bounds[0].orb_radial_bound_mu, 39)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->orbit_clock_bounds[0].orb_radial_bound_mu)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->orbit_clock_bounds[0].orb_radial_bound_mu)),
+      39)
       << "incorrect value for orbit_clock_bounds[0].orb_radial_bound_mu, "
          "expected 39, is "
       << last_msg_->orbit_clock_bounds[0].orb_radial_bound_mu;
-  EXPECT_EQ(last_msg_->orbit_clock_bounds[0].orb_radial_bound_sig, 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->orbit_clock_bounds[0].orb_radial_bound_sig)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->orbit_clock_bounds[0].orb_radial_bound_sig)),
+      1)
       << "incorrect value for orbit_clock_bounds[0].orb_radial_bound_sig, "
          "expected 1, is "
       << last_msg_->orbit_clock_bounds[0].orb_radial_bound_sig;
-  EXPECT_EQ(last_msg_->orbit_clock_bounds[0].sat_id, 24)
+  EXPECT_EQ(get_as<decltype(last_msg_->orbit_clock_bounds[0].sat_id)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->orbit_clock_bounds[0].sat_id)),
+            24)
       << "incorrect value for orbit_clock_bounds[0].sat_id, expected 24, is "
       << last_msg_->orbit_clock_bounds[0].sat_id;
-  EXPECT_EQ(last_msg_->orbit_clock_bounds[1].clock_bound_mu, 39)
+  EXPECT_EQ(get_as<decltype(last_msg_->orbit_clock_bounds[1].clock_bound_mu)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->orbit_clock_bounds[1].clock_bound_mu)),
+            39)
       << "incorrect value for orbit_clock_bounds[1].clock_bound_mu, expected "
          "39, is "
       << last_msg_->orbit_clock_bounds[1].clock_bound_mu;
-  EXPECT_EQ(last_msg_->orbit_clock_bounds[1].clock_bound_sig, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->orbit_clock_bounds[1].clock_bound_sig)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->orbit_clock_bounds[1].clock_bound_sig)),
+            1)
       << "incorrect value for orbit_clock_bounds[1].clock_bound_sig, expected "
          "1, is "
       << last_msg_->orbit_clock_bounds[1].clock_bound_sig;
-  EXPECT_EQ(last_msg_->orbit_clock_bounds[1].orb_along_bound_mu, 38)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->orbit_clock_bounds[1].orb_along_bound_mu)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->orbit_clock_bounds[1].orb_along_bound_mu)),
+      38)
       << "incorrect value for orbit_clock_bounds[1].orb_along_bound_mu, "
          "expected 38, is "
       << last_msg_->orbit_clock_bounds[1].orb_along_bound_mu;
-  EXPECT_EQ(last_msg_->orbit_clock_bounds[1].orb_along_bound_sig, 2)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->orbit_clock_bounds[1].orb_along_bound_sig)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->orbit_clock_bounds[1].orb_along_bound_sig)),
+      2)
       << "incorrect value for orbit_clock_bounds[1].orb_along_bound_sig, "
          "expected 2, is "
       << last_msg_->orbit_clock_bounds[1].orb_along_bound_sig;
-  EXPECT_EQ(last_msg_->orbit_clock_bounds[1].orb_cross_bound_mu, 37)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->orbit_clock_bounds[1].orb_cross_bound_mu)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->orbit_clock_bounds[1].orb_cross_bound_mu)),
+      37)
       << "incorrect value for orbit_clock_bounds[1].orb_cross_bound_mu, "
          "expected 37, is "
       << last_msg_->orbit_clock_bounds[1].orb_cross_bound_mu;
-  EXPECT_EQ(last_msg_->orbit_clock_bounds[1].orb_cross_bound_sig, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->orbit_clock_bounds[1].orb_cross_bound_sig)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->orbit_clock_bounds[1].orb_cross_bound_sig)),
+      3)
       << "incorrect value for orbit_clock_bounds[1].orb_cross_bound_sig, "
          "expected 3, is "
       << last_msg_->orbit_clock_bounds[1].orb_cross_bound_sig;
-  EXPECT_EQ(last_msg_->orbit_clock_bounds[1].orb_radial_bound_mu, 39)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->orbit_clock_bounds[1].orb_radial_bound_mu)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->orbit_clock_bounds[1].orb_radial_bound_mu)),
+      39)
       << "incorrect value for orbit_clock_bounds[1].orb_radial_bound_mu, "
          "expected 39, is "
       << last_msg_->orbit_clock_bounds[1].orb_radial_bound_mu;
-  EXPECT_EQ(last_msg_->orbit_clock_bounds[1].orb_radial_bound_sig, 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->orbit_clock_bounds[1].orb_radial_bound_sig)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->orbit_clock_bounds[1].orb_radial_bound_sig)),
+      1)
       << "incorrect value for orbit_clock_bounds[1].orb_radial_bound_sig, "
          "expected 1, is "
       << last_msg_->orbit_clock_bounds[1].orb_radial_bound_sig;
-  EXPECT_EQ(last_msg_->orbit_clock_bounds[1].sat_id, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->orbit_clock_bounds[1].sat_id)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->orbit_clock_bounds[1].sat_id)),
+            3)
       << "incorrect value for orbit_clock_bounds[1].sat_id, expected 3, is "
       << last_msg_->orbit_clock_bounds[1].sat_id;
-  EXPECT_EQ(last_msg_->ssr_iod, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->ssr_iod)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ssr_iod)),
+            15)
       << "incorrect value for ssr_iod, expected 15, is " << last_msg_->ssr_iod;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrOrbitClockBoundsDegradation.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrOrbitClockBoundsDegradation.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/ssr.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_ssr_MsgSsrOrbitClockBoundsDegradation0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -132,73 +139,132 @@ TEST_F(Test_legacy_auto_check_sbp_ssr_MsgSsrOrbitClockBoundsDegradation0,
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->const_id, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->const_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->const_id)),
+            1)
       << "incorrect value for const_id, expected 1, is " << last_msg_->const_id;
-  EXPECT_EQ(last_msg_->header.num_msgs, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.num_msgs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.num_msgs)),
+            1)
       << "incorrect value for header.num_msgs, expected 1, is "
       << last_msg_->header.num_msgs;
-  EXPECT_EQ(last_msg_->header.seq_num, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.seq_num)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.seq_num)),
+            2)
       << "incorrect value for header.seq_num, expected 2, is "
       << last_msg_->header.seq_num;
-  EXPECT_EQ(last_msg_->header.sol_id, 48)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.sol_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.sol_id)),
+            48)
       << "incorrect value for header.sol_id, expected 48, is "
       << last_msg_->header.sol_id;
-  EXPECT_EQ(last_msg_->header.time.tow, 180)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.time.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.time.tow)),
+            180)
       << "incorrect value for header.time.tow, expected 180, is "
       << last_msg_->header.time.tow;
-  EXPECT_EQ(last_msg_->header.time.wn, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.time.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.time.wn)),
+            3)
       << "incorrect value for header.time.wn, expected 3, is "
       << last_msg_->header.time.wn;
-  EXPECT_EQ(last_msg_->header.update_interval, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.update_interval)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->header.update_interval)),
+            3)
       << "incorrect value for header.update_interval, expected 3, is "
       << last_msg_->header.update_interval;
-  EXPECT_EQ(last_msg_->orbit_clock_bounds_degradation.clock_bound_mu_dot, 194)
+  EXPECT_EQ(
+      get_as<decltype(
+          last_msg_->orbit_clock_bounds_degradation.clock_bound_mu_dot)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->orbit_clock_bounds_degradation.clock_bound_mu_dot)),
+      194)
       << "incorrect value for "
          "orbit_clock_bounds_degradation.clock_bound_mu_dot, expected 194, is "
       << last_msg_->orbit_clock_bounds_degradation.clock_bound_mu_dot;
-  EXPECT_EQ(last_msg_->orbit_clock_bounds_degradation.clock_bound_sig_dot, 193)
+  EXPECT_EQ(
+      get_as<decltype(
+          last_msg_->orbit_clock_bounds_degradation.clock_bound_sig_dot)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->orbit_clock_bounds_degradation.clock_bound_sig_dot)),
+      193)
       << "incorrect value for "
          "orbit_clock_bounds_degradation.clock_bound_sig_dot, expected 193, is "
       << last_msg_->orbit_clock_bounds_degradation.clock_bound_sig_dot;
-  EXPECT_EQ(last_msg_->orbit_clock_bounds_degradation.orb_along_bound_mu_dot,
-            199)
+  EXPECT_EQ(
+      get_as<decltype(
+          last_msg_->orbit_clock_bounds_degradation.orb_along_bound_mu_dot)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->orbit_clock_bounds_degradation
+                   .orb_along_bound_mu_dot)),
+      199)
       << "incorrect value for "
          "orbit_clock_bounds_degradation.orb_along_bound_mu_dot, expected 199, "
          "is "
       << last_msg_->orbit_clock_bounds_degradation.orb_along_bound_mu_dot;
-  EXPECT_EQ(last_msg_->orbit_clock_bounds_degradation.orb_along_bound_sig_dot,
-            196)
+  EXPECT_EQ(
+      get_as<decltype(
+          last_msg_->orbit_clock_bounds_degradation.orb_along_bound_sig_dot)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->orbit_clock_bounds_degradation
+                   .orb_along_bound_sig_dot)),
+      196)
       << "incorrect value for "
          "orbit_clock_bounds_degradation.orb_along_bound_sig_dot, expected "
          "196, is "
       << last_msg_->orbit_clock_bounds_degradation.orb_along_bound_sig_dot;
-  EXPECT_EQ(last_msg_->orbit_clock_bounds_degradation.orb_cross_bound_mu_dot,
-            198)
+  EXPECT_EQ(
+      get_as<decltype(
+          last_msg_->orbit_clock_bounds_degradation.orb_cross_bound_mu_dot)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->orbit_clock_bounds_degradation
+                   .orb_cross_bound_mu_dot)),
+      198)
       << "incorrect value for "
          "orbit_clock_bounds_degradation.orb_cross_bound_mu_dot, expected 198, "
          "is "
       << last_msg_->orbit_clock_bounds_degradation.orb_cross_bound_mu_dot;
-  EXPECT_EQ(last_msg_->orbit_clock_bounds_degradation.orb_cross_bound_sig_dot,
-            195)
+  EXPECT_EQ(
+      get_as<decltype(
+          last_msg_->orbit_clock_bounds_degradation.orb_cross_bound_sig_dot)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->orbit_clock_bounds_degradation
+                   .orb_cross_bound_sig_dot)),
+      195)
       << "incorrect value for "
          "orbit_clock_bounds_degradation.orb_cross_bound_sig_dot, expected "
          "195, is "
       << last_msg_->orbit_clock_bounds_degradation.orb_cross_bound_sig_dot;
-  EXPECT_EQ(last_msg_->orbit_clock_bounds_degradation.orb_radial_bound_mu_dot,
-            200)
+  EXPECT_EQ(
+      get_as<decltype(
+          last_msg_->orbit_clock_bounds_degradation.orb_radial_bound_mu_dot)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->orbit_clock_bounds_degradation
+                   .orb_radial_bound_mu_dot)),
+      200)
       << "incorrect value for "
          "orbit_clock_bounds_degradation.orb_radial_bound_mu_dot, expected "
          "200, is "
       << last_msg_->orbit_clock_bounds_degradation.orb_radial_bound_mu_dot;
-  EXPECT_EQ(last_msg_->orbit_clock_bounds_degradation.orb_radial_bound_sig_dot,
-            197)
+  EXPECT_EQ(
+      get_as<decltype(
+          last_msg_->orbit_clock_bounds_degradation.orb_radial_bound_sig_dot)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->orbit_clock_bounds_degradation
+                   .orb_radial_bound_sig_dot)),
+      197)
       << "incorrect value for "
          "orbit_clock_bounds_degradation.orb_radial_bound_sig_dot, expected "
          "197, is "
       << last_msg_->orbit_clock_bounds_degradation.orb_radial_bound_sig_dot;
-  EXPECT_EQ(last_msg_->sat_bitmask, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->sat_bitmask)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sat_bitmask)),
+            10)
       << "incorrect value for sat_bitmask, expected 10, is "
       << last_msg_->sat_bitmask;
-  EXPECT_EQ(last_msg_->ssr_iod, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->ssr_iod)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ssr_iod)),
+            15)
       << "incorrect value for ssr_iod, expected 15, is " << last_msg_->ssr_iod;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrOrbitClockDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrOrbitClockDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/ssr.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_ssr_MsgSsrOrbitClockDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -130,46 +137,78 @@ TEST_F(Test_legacy_auto_check_sbp_ssr_MsgSsrOrbitClockDepA0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 42529);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->along, 132661048)
+  EXPECT_EQ(get_as<decltype(last_msg_->along)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->along)),
+            132661048)
       << "incorrect value for along, expected 132661048, is "
       << last_msg_->along;
-  EXPECT_EQ(last_msg_->c0, -970026069)
+  EXPECT_EQ(get_as<decltype(last_msg_->c0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->c0)),
+            -970026069)
       << "incorrect value for c0, expected -970026069, is " << last_msg_->c0;
-  EXPECT_EQ(last_msg_->c1, -503975083)
+  EXPECT_EQ(get_as<decltype(last_msg_->c1)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->c1)),
+            -503975083)
       << "incorrect value for c1, expected -503975083, is " << last_msg_->c1;
-  EXPECT_EQ(last_msg_->c2, -759858197)
+  EXPECT_EQ(get_as<decltype(last_msg_->c2)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->c2)),
+            -759858197)
       << "incorrect value for c2, expected -759858197, is " << last_msg_->c2;
-  EXPECT_EQ(last_msg_->cross, 1845577176)
+  EXPECT_EQ(get_as<decltype(last_msg_->cross)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cross)),
+            1845577176)
       << "incorrect value for cross, expected 1845577176, is "
       << last_msg_->cross;
-  EXPECT_EQ(last_msg_->dot_along, 72905755)
+  EXPECT_EQ(get_as<decltype(last_msg_->dot_along)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->dot_along)),
+            72905755)
       << "incorrect value for dot_along, expected 72905755, is "
       << last_msg_->dot_along;
-  EXPECT_EQ(last_msg_->dot_cross, 311886653)
+  EXPECT_EQ(get_as<decltype(last_msg_->dot_cross)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->dot_cross)),
+            311886653)
       << "incorrect value for dot_cross, expected 311886653, is "
       << last_msg_->dot_cross;
-  EXPECT_EQ(last_msg_->dot_radial, -1111196507)
+  EXPECT_EQ(get_as<decltype(last_msg_->dot_radial)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->dot_radial)),
+            -1111196507)
       << "incorrect value for dot_radial, expected -1111196507, is "
       << last_msg_->dot_radial;
-  EXPECT_EQ(last_msg_->iod, 193)
+  EXPECT_EQ(get_as<decltype(last_msg_->iod)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iod)),
+            193)
       << "incorrect value for iod, expected 193, is " << last_msg_->iod;
-  EXPECT_EQ(last_msg_->iod_ssr, 211)
+  EXPECT_EQ(get_as<decltype(last_msg_->iod_ssr)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iod_ssr)),
+            211)
       << "incorrect value for iod_ssr, expected 211, is " << last_msg_->iod_ssr;
-  EXPECT_EQ(last_msg_->radial, -24141393)
+  EXPECT_EQ(get_as<decltype(last_msg_->radial)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->radial)),
+            -24141393)
       << "incorrect value for radial, expected -24141393, is "
       << last_msg_->radial;
-  EXPECT_EQ(last_msg_->sid.code, 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.code)),
+            30)
       << "incorrect value for sid.code, expected 30, is "
       << last_msg_->sid.code;
-  EXPECT_EQ(last_msg_->sid.sat, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.sat)),
+            1)
       << "incorrect value for sid.sat, expected 1, is " << last_msg_->sid.sat;
-  EXPECT_EQ(last_msg_->time.tow, 3172954849)
+  EXPECT_EQ(get_as<decltype(last_msg_->time.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->time.tow)),
+            3172954849)
       << "incorrect value for time.tow, expected 3172954849, is "
       << last_msg_->time.tow;
-  EXPECT_EQ(last_msg_->time.wn, 7723)
+  EXPECT_EQ(get_as<decltype(last_msg_->time.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->time.wn)),
+            7723)
       << "incorrect value for time.wn, expected 7723, is "
       << last_msg_->time.wn;
-  EXPECT_EQ(last_msg_->update_interval, 194)
+  EXPECT_EQ(get_as<decltype(last_msg_->update_interval)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->update_interval)),
+            194)
       << "incorrect value for update_interval, expected 194, is "
       << last_msg_->update_interval;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrPhaseBiases.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrPhaseBiases.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/ssr.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_ssr_MsgSsrPhaseBiases0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -407,534 +414,944 @@ TEST_F(Test_legacy_auto_check_sbp_ssr_MsgSsrPhaseBiases0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 52955);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->biases[0].bias, -1311498533)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[0].bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[0].bias)),
+            -1311498533)
       << "incorrect value for biases[0].bias, expected -1311498533, is "
       << last_msg_->biases[0].bias;
-  EXPECT_EQ(last_msg_->biases[0].code, 29)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[0].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[0].code)),
+            29)
       << "incorrect value for biases[0].code, expected 29, is "
       << last_msg_->biases[0].code;
-  EXPECT_EQ(last_msg_->biases[0].discontinuity_counter, 193)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[0].discontinuity_counter)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[0].discontinuity_counter)),
+            193)
       << "incorrect value for biases[0].discontinuity_counter, expected 193, "
          "is "
       << last_msg_->biases[0].discontinuity_counter;
-  EXPECT_EQ(last_msg_->biases[0].integer_indicator, 250)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[0].integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[0].integer_indicator)),
+            250)
       << "incorrect value for biases[0].integer_indicator, expected 250, is "
       << last_msg_->biases[0].integer_indicator;
-  EXPECT_EQ(last_msg_->biases[0].widelane_integer_indicator, 245)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[0].widelane_integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[0].widelane_integer_indicator)),
+            245)
       << "incorrect value for biases[0].widelane_integer_indicator, expected "
          "245, is "
       << last_msg_->biases[0].widelane_integer_indicator;
-  EXPECT_EQ(last_msg_->biases[1].bias, 1101319226)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[1].bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[1].bias)),
+            1101319226)
       << "incorrect value for biases[1].bias, expected 1101319226, is "
       << last_msg_->biases[1].bias;
-  EXPECT_EQ(last_msg_->biases[1].code, 207)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[1].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[1].code)),
+            207)
       << "incorrect value for biases[1].code, expected 207, is "
       << last_msg_->biases[1].code;
-  EXPECT_EQ(last_msg_->biases[1].discontinuity_counter, 146)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[1].discontinuity_counter)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[1].discontinuity_counter)),
+            146)
       << "incorrect value for biases[1].discontinuity_counter, expected 146, "
          "is "
       << last_msg_->biases[1].discontinuity_counter;
-  EXPECT_EQ(last_msg_->biases[1].integer_indicator, 187)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[1].integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[1].integer_indicator)),
+            187)
       << "incorrect value for biases[1].integer_indicator, expected 187, is "
       << last_msg_->biases[1].integer_indicator;
-  EXPECT_EQ(last_msg_->biases[1].widelane_integer_indicator, 33)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[1].widelane_integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[1].widelane_integer_indicator)),
+            33)
       << "incorrect value for biases[1].widelane_integer_indicator, expected "
          "33, is "
       << last_msg_->biases[1].widelane_integer_indicator;
-  EXPECT_EQ(last_msg_->biases[2].bias, -64184056)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[2].bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[2].bias)),
+            -64184056)
       << "incorrect value for biases[2].bias, expected -64184056, is "
       << last_msg_->biases[2].bias;
-  EXPECT_EQ(last_msg_->biases[2].code, 114)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[2].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[2].code)),
+            114)
       << "incorrect value for biases[2].code, expected 114, is "
       << last_msg_->biases[2].code;
-  EXPECT_EQ(last_msg_->biases[2].discontinuity_counter, 52)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[2].discontinuity_counter)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[2].discontinuity_counter)),
+            52)
       << "incorrect value for biases[2].discontinuity_counter, expected 52, is "
       << last_msg_->biases[2].discontinuity_counter;
-  EXPECT_EQ(last_msg_->biases[2].integer_indicator, 49)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[2].integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[2].integer_indicator)),
+            49)
       << "incorrect value for biases[2].integer_indicator, expected 49, is "
       << last_msg_->biases[2].integer_indicator;
-  EXPECT_EQ(last_msg_->biases[2].widelane_integer_indicator, 248)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[2].widelane_integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[2].widelane_integer_indicator)),
+            248)
       << "incorrect value for biases[2].widelane_integer_indicator, expected "
          "248, is "
       << last_msg_->biases[2].widelane_integer_indicator;
-  EXPECT_EQ(last_msg_->biases[3].bias, -240298362)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[3].bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[3].bias)),
+            -240298362)
       << "incorrect value for biases[3].bias, expected -240298362, is "
       << last_msg_->biases[3].bias;
-  EXPECT_EQ(last_msg_->biases[3].code, 166)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[3].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[3].code)),
+            166)
       << "incorrect value for biases[3].code, expected 166, is "
       << last_msg_->biases[3].code;
-  EXPECT_EQ(last_msg_->biases[3].discontinuity_counter, 124)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[3].discontinuity_counter)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[3].discontinuity_counter)),
+            124)
       << "incorrect value for biases[3].discontinuity_counter, expected 124, "
          "is "
       << last_msg_->biases[3].discontinuity_counter;
-  EXPECT_EQ(last_msg_->biases[3].integer_indicator, 168)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[3].integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[3].integer_indicator)),
+            168)
       << "incorrect value for biases[3].integer_indicator, expected 168, is "
       << last_msg_->biases[3].integer_indicator;
-  EXPECT_EQ(last_msg_->biases[3].widelane_integer_indicator, 232)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[3].widelane_integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[3].widelane_integer_indicator)),
+            232)
       << "incorrect value for biases[3].widelane_integer_indicator, expected "
          "232, is "
       << last_msg_->biases[3].widelane_integer_indicator;
-  EXPECT_EQ(last_msg_->biases[4].bias, -1581740159)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[4].bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[4].bias)),
+            -1581740159)
       << "incorrect value for biases[4].bias, expected -1581740159, is "
       << last_msg_->biases[4].bias;
-  EXPECT_EQ(last_msg_->biases[4].code, 174)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[4].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[4].code)),
+            174)
       << "incorrect value for biases[4].code, expected 174, is "
       << last_msg_->biases[4].code;
-  EXPECT_EQ(last_msg_->biases[4].discontinuity_counter, 155)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[4].discontinuity_counter)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[4].discontinuity_counter)),
+            155)
       << "incorrect value for biases[4].discontinuity_counter, expected 155, "
          "is "
       << last_msg_->biases[4].discontinuity_counter;
-  EXPECT_EQ(last_msg_->biases[4].integer_indicator, 44)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[4].integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[4].integer_indicator)),
+            44)
       << "incorrect value for biases[4].integer_indicator, expected 44, is "
       << last_msg_->biases[4].integer_indicator;
-  EXPECT_EQ(last_msg_->biases[4].widelane_integer_indicator, 142)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[4].widelane_integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[4].widelane_integer_indicator)),
+            142)
       << "incorrect value for biases[4].widelane_integer_indicator, expected "
          "142, is "
       << last_msg_->biases[4].widelane_integer_indicator;
-  EXPECT_EQ(last_msg_->biases[5].bias, -1730297136)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[5].bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[5].bias)),
+            -1730297136)
       << "incorrect value for biases[5].bias, expected -1730297136, is "
       << last_msg_->biases[5].bias;
-  EXPECT_EQ(last_msg_->biases[5].code, 211)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[5].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[5].code)),
+            211)
       << "incorrect value for biases[5].code, expected 211, is "
       << last_msg_->biases[5].code;
-  EXPECT_EQ(last_msg_->biases[5].discontinuity_counter, 189)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[5].discontinuity_counter)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[5].discontinuity_counter)),
+            189)
       << "incorrect value for biases[5].discontinuity_counter, expected 189, "
          "is "
       << last_msg_->biases[5].discontinuity_counter;
-  EXPECT_EQ(last_msg_->biases[5].integer_indicator, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[5].integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[5].integer_indicator)),
+            15)
       << "incorrect value for biases[5].integer_indicator, expected 15, is "
       << last_msg_->biases[5].integer_indicator;
-  EXPECT_EQ(last_msg_->biases[5].widelane_integer_indicator, 36)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[5].widelane_integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[5].widelane_integer_indicator)),
+            36)
       << "incorrect value for biases[5].widelane_integer_indicator, expected "
          "36, is "
       << last_msg_->biases[5].widelane_integer_indicator;
-  EXPECT_EQ(last_msg_->biases[6].bias, -1117221444)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[6].bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[6].bias)),
+            -1117221444)
       << "incorrect value for biases[6].bias, expected -1117221444, is "
       << last_msg_->biases[6].bias;
-  EXPECT_EQ(last_msg_->biases[6].code, 16)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[6].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[6].code)),
+            16)
       << "incorrect value for biases[6].code, expected 16, is "
       << last_msg_->biases[6].code;
-  EXPECT_EQ(last_msg_->biases[6].discontinuity_counter, 34)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[6].discontinuity_counter)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[6].discontinuity_counter)),
+            34)
       << "incorrect value for biases[6].discontinuity_counter, expected 34, is "
       << last_msg_->biases[6].discontinuity_counter;
-  EXPECT_EQ(last_msg_->biases[6].integer_indicator, 203)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[6].integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[6].integer_indicator)),
+            203)
       << "incorrect value for biases[6].integer_indicator, expected 203, is "
       << last_msg_->biases[6].integer_indicator;
-  EXPECT_EQ(last_msg_->biases[6].widelane_integer_indicator, 87)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[6].widelane_integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[6].widelane_integer_indicator)),
+            87)
       << "incorrect value for biases[6].widelane_integer_indicator, expected "
          "87, is "
       << last_msg_->biases[6].widelane_integer_indicator;
-  EXPECT_EQ(last_msg_->biases[7].bias, -1137604357)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[7].bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[7].bias)),
+            -1137604357)
       << "incorrect value for biases[7].bias, expected -1137604357, is "
       << last_msg_->biases[7].bias;
-  EXPECT_EQ(last_msg_->biases[7].code, 102)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[7].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[7].code)),
+            102)
       << "incorrect value for biases[7].code, expected 102, is "
       << last_msg_->biases[7].code;
-  EXPECT_EQ(last_msg_->biases[7].discontinuity_counter, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[7].discontinuity_counter)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[7].discontinuity_counter)),
+            22)
       << "incorrect value for biases[7].discontinuity_counter, expected 22, is "
       << last_msg_->biases[7].discontinuity_counter;
-  EXPECT_EQ(last_msg_->biases[7].integer_indicator, 156)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[7].integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[7].integer_indicator)),
+            156)
       << "incorrect value for biases[7].integer_indicator, expected 156, is "
       << last_msg_->biases[7].integer_indicator;
-  EXPECT_EQ(last_msg_->biases[7].widelane_integer_indicator, 252)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[7].widelane_integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[7].widelane_integer_indicator)),
+            252)
       << "incorrect value for biases[7].widelane_integer_indicator, expected "
          "252, is "
       << last_msg_->biases[7].widelane_integer_indicator;
-  EXPECT_EQ(last_msg_->biases[8].bias, -1910370172)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[8].bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[8].bias)),
+            -1910370172)
       << "incorrect value for biases[8].bias, expected -1910370172, is "
       << last_msg_->biases[8].bias;
-  EXPECT_EQ(last_msg_->biases[8].code, 157)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[8].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[8].code)),
+            157)
       << "incorrect value for biases[8].code, expected 157, is "
       << last_msg_->biases[8].code;
-  EXPECT_EQ(last_msg_->biases[8].discontinuity_counter, 49)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[8].discontinuity_counter)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[8].discontinuity_counter)),
+            49)
       << "incorrect value for biases[8].discontinuity_counter, expected 49, is "
       << last_msg_->biases[8].discontinuity_counter;
-  EXPECT_EQ(last_msg_->biases[8].integer_indicator, 222)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[8].integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[8].integer_indicator)),
+            222)
       << "incorrect value for biases[8].integer_indicator, expected 222, is "
       << last_msg_->biases[8].integer_indicator;
-  EXPECT_EQ(last_msg_->biases[8].widelane_integer_indicator, 245)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[8].widelane_integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[8].widelane_integer_indicator)),
+            245)
       << "incorrect value for biases[8].widelane_integer_indicator, expected "
          "245, is "
       << last_msg_->biases[8].widelane_integer_indicator;
-  EXPECT_EQ(last_msg_->biases[9].bias, 1247996869)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[9].bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[9].bias)),
+            1247996869)
       << "incorrect value for biases[9].bias, expected 1247996869, is "
       << last_msg_->biases[9].bias;
-  EXPECT_EQ(last_msg_->biases[9].code, 228)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[9].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[9].code)),
+            228)
       << "incorrect value for biases[9].code, expected 228, is "
       << last_msg_->biases[9].code;
-  EXPECT_EQ(last_msg_->biases[9].discontinuity_counter, 221)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[9].discontinuity_counter)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[9].discontinuity_counter)),
+            221)
       << "incorrect value for biases[9].discontinuity_counter, expected 221, "
          "is "
       << last_msg_->biases[9].discontinuity_counter;
-  EXPECT_EQ(last_msg_->biases[9].integer_indicator, 85)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[9].integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[9].integer_indicator)),
+            85)
       << "incorrect value for biases[9].integer_indicator, expected 85, is "
       << last_msg_->biases[9].integer_indicator;
-  EXPECT_EQ(last_msg_->biases[9].widelane_integer_indicator, 139)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[9].widelane_integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[9].widelane_integer_indicator)),
+            139)
       << "incorrect value for biases[9].widelane_integer_indicator, expected "
          "139, is "
       << last_msg_->biases[9].widelane_integer_indicator;
-  EXPECT_EQ(last_msg_->biases[10].bias, -1133446161)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[10].bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[10].bias)),
+            -1133446161)
       << "incorrect value for biases[10].bias, expected -1133446161, is "
       << last_msg_->biases[10].bias;
-  EXPECT_EQ(last_msg_->biases[10].code, 107)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[10].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[10].code)),
+            107)
       << "incorrect value for biases[10].code, expected 107, is "
       << last_msg_->biases[10].code;
-  EXPECT_EQ(last_msg_->biases[10].discontinuity_counter, 38)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[10].discontinuity_counter)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[10].discontinuity_counter)),
+            38)
       << "incorrect value for biases[10].discontinuity_counter, expected 38, "
          "is "
       << last_msg_->biases[10].discontinuity_counter;
-  EXPECT_EQ(last_msg_->biases[10].integer_indicator, 70)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[10].integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[10].integer_indicator)),
+            70)
       << "incorrect value for biases[10].integer_indicator, expected 70, is "
       << last_msg_->biases[10].integer_indicator;
-  EXPECT_EQ(last_msg_->biases[10].widelane_integer_indicator, 36)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[10].widelane_integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[10].widelane_integer_indicator)),
+            36)
       << "incorrect value for biases[10].widelane_integer_indicator, expected "
          "36, is "
       << last_msg_->biases[10].widelane_integer_indicator;
-  EXPECT_EQ(last_msg_->biases[11].bias, -720934762)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[11].bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[11].bias)),
+            -720934762)
       << "incorrect value for biases[11].bias, expected -720934762, is "
       << last_msg_->biases[11].bias;
-  EXPECT_EQ(last_msg_->biases[11].code, 124)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[11].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[11].code)),
+            124)
       << "incorrect value for biases[11].code, expected 124, is "
       << last_msg_->biases[11].code;
-  EXPECT_EQ(last_msg_->biases[11].discontinuity_counter, 164)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[11].discontinuity_counter)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[11].discontinuity_counter)),
+            164)
       << "incorrect value for biases[11].discontinuity_counter, expected 164, "
          "is "
       << last_msg_->biases[11].discontinuity_counter;
-  EXPECT_EQ(last_msg_->biases[11].integer_indicator, 246)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[11].integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[11].integer_indicator)),
+            246)
       << "incorrect value for biases[11].integer_indicator, expected 246, is "
       << last_msg_->biases[11].integer_indicator;
-  EXPECT_EQ(last_msg_->biases[11].widelane_integer_indicator, 141)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[11].widelane_integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[11].widelane_integer_indicator)),
+            141)
       << "incorrect value for biases[11].widelane_integer_indicator, expected "
          "141, is "
       << last_msg_->biases[11].widelane_integer_indicator;
-  EXPECT_EQ(last_msg_->biases[12].bias, 706252548)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[12].bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[12].bias)),
+            706252548)
       << "incorrect value for biases[12].bias, expected 706252548, is "
       << last_msg_->biases[12].bias;
-  EXPECT_EQ(last_msg_->biases[12].code, 44)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[12].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[12].code)),
+            44)
       << "incorrect value for biases[12].code, expected 44, is "
       << last_msg_->biases[12].code;
-  EXPECT_EQ(last_msg_->biases[12].discontinuity_counter, 192)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[12].discontinuity_counter)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[12].discontinuity_counter)),
+            192)
       << "incorrect value for biases[12].discontinuity_counter, expected 192, "
          "is "
       << last_msg_->biases[12].discontinuity_counter;
-  EXPECT_EQ(last_msg_->biases[12].integer_indicator, 21)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[12].integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[12].integer_indicator)),
+            21)
       << "incorrect value for biases[12].integer_indicator, expected 21, is "
       << last_msg_->biases[12].integer_indicator;
-  EXPECT_EQ(last_msg_->biases[12].widelane_integer_indicator, 244)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[12].widelane_integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[12].widelane_integer_indicator)),
+            244)
       << "incorrect value for biases[12].widelane_integer_indicator, expected "
          "244, is "
       << last_msg_->biases[12].widelane_integer_indicator;
-  EXPECT_EQ(last_msg_->biases[13].bias, 388855338)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[13].bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[13].bias)),
+            388855338)
       << "incorrect value for biases[13].bias, expected 388855338, is "
       << last_msg_->biases[13].bias;
-  EXPECT_EQ(last_msg_->biases[13].code, 21)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[13].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[13].code)),
+            21)
       << "incorrect value for biases[13].code, expected 21, is "
       << last_msg_->biases[13].code;
-  EXPECT_EQ(last_msg_->biases[13].discontinuity_counter, 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[13].discontinuity_counter)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[13].discontinuity_counter)),
+            7)
       << "incorrect value for biases[13].discontinuity_counter, expected 7, is "
       << last_msg_->biases[13].discontinuity_counter;
-  EXPECT_EQ(last_msg_->biases[13].integer_indicator, 84)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[13].integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[13].integer_indicator)),
+            84)
       << "incorrect value for biases[13].integer_indicator, expected 84, is "
       << last_msg_->biases[13].integer_indicator;
-  EXPECT_EQ(last_msg_->biases[13].widelane_integer_indicator, 136)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[13].widelane_integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[13].widelane_integer_indicator)),
+            136)
       << "incorrect value for biases[13].widelane_integer_indicator, expected "
          "136, is "
       << last_msg_->biases[13].widelane_integer_indicator;
-  EXPECT_EQ(last_msg_->biases[14].bias, 47517353)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[14].bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[14].bias)),
+            47517353)
       << "incorrect value for biases[14].bias, expected 47517353, is "
       << last_msg_->biases[14].bias;
-  EXPECT_EQ(last_msg_->biases[14].code, 174)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[14].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[14].code)),
+            174)
       << "incorrect value for biases[14].code, expected 174, is "
       << last_msg_->biases[14].code;
-  EXPECT_EQ(last_msg_->biases[14].discontinuity_counter, 54)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[14].discontinuity_counter)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[14].discontinuity_counter)),
+            54)
       << "incorrect value for biases[14].discontinuity_counter, expected 54, "
          "is "
       << last_msg_->biases[14].discontinuity_counter;
-  EXPECT_EQ(last_msg_->biases[14].integer_indicator, 175)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[14].integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[14].integer_indicator)),
+            175)
       << "incorrect value for biases[14].integer_indicator, expected 175, is "
       << last_msg_->biases[14].integer_indicator;
-  EXPECT_EQ(last_msg_->biases[14].widelane_integer_indicator, 129)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[14].widelane_integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[14].widelane_integer_indicator)),
+            129)
       << "incorrect value for biases[14].widelane_integer_indicator, expected "
          "129, is "
       << last_msg_->biases[14].widelane_integer_indicator;
-  EXPECT_EQ(last_msg_->biases[15].bias, -2124125745)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[15].bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[15].bias)),
+            -2124125745)
       << "incorrect value for biases[15].bias, expected -2124125745, is "
       << last_msg_->biases[15].bias;
-  EXPECT_EQ(last_msg_->biases[15].code, 197)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[15].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[15].code)),
+            197)
       << "incorrect value for biases[15].code, expected 197, is "
       << last_msg_->biases[15].code;
-  EXPECT_EQ(last_msg_->biases[15].discontinuity_counter, 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[15].discontinuity_counter)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[15].discontinuity_counter)),
+            13)
       << "incorrect value for biases[15].discontinuity_counter, expected 13, "
          "is "
       << last_msg_->biases[15].discontinuity_counter;
-  EXPECT_EQ(last_msg_->biases[15].integer_indicator, 98)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[15].integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[15].integer_indicator)),
+            98)
       << "incorrect value for biases[15].integer_indicator, expected 98, is "
       << last_msg_->biases[15].integer_indicator;
-  EXPECT_EQ(last_msg_->biases[15].widelane_integer_indicator, 60)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[15].widelane_integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[15].widelane_integer_indicator)),
+            60)
       << "incorrect value for biases[15].widelane_integer_indicator, expected "
          "60, is "
       << last_msg_->biases[15].widelane_integer_indicator;
-  EXPECT_EQ(last_msg_->biases[16].bias, -1401812607)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[16].bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[16].bias)),
+            -1401812607)
       << "incorrect value for biases[16].bias, expected -1401812607, is "
       << last_msg_->biases[16].bias;
-  EXPECT_EQ(last_msg_->biases[16].code, 72)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[16].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[16].code)),
+            72)
       << "incorrect value for biases[16].code, expected 72, is "
       << last_msg_->biases[16].code;
-  EXPECT_EQ(last_msg_->biases[16].discontinuity_counter, 140)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[16].discontinuity_counter)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[16].discontinuity_counter)),
+            140)
       << "incorrect value for biases[16].discontinuity_counter, expected 140, "
          "is "
       << last_msg_->biases[16].discontinuity_counter;
-  EXPECT_EQ(last_msg_->biases[16].integer_indicator, 136)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[16].integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[16].integer_indicator)),
+            136)
       << "incorrect value for biases[16].integer_indicator, expected 136, is "
       << last_msg_->biases[16].integer_indicator;
-  EXPECT_EQ(last_msg_->biases[16].widelane_integer_indicator, 240)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[16].widelane_integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[16].widelane_integer_indicator)),
+            240)
       << "incorrect value for biases[16].widelane_integer_indicator, expected "
          "240, is "
       << last_msg_->biases[16].widelane_integer_indicator;
-  EXPECT_EQ(last_msg_->biases[17].bias, 60257151)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[17].bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[17].bias)),
+            60257151)
       << "incorrect value for biases[17].bias, expected 60257151, is "
       << last_msg_->biases[17].bias;
-  EXPECT_EQ(last_msg_->biases[17].code, 151)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[17].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[17].code)),
+            151)
       << "incorrect value for biases[17].code, expected 151, is "
       << last_msg_->biases[17].code;
-  EXPECT_EQ(last_msg_->biases[17].discontinuity_counter, 210)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[17].discontinuity_counter)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[17].discontinuity_counter)),
+            210)
       << "incorrect value for biases[17].discontinuity_counter, expected 210, "
          "is "
       << last_msg_->biases[17].discontinuity_counter;
-  EXPECT_EQ(last_msg_->biases[17].integer_indicator, 150)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[17].integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[17].integer_indicator)),
+            150)
       << "incorrect value for biases[17].integer_indicator, expected 150, is "
       << last_msg_->biases[17].integer_indicator;
-  EXPECT_EQ(last_msg_->biases[17].widelane_integer_indicator, 17)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[17].widelane_integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[17].widelane_integer_indicator)),
+            17)
       << "incorrect value for biases[17].widelane_integer_indicator, expected "
          "17, is "
       << last_msg_->biases[17].widelane_integer_indicator;
-  EXPECT_EQ(last_msg_->biases[18].bias, 41820677)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[18].bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[18].bias)),
+            41820677)
       << "incorrect value for biases[18].bias, expected 41820677, is "
       << last_msg_->biases[18].bias;
-  EXPECT_EQ(last_msg_->biases[18].code, 242)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[18].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[18].code)),
+            242)
       << "incorrect value for biases[18].code, expected 242, is "
       << last_msg_->biases[18].code;
-  EXPECT_EQ(last_msg_->biases[18].discontinuity_counter, 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[18].discontinuity_counter)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[18].discontinuity_counter)),
+            14)
       << "incorrect value for biases[18].discontinuity_counter, expected 14, "
          "is "
       << last_msg_->biases[18].discontinuity_counter;
-  EXPECT_EQ(last_msg_->biases[18].integer_indicator, 254)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[18].integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[18].integer_indicator)),
+            254)
       << "incorrect value for biases[18].integer_indicator, expected 254, is "
       << last_msg_->biases[18].integer_indicator;
-  EXPECT_EQ(last_msg_->biases[18].widelane_integer_indicator, 215)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[18].widelane_integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[18].widelane_integer_indicator)),
+            215)
       << "incorrect value for biases[18].widelane_integer_indicator, expected "
          "215, is "
       << last_msg_->biases[18].widelane_integer_indicator;
-  EXPECT_EQ(last_msg_->biases[19].bias, 1640616471)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[19].bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[19].bias)),
+            1640616471)
       << "incorrect value for biases[19].bias, expected 1640616471, is "
       << last_msg_->biases[19].bias;
-  EXPECT_EQ(last_msg_->biases[19].code, 215)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[19].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[19].code)),
+            215)
       << "incorrect value for biases[19].code, expected 215, is "
       << last_msg_->biases[19].code;
-  EXPECT_EQ(last_msg_->biases[19].discontinuity_counter, 176)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[19].discontinuity_counter)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[19].discontinuity_counter)),
+            176)
       << "incorrect value for biases[19].discontinuity_counter, expected 176, "
          "is "
       << last_msg_->biases[19].discontinuity_counter;
-  EXPECT_EQ(last_msg_->biases[19].integer_indicator, 65)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[19].integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[19].integer_indicator)),
+            65)
       << "incorrect value for biases[19].integer_indicator, expected 65, is "
       << last_msg_->biases[19].integer_indicator;
-  EXPECT_EQ(last_msg_->biases[19].widelane_integer_indicator, 38)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[19].widelane_integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[19].widelane_integer_indicator)),
+            38)
       << "incorrect value for biases[19].widelane_integer_indicator, expected "
          "38, is "
       << last_msg_->biases[19].widelane_integer_indicator;
-  EXPECT_EQ(last_msg_->biases[20].bias, -744786918)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[20].bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[20].bias)),
+            -744786918)
       << "incorrect value for biases[20].bias, expected -744786918, is "
       << last_msg_->biases[20].bias;
-  EXPECT_EQ(last_msg_->biases[20].code, 36)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[20].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[20].code)),
+            36)
       << "incorrect value for biases[20].code, expected 36, is "
       << last_msg_->biases[20].code;
-  EXPECT_EQ(last_msg_->biases[20].discontinuity_counter, 224)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[20].discontinuity_counter)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[20].discontinuity_counter)),
+            224)
       << "incorrect value for biases[20].discontinuity_counter, expected 224, "
          "is "
       << last_msg_->biases[20].discontinuity_counter;
-  EXPECT_EQ(last_msg_->biases[20].integer_indicator, 207)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[20].integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[20].integer_indicator)),
+            207)
       << "incorrect value for biases[20].integer_indicator, expected 207, is "
       << last_msg_->biases[20].integer_indicator;
-  EXPECT_EQ(last_msg_->biases[20].widelane_integer_indicator, 92)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[20].widelane_integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[20].widelane_integer_indicator)),
+            92)
       << "incorrect value for biases[20].widelane_integer_indicator, expected "
          "92, is "
       << last_msg_->biases[20].widelane_integer_indicator;
-  EXPECT_EQ(last_msg_->biases[21].bias, 1966589763)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[21].bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[21].bias)),
+            1966589763)
       << "incorrect value for biases[21].bias, expected 1966589763, is "
       << last_msg_->biases[21].bias;
-  EXPECT_EQ(last_msg_->biases[21].code, 165)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[21].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[21].code)),
+            165)
       << "incorrect value for biases[21].code, expected 165, is "
       << last_msg_->biases[21].code;
-  EXPECT_EQ(last_msg_->biases[21].discontinuity_counter, 38)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[21].discontinuity_counter)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[21].discontinuity_counter)),
+            38)
       << "incorrect value for biases[21].discontinuity_counter, expected 38, "
          "is "
       << last_msg_->biases[21].discontinuity_counter;
-  EXPECT_EQ(last_msg_->biases[21].integer_indicator, 47)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[21].integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[21].integer_indicator)),
+            47)
       << "incorrect value for biases[21].integer_indicator, expected 47, is "
       << last_msg_->biases[21].integer_indicator;
-  EXPECT_EQ(last_msg_->biases[21].widelane_integer_indicator, 102)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[21].widelane_integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[21].widelane_integer_indicator)),
+            102)
       << "incorrect value for biases[21].widelane_integer_indicator, expected "
          "102, is "
       << last_msg_->biases[21].widelane_integer_indicator;
-  EXPECT_EQ(last_msg_->biases[22].bias, 364366310)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[22].bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[22].bias)),
+            364366310)
       << "incorrect value for biases[22].bias, expected 364366310, is "
       << last_msg_->biases[22].bias;
-  EXPECT_EQ(last_msg_->biases[22].code, 36)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[22].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[22].code)),
+            36)
       << "incorrect value for biases[22].code, expected 36, is "
       << last_msg_->biases[22].code;
-  EXPECT_EQ(last_msg_->biases[22].discontinuity_counter, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[22].discontinuity_counter)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[22].discontinuity_counter)),
+            1)
       << "incorrect value for biases[22].discontinuity_counter, expected 1, is "
       << last_msg_->biases[22].discontinuity_counter;
-  EXPECT_EQ(last_msg_->biases[22].integer_indicator, 169)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[22].integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[22].integer_indicator)),
+            169)
       << "incorrect value for biases[22].integer_indicator, expected 169, is "
       << last_msg_->biases[22].integer_indicator;
-  EXPECT_EQ(last_msg_->biases[22].widelane_integer_indicator, 33)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[22].widelane_integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[22].widelane_integer_indicator)),
+            33)
       << "incorrect value for biases[22].widelane_integer_indicator, expected "
          "33, is "
       << last_msg_->biases[22].widelane_integer_indicator;
-  EXPECT_EQ(last_msg_->biases[23].bias, -1839031379)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[23].bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[23].bias)),
+            -1839031379)
       << "incorrect value for biases[23].bias, expected -1839031379, is "
       << last_msg_->biases[23].bias;
-  EXPECT_EQ(last_msg_->biases[23].code, 42)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[23].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[23].code)),
+            42)
       << "incorrect value for biases[23].code, expected 42, is "
       << last_msg_->biases[23].code;
-  EXPECT_EQ(last_msg_->biases[23].discontinuity_counter, 173)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[23].discontinuity_counter)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[23].discontinuity_counter)),
+            173)
       << "incorrect value for biases[23].discontinuity_counter, expected 173, "
          "is "
       << last_msg_->biases[23].discontinuity_counter;
-  EXPECT_EQ(last_msg_->biases[23].integer_indicator, 62)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[23].integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[23].integer_indicator)),
+            62)
       << "incorrect value for biases[23].integer_indicator, expected 62, is "
       << last_msg_->biases[23].integer_indicator;
-  EXPECT_EQ(last_msg_->biases[23].widelane_integer_indicator, 147)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[23].widelane_integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[23].widelane_integer_indicator)),
+            147)
       << "incorrect value for biases[23].widelane_integer_indicator, expected "
          "147, is "
       << last_msg_->biases[23].widelane_integer_indicator;
-  EXPECT_EQ(last_msg_->biases[24].bias, 31817639)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[24].bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[24].bias)),
+            31817639)
       << "incorrect value for biases[24].bias, expected 31817639, is "
       << last_msg_->biases[24].bias;
-  EXPECT_EQ(last_msg_->biases[24].code, 231)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[24].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[24].code)),
+            231)
       << "incorrect value for biases[24].code, expected 231, is "
       << last_msg_->biases[24].code;
-  EXPECT_EQ(last_msg_->biases[24].discontinuity_counter, 82)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[24].discontinuity_counter)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[24].discontinuity_counter)),
+            82)
       << "incorrect value for biases[24].discontinuity_counter, expected 82, "
          "is "
       << last_msg_->biases[24].discontinuity_counter;
-  EXPECT_EQ(last_msg_->biases[24].integer_indicator, 167)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[24].integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[24].integer_indicator)),
+            167)
       << "incorrect value for biases[24].integer_indicator, expected 167, is "
       << last_msg_->biases[24].integer_indicator;
-  EXPECT_EQ(last_msg_->biases[24].widelane_integer_indicator, 138)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[24].widelane_integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[24].widelane_integer_indicator)),
+            138)
       << "incorrect value for biases[24].widelane_integer_indicator, expected "
          "138, is "
       << last_msg_->biases[24].widelane_integer_indicator;
-  EXPECT_EQ(last_msg_->biases[25].bias, -1619830156)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[25].bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[25].bias)),
+            -1619830156)
       << "incorrect value for biases[25].bias, expected -1619830156, is "
       << last_msg_->biases[25].bias;
-  EXPECT_EQ(last_msg_->biases[25].code, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[25].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[25].code)),
+            2)
       << "incorrect value for biases[25].code, expected 2, is "
       << last_msg_->biases[25].code;
-  EXPECT_EQ(last_msg_->biases[25].discontinuity_counter, 207)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[25].discontinuity_counter)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[25].discontinuity_counter)),
+            207)
       << "incorrect value for biases[25].discontinuity_counter, expected 207, "
          "is "
       << last_msg_->biases[25].discontinuity_counter;
-  EXPECT_EQ(last_msg_->biases[25].integer_indicator, 127)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[25].integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[25].integer_indicator)),
+            127)
       << "incorrect value for biases[25].integer_indicator, expected 127, is "
       << last_msg_->biases[25].integer_indicator;
-  EXPECT_EQ(last_msg_->biases[25].widelane_integer_indicator, 237)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[25].widelane_integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[25].widelane_integer_indicator)),
+            237)
       << "incorrect value for biases[25].widelane_integer_indicator, expected "
          "237, is "
       << last_msg_->biases[25].widelane_integer_indicator;
-  EXPECT_EQ(last_msg_->biases[26].bias, -83375622)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[26].bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[26].bias)),
+            -83375622)
       << "incorrect value for biases[26].bias, expected -83375622, is "
       << last_msg_->biases[26].bias;
-  EXPECT_EQ(last_msg_->biases[26].code, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[26].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[26].code)),
+            3)
       << "incorrect value for biases[26].code, expected 3, is "
       << last_msg_->biases[26].code;
-  EXPECT_EQ(last_msg_->biases[26].discontinuity_counter, 145)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[26].discontinuity_counter)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[26].discontinuity_counter)),
+            145)
       << "incorrect value for biases[26].discontinuity_counter, expected 145, "
          "is "
       << last_msg_->biases[26].discontinuity_counter;
-  EXPECT_EQ(last_msg_->biases[26].integer_indicator, 42)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[26].integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[26].integer_indicator)),
+            42)
       << "incorrect value for biases[26].integer_indicator, expected 42, is "
       << last_msg_->biases[26].integer_indicator;
-  EXPECT_EQ(last_msg_->biases[26].widelane_integer_indicator, 66)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[26].widelane_integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[26].widelane_integer_indicator)),
+            66)
       << "incorrect value for biases[26].widelane_integer_indicator, expected "
          "66, is "
       << last_msg_->biases[26].widelane_integer_indicator;
-  EXPECT_EQ(last_msg_->biases[27].bias, 1077458389)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[27].bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[27].bias)),
+            1077458389)
       << "incorrect value for biases[27].bias, expected 1077458389, is "
       << last_msg_->biases[27].bias;
-  EXPECT_EQ(last_msg_->biases[27].code, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[27].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[27].code)),
+            2)
       << "incorrect value for biases[27].code, expected 2, is "
       << last_msg_->biases[27].code;
-  EXPECT_EQ(last_msg_->biases[27].discontinuity_counter, 26)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[27].discontinuity_counter)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[27].discontinuity_counter)),
+            26)
       << "incorrect value for biases[27].discontinuity_counter, expected 26, "
          "is "
       << last_msg_->biases[27].discontinuity_counter;
-  EXPECT_EQ(last_msg_->biases[27].integer_indicator, 75)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[27].integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[27].integer_indicator)),
+            75)
       << "incorrect value for biases[27].integer_indicator, expected 75, is "
       << last_msg_->biases[27].integer_indicator;
-  EXPECT_EQ(last_msg_->biases[27].widelane_integer_indicator, 230)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[27].widelane_integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[27].widelane_integer_indicator)),
+            230)
       << "incorrect value for biases[27].widelane_integer_indicator, expected "
          "230, is "
       << last_msg_->biases[27].widelane_integer_indicator;
-  EXPECT_EQ(last_msg_->biases[28].bias, -883355501)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[28].bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[28].bias)),
+            -883355501)
       << "incorrect value for biases[28].bias, expected -883355501, is "
       << last_msg_->biases[28].bias;
-  EXPECT_EQ(last_msg_->biases[28].code, 97)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[28].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[28].code)),
+            97)
       << "incorrect value for biases[28].code, expected 97, is "
       << last_msg_->biases[28].code;
-  EXPECT_EQ(last_msg_->biases[28].discontinuity_counter, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[28].discontinuity_counter)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[28].discontinuity_counter)),
+            6)
       << "incorrect value for biases[28].discontinuity_counter, expected 6, is "
       << last_msg_->biases[28].discontinuity_counter;
-  EXPECT_EQ(last_msg_->biases[28].integer_indicator, 88)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[28].integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[28].integer_indicator)),
+            88)
       << "incorrect value for biases[28].integer_indicator, expected 88, is "
       << last_msg_->biases[28].integer_indicator;
-  EXPECT_EQ(last_msg_->biases[28].widelane_integer_indicator, 255)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[28].widelane_integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[28].widelane_integer_indicator)),
+            255)
       << "incorrect value for biases[28].widelane_integer_indicator, expected "
          "255, is "
       << last_msg_->biases[28].widelane_integer_indicator;
-  EXPECT_EQ(last_msg_->biases[29].bias, -1448611273)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[29].bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[29].bias)),
+            -1448611273)
       << "incorrect value for biases[29].bias, expected -1448611273, is "
       << last_msg_->biases[29].bias;
-  EXPECT_EQ(last_msg_->biases[29].code, 27)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[29].code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->biases[29].code)),
+            27)
       << "incorrect value for biases[29].code, expected 27, is "
       << last_msg_->biases[29].code;
-  EXPECT_EQ(last_msg_->biases[29].discontinuity_counter, 230)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[29].discontinuity_counter)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[29].discontinuity_counter)),
+            230)
       << "incorrect value for biases[29].discontinuity_counter, expected 230, "
          "is "
       << last_msg_->biases[29].discontinuity_counter;
-  EXPECT_EQ(last_msg_->biases[29].integer_indicator, 68)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[29].integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[29].integer_indicator)),
+            68)
       << "incorrect value for biases[29].integer_indicator, expected 68, is "
       << last_msg_->biases[29].integer_indicator;
-  EXPECT_EQ(last_msg_->biases[29].widelane_integer_indicator, 243)
+  EXPECT_EQ(get_as<decltype(last_msg_->biases[29].widelane_integer_indicator)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->biases[29].widelane_integer_indicator)),
+            243)
       << "incorrect value for biases[29].widelane_integer_indicator, expected "
          "243, is "
       << last_msg_->biases[29].widelane_integer_indicator;
-  EXPECT_EQ(last_msg_->dispersive_bias, 98)
+  EXPECT_EQ(get_as<decltype(last_msg_->dispersive_bias)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->dispersive_bias)),
+            98)
       << "incorrect value for dispersive_bias, expected 98, is "
       << last_msg_->dispersive_bias;
-  EXPECT_EQ(last_msg_->iod_ssr, 230)
+  EXPECT_EQ(get_as<decltype(last_msg_->iod_ssr)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iod_ssr)),
+            230)
       << "incorrect value for iod_ssr, expected 230, is " << last_msg_->iod_ssr;
-  EXPECT_EQ(last_msg_->mw_consistency, 209)
+  EXPECT_EQ(get_as<decltype(last_msg_->mw_consistency)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->mw_consistency)),
+            209)
       << "incorrect value for mw_consistency, expected 209, is "
       << last_msg_->mw_consistency;
-  EXPECT_EQ(last_msg_->sid.code, 82)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.code)),
+            82)
       << "incorrect value for sid.code, expected 82, is "
       << last_msg_->sid.code;
-  EXPECT_EQ(last_msg_->sid.sat, 169)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.sat)),
+            169)
       << "incorrect value for sid.sat, expected 169, is " << last_msg_->sid.sat;
-  EXPECT_EQ(last_msg_->time.tow, 210803409)
+  EXPECT_EQ(get_as<decltype(last_msg_->time.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->time.tow)),
+            210803409)
       << "incorrect value for time.tow, expected 210803409, is "
       << last_msg_->time.tow;
-  EXPECT_EQ(last_msg_->time.wn, 42197)
+  EXPECT_EQ(get_as<decltype(last_msg_->time.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->time.wn)),
+            42197)
       << "incorrect value for time.wn, expected 42197, is "
       << last_msg_->time.wn;
-  EXPECT_EQ(last_msg_->update_interval, 177)
+  EXPECT_EQ(get_as<decltype(last_msg_->update_interval)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->update_interval)),
+            177)
       << "incorrect value for update_interval, expected 177, is "
       << last_msg_->update_interval;
-  EXPECT_EQ(last_msg_->yaw, 5881)
+  EXPECT_EQ(get_as<decltype(last_msg_->yaw)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->yaw)),
+            5881)
       << "incorrect value for yaw, expected 5881, is " << last_msg_->yaw;
-  EXPECT_EQ(last_msg_->yaw_rate, 17)
+  EXPECT_EQ(get_as<decltype(last_msg_->yaw_rate)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->yaw_rate)),
+            17)
       << "incorrect value for yaw_rate, expected 17, is "
       << last_msg_->yaw_rate;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrSatelliteApc.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrSatelliteApc.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/ssr.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_ssr_MsgSsrSatelliteApc0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -247,101 +254,167 @@ TEST_F(Test_legacy_auto_check_sbp_ssr_MsgSsrSatelliteApc0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 0);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->apc[0].pco[0], 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pco[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pco[0])),
+            1)
       << "incorrect value for apc[0].pco[0], expected 1, is "
       << last_msg_->apc[0].pco[0];
-  EXPECT_EQ(last_msg_->apc[0].pco[1], -1)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pco[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pco[1])),
+            -1)
       << "incorrect value for apc[0].pco[1], expected -1, is "
       << last_msg_->apc[0].pco[1];
-  EXPECT_EQ(last_msg_->apc[0].pco[2], 729)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pco[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pco[2])),
+            729)
       << "incorrect value for apc[0].pco[2], expected 729, is "
       << last_msg_->apc[0].pco[2];
-  EXPECT_EQ(last_msg_->apc[0].pcv[0], 11)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[0])),
+            11)
       << "incorrect value for apc[0].pcv[0], expected 11, is "
       << last_msg_->apc[0].pcv[0];
-  EXPECT_EQ(last_msg_->apc[0].pcv[1], 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[1])),
+            10)
       << "incorrect value for apc[0].pcv[1], expected 10, is "
       << last_msg_->apc[0].pcv[1];
-  EXPECT_EQ(last_msg_->apc[0].pcv[2], 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[2])),
+            8)
       << "incorrect value for apc[0].pcv[2], expected 8, is "
       << last_msg_->apc[0].pcv[2];
-  EXPECT_EQ(last_msg_->apc[0].pcv[3], 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[3])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[3])),
+            5)
       << "incorrect value for apc[0].pcv[3], expected 5, is "
       << last_msg_->apc[0].pcv[3];
-  EXPECT_EQ(last_msg_->apc[0].pcv[4], 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[4])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[4])),
+            1)
       << "incorrect value for apc[0].pcv[4], expected 1, is "
       << last_msg_->apc[0].pcv[4];
-  EXPECT_EQ(last_msg_->apc[0].pcv[5], -4)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[5])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[5])),
+            -4)
       << "incorrect value for apc[0].pcv[5], expected -4, is "
       << last_msg_->apc[0].pcv[5];
-  EXPECT_EQ(last_msg_->apc[0].pcv[6], -8)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[6])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[6])),
+            -8)
       << "incorrect value for apc[0].pcv[6], expected -8, is "
       << last_msg_->apc[0].pcv[6];
-  EXPECT_EQ(last_msg_->apc[0].pcv[7], -10)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[7])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[7])),
+            -10)
       << "incorrect value for apc[0].pcv[7], expected -10, is "
       << last_msg_->apc[0].pcv[7];
-  EXPECT_EQ(last_msg_->apc[0].pcv[8], -10)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[8])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[8])),
+            -10)
       << "incorrect value for apc[0].pcv[8], expected -10, is "
       << last_msg_->apc[0].pcv[8];
-  EXPECT_EQ(last_msg_->apc[0].pcv[9], -10)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[9])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[9])),
+            -10)
       << "incorrect value for apc[0].pcv[9], expected -10, is "
       << last_msg_->apc[0].pcv[9];
-  EXPECT_EQ(last_msg_->apc[0].pcv[10], -7)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[10])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[10])),
+            -7)
       << "incorrect value for apc[0].pcv[10], expected -7, is "
       << last_msg_->apc[0].pcv[10];
-  EXPECT_EQ(last_msg_->apc[0].pcv[11], -4)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[11])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[11])),
+            -4)
       << "incorrect value for apc[0].pcv[11], expected -4, is "
       << last_msg_->apc[0].pcv[11];
-  EXPECT_EQ(last_msg_->apc[0].pcv[12], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[12])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[12])),
+            0)
       << "incorrect value for apc[0].pcv[12], expected 0, is "
       << last_msg_->apc[0].pcv[12];
-  EXPECT_EQ(last_msg_->apc[0].pcv[13], 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[13])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[13])),
+            6)
       << "incorrect value for apc[0].pcv[13], expected 6, is "
       << last_msg_->apc[0].pcv[13];
-  EXPECT_EQ(last_msg_->apc[0].pcv[14], 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[14])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[14])),
+            12)
       << "incorrect value for apc[0].pcv[14], expected 12, is "
       << last_msg_->apc[0].pcv[14];
-  EXPECT_EQ(last_msg_->apc[0].pcv[15], 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[15])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[15])),
+            22)
       << "incorrect value for apc[0].pcv[15], expected 22, is "
       << last_msg_->apc[0].pcv[15];
-  EXPECT_EQ(last_msg_->apc[0].pcv[16], 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[16])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[16])),
+            30)
       << "incorrect value for apc[0].pcv[16], expected 30, is "
       << last_msg_->apc[0].pcv[16];
-  EXPECT_EQ(last_msg_->apc[0].pcv[17], 41)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[17])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[17])),
+            41)
       << "incorrect value for apc[0].pcv[17], expected 41, is "
       << last_msg_->apc[0].pcv[17];
-  EXPECT_EQ(last_msg_->apc[0].pcv[18], 41)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[18])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[18])),
+            41)
       << "incorrect value for apc[0].pcv[18], expected 41, is "
       << last_msg_->apc[0].pcv[18];
-  EXPECT_EQ(last_msg_->apc[0].pcv[19], 41)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[19])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[19])),
+            41)
       << "incorrect value for apc[0].pcv[19], expected 41, is "
       << last_msg_->apc[0].pcv[19];
-  EXPECT_EQ(last_msg_->apc[0].pcv[20], 41)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[20])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[20])),
+            41)
       << "incorrect value for apc[0].pcv[20], expected 41, is "
       << last_msg_->apc[0].pcv[20];
-  EXPECT_EQ(last_msg_->apc[0].sat_info, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].sat_info)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].sat_info)),
+            4)
       << "incorrect value for apc[0].sat_info, expected 4, is "
       << last_msg_->apc[0].sat_info;
-  EXPECT_EQ(last_msg_->apc[0].sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].sid.code)),
+            0)
       << "incorrect value for apc[0].sid.code, expected 0, is "
       << last_msg_->apc[0].sid.code;
-  EXPECT_EQ(last_msg_->apc[0].sid.sat, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].sid.sat)),
+            2)
       << "incorrect value for apc[0].sid.sat, expected 2, is "
       << last_msg_->apc[0].sid.sat;
-  EXPECT_EQ(last_msg_->apc[0].svn, 61)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].svn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].svn)),
+            61)
       << "incorrect value for apc[0].svn, expected 61, is "
       << last_msg_->apc[0].svn;
-  EXPECT_EQ(last_msg_->iod_ssr, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->iod_ssr)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iod_ssr)),
+            3)
       << "incorrect value for iod_ssr, expected 3, is " << last_msg_->iod_ssr;
-  EXPECT_EQ(last_msg_->sol_id, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sol_id)),
+            2)
       << "incorrect value for sol_id, expected 2, is " << last_msg_->sol_id;
-  EXPECT_EQ(last_msg_->time.tow, 604799)
+  EXPECT_EQ(get_as<decltype(last_msg_->time.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->time.tow)),
+            604799)
       << "incorrect value for time.tow, expected 604799, is "
       << last_msg_->time.tow;
-  EXPECT_EQ(last_msg_->time.wn, 2222)
+  EXPECT_EQ(get_as<decltype(last_msg_->time.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->time.wn)),
+            2222)
       << "incorrect value for time.wn, expected 2222, is "
       << last_msg_->time.wn;
-  EXPECT_EQ(last_msg_->update_interval, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->update_interval)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->update_interval)),
+            1)
       << "incorrect value for update_interval, expected 1, is "
       << last_msg_->update_interval;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrSatelliteApcDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrSatelliteApcDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/ssr.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_ssr_MsgSsrSatelliteApcDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -1022,592 +1029,984 @@ TEST_F(Test_legacy_auto_check_sbp_ssr_MsgSsrSatelliteApcDepA0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 4920);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->apc[0].pco[0], -21547)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pco[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pco[0])),
+            -21547)
       << "incorrect value for apc[0].pco[0], expected -21547, is "
       << last_msg_->apc[0].pco[0];
-  EXPECT_EQ(last_msg_->apc[0].pco[1], -10498)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pco[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pco[1])),
+            -10498)
       << "incorrect value for apc[0].pco[1], expected -10498, is "
       << last_msg_->apc[0].pco[1];
-  EXPECT_EQ(last_msg_->apc[0].pco[2], 1236)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pco[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pco[2])),
+            1236)
       << "incorrect value for apc[0].pco[2], expected 1236, is "
       << last_msg_->apc[0].pco[2];
-  EXPECT_EQ(last_msg_->apc[0].pcv[0], 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[0])),
+            8)
       << "incorrect value for apc[0].pcv[0], expected 8, is "
       << last_msg_->apc[0].pcv[0];
-  EXPECT_EQ(last_msg_->apc[0].pcv[1], 33)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[1])),
+            33)
       << "incorrect value for apc[0].pcv[1], expected 33, is "
       << last_msg_->apc[0].pcv[1];
-  EXPECT_EQ(last_msg_->apc[0].pcv[2], 31)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[2])),
+            31)
       << "incorrect value for apc[0].pcv[2], expected 31, is "
       << last_msg_->apc[0].pcv[2];
-  EXPECT_EQ(last_msg_->apc[0].pcv[3], 80)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[3])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[3])),
+            80)
       << "incorrect value for apc[0].pcv[3], expected 80, is "
       << last_msg_->apc[0].pcv[3];
-  EXPECT_EQ(last_msg_->apc[0].pcv[4], 21)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[4])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[4])),
+            21)
       << "incorrect value for apc[0].pcv[4], expected 21, is "
       << last_msg_->apc[0].pcv[4];
-  EXPECT_EQ(last_msg_->apc[0].pcv[5], 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[5])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[5])),
+            4)
       << "incorrect value for apc[0].pcv[5], expected 4, is "
       << last_msg_->apc[0].pcv[5];
-  EXPECT_EQ(last_msg_->apc[0].pcv[6], 105)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[6])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[6])),
+            105)
       << "incorrect value for apc[0].pcv[6], expected 105, is "
       << last_msg_->apc[0].pcv[6];
-  EXPECT_EQ(last_msg_->apc[0].pcv[7], -31)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[7])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[7])),
+            -31)
       << "incorrect value for apc[0].pcv[7], expected -31, is "
       << last_msg_->apc[0].pcv[7];
-  EXPECT_EQ(last_msg_->apc[0].pcv[8], 39)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[8])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[8])),
+            39)
       << "incorrect value for apc[0].pcv[8], expected 39, is "
       << last_msg_->apc[0].pcv[8];
-  EXPECT_EQ(last_msg_->apc[0].pcv[9], -117)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[9])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[9])),
+            -117)
       << "incorrect value for apc[0].pcv[9], expected -117, is "
       << last_msg_->apc[0].pcv[9];
-  EXPECT_EQ(last_msg_->apc[0].pcv[10], 124)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[10])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[10])),
+            124)
       << "incorrect value for apc[0].pcv[10], expected 124, is "
       << last_msg_->apc[0].pcv[10];
-  EXPECT_EQ(last_msg_->apc[0].pcv[11], -107)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[11])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[11])),
+            -107)
       << "incorrect value for apc[0].pcv[11], expected -107, is "
       << last_msg_->apc[0].pcv[11];
-  EXPECT_EQ(last_msg_->apc[0].pcv[12], 48)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[12])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[12])),
+            48)
       << "incorrect value for apc[0].pcv[12], expected 48, is "
       << last_msg_->apc[0].pcv[12];
-  EXPECT_EQ(last_msg_->apc[0].pcv[13], 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[13])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[13])),
+            15)
       << "incorrect value for apc[0].pcv[13], expected 15, is "
       << last_msg_->apc[0].pcv[13];
-  EXPECT_EQ(last_msg_->apc[0].pcv[14], -42)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[14])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[14])),
+            -42)
       << "incorrect value for apc[0].pcv[14], expected -42, is "
       << last_msg_->apc[0].pcv[14];
-  EXPECT_EQ(last_msg_->apc[0].pcv[15], -59)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[15])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[15])),
+            -59)
       << "incorrect value for apc[0].pcv[15], expected -59, is "
       << last_msg_->apc[0].pcv[15];
-  EXPECT_EQ(last_msg_->apc[0].pcv[16], -115)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[16])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[16])),
+            -115)
       << "incorrect value for apc[0].pcv[16], expected -115, is "
       << last_msg_->apc[0].pcv[16];
-  EXPECT_EQ(last_msg_->apc[0].pcv[17], 32)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[17])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[17])),
+            32)
       << "incorrect value for apc[0].pcv[17], expected 32, is "
       << last_msg_->apc[0].pcv[17];
-  EXPECT_EQ(last_msg_->apc[0].pcv[18], 33)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[18])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[18])),
+            33)
       << "incorrect value for apc[0].pcv[18], expected 33, is "
       << last_msg_->apc[0].pcv[18];
-  EXPECT_EQ(last_msg_->apc[0].pcv[19], -121)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[19])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[19])),
+            -121)
       << "incorrect value for apc[0].pcv[19], expected -121, is "
       << last_msg_->apc[0].pcv[19];
-  EXPECT_EQ(last_msg_->apc[0].pcv[20], -106)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].pcv[20])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].pcv[20])),
+            -106)
       << "incorrect value for apc[0].pcv[20], expected -106, is "
       << last_msg_->apc[0].pcv[20];
-  EXPECT_EQ(last_msg_->apc[0].sat_info, 240)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].sat_info)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].sat_info)),
+            240)
       << "incorrect value for apc[0].sat_info, expected 240, is "
       << last_msg_->apc[0].sat_info;
-  EXPECT_EQ(last_msg_->apc[0].sid.code, 169)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].sid.code)),
+            169)
       << "incorrect value for apc[0].sid.code, expected 169, is "
       << last_msg_->apc[0].sid.code;
-  EXPECT_EQ(last_msg_->apc[0].sid.sat, 203)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].sid.sat)),
+            203)
       << "incorrect value for apc[0].sid.sat, expected 203, is "
       << last_msg_->apc[0].sid.sat;
-  EXPECT_EQ(last_msg_->apc[0].svn, 1102)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[0].svn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[0].svn)),
+            1102)
       << "incorrect value for apc[0].svn, expected 1102, is "
       << last_msg_->apc[0].svn;
-  EXPECT_EQ(last_msg_->apc[1].pco[0], 23079)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[1].pco[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[1].pco[0])),
+            23079)
       << "incorrect value for apc[1].pco[0], expected 23079, is "
       << last_msg_->apc[1].pco[0];
-  EXPECT_EQ(last_msg_->apc[1].pco[1], -22252)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[1].pco[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[1].pco[1])),
+            -22252)
       << "incorrect value for apc[1].pco[1], expected -22252, is "
       << last_msg_->apc[1].pco[1];
-  EXPECT_EQ(last_msg_->apc[1].pco[2], 12271)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[1].pco[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[1].pco[2])),
+            12271)
       << "incorrect value for apc[1].pco[2], expected 12271, is "
       << last_msg_->apc[1].pco[2];
-  EXPECT_EQ(last_msg_->apc[1].pcv[0], -103)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[1].pcv[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[1].pcv[0])),
+            -103)
       << "incorrect value for apc[1].pcv[0], expected -103, is "
       << last_msg_->apc[1].pcv[0];
-  EXPECT_EQ(last_msg_->apc[1].pcv[1], -81)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[1].pcv[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[1].pcv[1])),
+            -81)
       << "incorrect value for apc[1].pcv[1], expected -81, is "
       << last_msg_->apc[1].pcv[1];
-  EXPECT_EQ(last_msg_->apc[1].pcv[2], 35)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[1].pcv[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[1].pcv[2])),
+            35)
       << "incorrect value for apc[1].pcv[2], expected 35, is "
       << last_msg_->apc[1].pcv[2];
-  EXPECT_EQ(last_msg_->apc[1].pcv[3], -111)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[1].pcv[3])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[1].pcv[3])),
+            -111)
       << "incorrect value for apc[1].pcv[3], expected -111, is "
       << last_msg_->apc[1].pcv[3];
-  EXPECT_EQ(last_msg_->apc[1].pcv[4], -111)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[1].pcv[4])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[1].pcv[4])),
+            -111)
       << "incorrect value for apc[1].pcv[4], expected -111, is "
       << last_msg_->apc[1].pcv[4];
-  EXPECT_EQ(last_msg_->apc[1].pcv[5], 123)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[1].pcv[5])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[1].pcv[5])),
+            123)
       << "incorrect value for apc[1].pcv[5], expected 123, is "
       << last_msg_->apc[1].pcv[5];
-  EXPECT_EQ(last_msg_->apc[1].pcv[6], -62)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[1].pcv[6])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[1].pcv[6])),
+            -62)
       << "incorrect value for apc[1].pcv[6], expected -62, is "
       << last_msg_->apc[1].pcv[6];
-  EXPECT_EQ(last_msg_->apc[1].pcv[7], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[1].pcv[7])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[1].pcv[7])),
+            2)
       << "incorrect value for apc[1].pcv[7], expected 2, is "
       << last_msg_->apc[1].pcv[7];
-  EXPECT_EQ(last_msg_->apc[1].pcv[8], 102)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[1].pcv[8])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[1].pcv[8])),
+            102)
       << "incorrect value for apc[1].pcv[8], expected 102, is "
       << last_msg_->apc[1].pcv[8];
-  EXPECT_EQ(last_msg_->apc[1].pcv[9], 74)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[1].pcv[9])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[1].pcv[9])),
+            74)
       << "incorrect value for apc[1].pcv[9], expected 74, is "
       << last_msg_->apc[1].pcv[9];
-  EXPECT_EQ(last_msg_->apc[1].pcv[10], -107)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[1].pcv[10])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[1].pcv[10])),
+            -107)
       << "incorrect value for apc[1].pcv[10], expected -107, is "
       << last_msg_->apc[1].pcv[10];
-  EXPECT_EQ(last_msg_->apc[1].pcv[11], 95)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[1].pcv[11])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[1].pcv[11])),
+            95)
       << "incorrect value for apc[1].pcv[11], expected 95, is "
       << last_msg_->apc[1].pcv[11];
-  EXPECT_EQ(last_msg_->apc[1].pcv[12], -85)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[1].pcv[12])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[1].pcv[12])),
+            -85)
       << "incorrect value for apc[1].pcv[12], expected -85, is "
       << last_msg_->apc[1].pcv[12];
-  EXPECT_EQ(last_msg_->apc[1].pcv[13], -18)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[1].pcv[13])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[1].pcv[13])),
+            -18)
       << "incorrect value for apc[1].pcv[13], expected -18, is "
       << last_msg_->apc[1].pcv[13];
-  EXPECT_EQ(last_msg_->apc[1].pcv[14], -7)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[1].pcv[14])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[1].pcv[14])),
+            -7)
       << "incorrect value for apc[1].pcv[14], expected -7, is "
       << last_msg_->apc[1].pcv[14];
-  EXPECT_EQ(last_msg_->apc[1].pcv[15], 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[1].pcv[15])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[1].pcv[15])),
+            7)
       << "incorrect value for apc[1].pcv[15], expected 7, is "
       << last_msg_->apc[1].pcv[15];
-  EXPECT_EQ(last_msg_->apc[1].pcv[16], -19)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[1].pcv[16])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[1].pcv[16])),
+            -19)
       << "incorrect value for apc[1].pcv[16], expected -19, is "
       << last_msg_->apc[1].pcv[16];
-  EXPECT_EQ(last_msg_->apc[1].pcv[17], -86)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[1].pcv[17])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[1].pcv[17])),
+            -86)
       << "incorrect value for apc[1].pcv[17], expected -86, is "
       << last_msg_->apc[1].pcv[17];
-  EXPECT_EQ(last_msg_->apc[1].pcv[18], 125)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[1].pcv[18])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[1].pcv[18])),
+            125)
       << "incorrect value for apc[1].pcv[18], expected 125, is "
       << last_msg_->apc[1].pcv[18];
-  EXPECT_EQ(last_msg_->apc[1].pcv[19], 106)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[1].pcv[19])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[1].pcv[19])),
+            106)
       << "incorrect value for apc[1].pcv[19], expected 106, is "
       << last_msg_->apc[1].pcv[19];
-  EXPECT_EQ(last_msg_->apc[1].pcv[20], -98)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[1].pcv[20])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[1].pcv[20])),
+            -98)
       << "incorrect value for apc[1].pcv[20], expected -98, is "
       << last_msg_->apc[1].pcv[20];
-  EXPECT_EQ(last_msg_->apc[1].sat_info, 49)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[1].sat_info)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[1].sat_info)),
+            49)
       << "incorrect value for apc[1].sat_info, expected 49, is "
       << last_msg_->apc[1].sat_info;
-  EXPECT_EQ(last_msg_->apc[1].sid.code, 123)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[1].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[1].sid.code)),
+            123)
       << "incorrect value for apc[1].sid.code, expected 123, is "
       << last_msg_->apc[1].sid.code;
-  EXPECT_EQ(last_msg_->apc[1].sid.sat, 148)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[1].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[1].sid.sat)),
+            148)
       << "incorrect value for apc[1].sid.sat, expected 148, is "
       << last_msg_->apc[1].sid.sat;
-  EXPECT_EQ(last_msg_->apc[1].svn, 24967)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[1].svn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[1].svn)),
+            24967)
       << "incorrect value for apc[1].svn, expected 24967, is "
       << last_msg_->apc[1].svn;
-  EXPECT_EQ(last_msg_->apc[2].pco[0], -7596)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[2].pco[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[2].pco[0])),
+            -7596)
       << "incorrect value for apc[2].pco[0], expected -7596, is "
       << last_msg_->apc[2].pco[0];
-  EXPECT_EQ(last_msg_->apc[2].pco[1], 31630)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[2].pco[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[2].pco[1])),
+            31630)
       << "incorrect value for apc[2].pco[1], expected 31630, is "
       << last_msg_->apc[2].pco[1];
-  EXPECT_EQ(last_msg_->apc[2].pco[2], -9907)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[2].pco[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[2].pco[2])),
+            -9907)
       << "incorrect value for apc[2].pco[2], expected -9907, is "
       << last_msg_->apc[2].pco[2];
-  EXPECT_EQ(last_msg_->apc[2].pcv[0], -8)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[2].pcv[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[2].pcv[0])),
+            -8)
       << "incorrect value for apc[2].pcv[0], expected -8, is "
       << last_msg_->apc[2].pcv[0];
-  EXPECT_EQ(last_msg_->apc[2].pcv[1], 67)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[2].pcv[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[2].pcv[1])),
+            67)
       << "incorrect value for apc[2].pcv[1], expected 67, is "
       << last_msg_->apc[2].pcv[1];
-  EXPECT_EQ(last_msg_->apc[2].pcv[2], -41)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[2].pcv[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[2].pcv[2])),
+            -41)
       << "incorrect value for apc[2].pcv[2], expected -41, is "
       << last_msg_->apc[2].pcv[2];
-  EXPECT_EQ(last_msg_->apc[2].pcv[3], -127)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[2].pcv[3])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[2].pcv[3])),
+            -127)
       << "incorrect value for apc[2].pcv[3], expected -127, is "
       << last_msg_->apc[2].pcv[3];
-  EXPECT_EQ(last_msg_->apc[2].pcv[4], 114)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[2].pcv[4])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[2].pcv[4])),
+            114)
       << "incorrect value for apc[2].pcv[4], expected 114, is "
       << last_msg_->apc[2].pcv[4];
-  EXPECT_EQ(last_msg_->apc[2].pcv[5], -118)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[2].pcv[5])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[2].pcv[5])),
+            -118)
       << "incorrect value for apc[2].pcv[5], expected -118, is "
       << last_msg_->apc[2].pcv[5];
-  EXPECT_EQ(last_msg_->apc[2].pcv[6], 25)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[2].pcv[6])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[2].pcv[6])),
+            25)
       << "incorrect value for apc[2].pcv[6], expected 25, is "
       << last_msg_->apc[2].pcv[6];
-  EXPECT_EQ(last_msg_->apc[2].pcv[7], -16)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[2].pcv[7])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[2].pcv[7])),
+            -16)
       << "incorrect value for apc[2].pcv[7], expected -16, is "
       << last_msg_->apc[2].pcv[7];
-  EXPECT_EQ(last_msg_->apc[2].pcv[8], 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[2].pcv[8])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[2].pcv[8])),
+            10)
       << "incorrect value for apc[2].pcv[8], expected 10, is "
       << last_msg_->apc[2].pcv[8];
-  EXPECT_EQ(last_msg_->apc[2].pcv[9], 56)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[2].pcv[9])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[2].pcv[9])),
+            56)
       << "incorrect value for apc[2].pcv[9], expected 56, is "
       << last_msg_->apc[2].pcv[9];
-  EXPECT_EQ(last_msg_->apc[2].pcv[10], 76)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[2].pcv[10])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[2].pcv[10])),
+            76)
       << "incorrect value for apc[2].pcv[10], expected 76, is "
       << last_msg_->apc[2].pcv[10];
-  EXPECT_EQ(last_msg_->apc[2].pcv[11], 61)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[2].pcv[11])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[2].pcv[11])),
+            61)
       << "incorrect value for apc[2].pcv[11], expected 61, is "
       << last_msg_->apc[2].pcv[11];
-  EXPECT_EQ(last_msg_->apc[2].pcv[12], -95)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[2].pcv[12])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[2].pcv[12])),
+            -95)
       << "incorrect value for apc[2].pcv[12], expected -95, is "
       << last_msg_->apc[2].pcv[12];
-  EXPECT_EQ(last_msg_->apc[2].pcv[13], -40)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[2].pcv[13])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[2].pcv[13])),
+            -40)
       << "incorrect value for apc[2].pcv[13], expected -40, is "
       << last_msg_->apc[2].pcv[13];
-  EXPECT_EQ(last_msg_->apc[2].pcv[14], 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[2].pcv[14])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[2].pcv[14])),
+            22)
       << "incorrect value for apc[2].pcv[14], expected 22, is "
       << last_msg_->apc[2].pcv[14];
-  EXPECT_EQ(last_msg_->apc[2].pcv[15], -75)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[2].pcv[15])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[2].pcv[15])),
+            -75)
       << "incorrect value for apc[2].pcv[15], expected -75, is "
       << last_msg_->apc[2].pcv[15];
-  EXPECT_EQ(last_msg_->apc[2].pcv[16], -82)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[2].pcv[16])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[2].pcv[16])),
+            -82)
       << "incorrect value for apc[2].pcv[16], expected -82, is "
       << last_msg_->apc[2].pcv[16];
-  EXPECT_EQ(last_msg_->apc[2].pcv[17], 33)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[2].pcv[17])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[2].pcv[17])),
+            33)
       << "incorrect value for apc[2].pcv[17], expected 33, is "
       << last_msg_->apc[2].pcv[17];
-  EXPECT_EQ(last_msg_->apc[2].pcv[18], 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[2].pcv[18])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[2].pcv[18])),
+            13)
       << "incorrect value for apc[2].pcv[18], expected 13, is "
       << last_msg_->apc[2].pcv[18];
-  EXPECT_EQ(last_msg_->apc[2].pcv[19], -4)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[2].pcv[19])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[2].pcv[19])),
+            -4)
       << "incorrect value for apc[2].pcv[19], expected -4, is "
       << last_msg_->apc[2].pcv[19];
-  EXPECT_EQ(last_msg_->apc[2].pcv[20], -20)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[2].pcv[20])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[2].pcv[20])),
+            -20)
       << "incorrect value for apc[2].pcv[20], expected -20, is "
       << last_msg_->apc[2].pcv[20];
-  EXPECT_EQ(last_msg_->apc[2].sat_info, 181)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[2].sat_info)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[2].sat_info)),
+            181)
       << "incorrect value for apc[2].sat_info, expected 181, is "
       << last_msg_->apc[2].sat_info;
-  EXPECT_EQ(last_msg_->apc[2].sid.code, 188)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[2].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[2].sid.code)),
+            188)
       << "incorrect value for apc[2].sid.code, expected 188, is "
       << last_msg_->apc[2].sid.code;
-  EXPECT_EQ(last_msg_->apc[2].sid.sat, 83)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[2].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[2].sid.sat)),
+            83)
       << "incorrect value for apc[2].sid.sat, expected 83, is "
       << last_msg_->apc[2].sid.sat;
-  EXPECT_EQ(last_msg_->apc[2].svn, 7106)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[2].svn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[2].svn)),
+            7106)
       << "incorrect value for apc[2].svn, expected 7106, is "
       << last_msg_->apc[2].svn;
-  EXPECT_EQ(last_msg_->apc[3].pco[0], -19478)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[3].pco[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[3].pco[0])),
+            -19478)
       << "incorrect value for apc[3].pco[0], expected -19478, is "
       << last_msg_->apc[3].pco[0];
-  EXPECT_EQ(last_msg_->apc[3].pco[1], 11484)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[3].pco[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[3].pco[1])),
+            11484)
       << "incorrect value for apc[3].pco[1], expected 11484, is "
       << last_msg_->apc[3].pco[1];
-  EXPECT_EQ(last_msg_->apc[3].pco[2], 14804)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[3].pco[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[3].pco[2])),
+            14804)
       << "incorrect value for apc[3].pco[2], expected 14804, is "
       << last_msg_->apc[3].pco[2];
-  EXPECT_EQ(last_msg_->apc[3].pcv[0], 44)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[3].pcv[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[3].pcv[0])),
+            44)
       << "incorrect value for apc[3].pcv[0], expected 44, is "
       << last_msg_->apc[3].pcv[0];
-  EXPECT_EQ(last_msg_->apc[3].pcv[1], -83)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[3].pcv[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[3].pcv[1])),
+            -83)
       << "incorrect value for apc[3].pcv[1], expected -83, is "
       << last_msg_->apc[3].pcv[1];
-  EXPECT_EQ(last_msg_->apc[3].pcv[2], 49)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[3].pcv[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[3].pcv[2])),
+            49)
       << "incorrect value for apc[3].pcv[2], expected 49, is "
       << last_msg_->apc[3].pcv[2];
-  EXPECT_EQ(last_msg_->apc[3].pcv[3], 36)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[3].pcv[3])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[3].pcv[3])),
+            36)
       << "incorrect value for apc[3].pcv[3], expected 36, is "
       << last_msg_->apc[3].pcv[3];
-  EXPECT_EQ(last_msg_->apc[3].pcv[4], -119)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[3].pcv[4])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[3].pcv[4])),
+            -119)
       << "incorrect value for apc[3].pcv[4], expected -119, is "
       << last_msg_->apc[3].pcv[4];
-  EXPECT_EQ(last_msg_->apc[3].pcv[5], -8)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[3].pcv[5])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[3].pcv[5])),
+            -8)
       << "incorrect value for apc[3].pcv[5], expected -8, is "
       << last_msg_->apc[3].pcv[5];
-  EXPECT_EQ(last_msg_->apc[3].pcv[6], -21)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[3].pcv[6])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[3].pcv[6])),
+            -21)
       << "incorrect value for apc[3].pcv[6], expected -21, is "
       << last_msg_->apc[3].pcv[6];
-  EXPECT_EQ(last_msg_->apc[3].pcv[7], 97)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[3].pcv[7])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[3].pcv[7])),
+            97)
       << "incorrect value for apc[3].pcv[7], expected 97, is "
       << last_msg_->apc[3].pcv[7];
-  EXPECT_EQ(last_msg_->apc[3].pcv[8], 112)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[3].pcv[8])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[3].pcv[8])),
+            112)
       << "incorrect value for apc[3].pcv[8], expected 112, is "
       << last_msg_->apc[3].pcv[8];
-  EXPECT_EQ(last_msg_->apc[3].pcv[9], -99)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[3].pcv[9])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[3].pcv[9])),
+            -99)
       << "incorrect value for apc[3].pcv[9], expected -99, is "
       << last_msg_->apc[3].pcv[9];
-  EXPECT_EQ(last_msg_->apc[3].pcv[10], -117)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[3].pcv[10])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[3].pcv[10])),
+            -117)
       << "incorrect value for apc[3].pcv[10], expected -117, is "
       << last_msg_->apc[3].pcv[10];
-  EXPECT_EQ(last_msg_->apc[3].pcv[11], 26)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[3].pcv[11])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[3].pcv[11])),
+            26)
       << "incorrect value for apc[3].pcv[11], expected 26, is "
       << last_msg_->apc[3].pcv[11];
-  EXPECT_EQ(last_msg_->apc[3].pcv[12], 115)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[3].pcv[12])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[3].pcv[12])),
+            115)
       << "incorrect value for apc[3].pcv[12], expected 115, is "
       << last_msg_->apc[3].pcv[12];
-  EXPECT_EQ(last_msg_->apc[3].pcv[13], -64)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[3].pcv[13])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[3].pcv[13])),
+            -64)
       << "incorrect value for apc[3].pcv[13], expected -64, is "
       << last_msg_->apc[3].pcv[13];
-  EXPECT_EQ(last_msg_->apc[3].pcv[14], 31)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[3].pcv[14])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[3].pcv[14])),
+            31)
       << "incorrect value for apc[3].pcv[14], expected 31, is "
       << last_msg_->apc[3].pcv[14];
-  EXPECT_EQ(last_msg_->apc[3].pcv[15], 85)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[3].pcv[15])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[3].pcv[15])),
+            85)
       << "incorrect value for apc[3].pcv[15], expected 85, is "
       << last_msg_->apc[3].pcv[15];
-  EXPECT_EQ(last_msg_->apc[3].pcv[16], 127)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[3].pcv[16])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[3].pcv[16])),
+            127)
       << "incorrect value for apc[3].pcv[16], expected 127, is "
       << last_msg_->apc[3].pcv[16];
-  EXPECT_EQ(last_msg_->apc[3].pcv[17], -28)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[3].pcv[17])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[3].pcv[17])),
+            -28)
       << "incorrect value for apc[3].pcv[17], expected -28, is "
       << last_msg_->apc[3].pcv[17];
-  EXPECT_EQ(last_msg_->apc[3].pcv[18], 81)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[3].pcv[18])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[3].pcv[18])),
+            81)
       << "incorrect value for apc[3].pcv[18], expected 81, is "
       << last_msg_->apc[3].pcv[18];
-  EXPECT_EQ(last_msg_->apc[3].pcv[19], -4)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[3].pcv[19])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[3].pcv[19])),
+            -4)
       << "incorrect value for apc[3].pcv[19], expected -4, is "
       << last_msg_->apc[3].pcv[19];
-  EXPECT_EQ(last_msg_->apc[3].pcv[20], -37)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[3].pcv[20])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[3].pcv[20])),
+            -37)
       << "incorrect value for apc[3].pcv[20], expected -37, is "
       << last_msg_->apc[3].pcv[20];
-  EXPECT_EQ(last_msg_->apc[3].sat_info, 128)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[3].sat_info)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[3].sat_info)),
+            128)
       << "incorrect value for apc[3].sat_info, expected 128, is "
       << last_msg_->apc[3].sat_info;
-  EXPECT_EQ(last_msg_->apc[3].sid.code, 196)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[3].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[3].sid.code)),
+            196)
       << "incorrect value for apc[3].sid.code, expected 196, is "
       << last_msg_->apc[3].sid.code;
-  EXPECT_EQ(last_msg_->apc[3].sid.sat, 230)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[3].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[3].sid.sat)),
+            230)
       << "incorrect value for apc[3].sid.sat, expected 230, is "
       << last_msg_->apc[3].sid.sat;
-  EXPECT_EQ(last_msg_->apc[3].svn, 61399)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[3].svn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[3].svn)),
+            61399)
       << "incorrect value for apc[3].svn, expected 61399, is "
       << last_msg_->apc[3].svn;
-  EXPECT_EQ(last_msg_->apc[4].pco[0], -11049)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[4].pco[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[4].pco[0])),
+            -11049)
       << "incorrect value for apc[4].pco[0], expected -11049, is "
       << last_msg_->apc[4].pco[0];
-  EXPECT_EQ(last_msg_->apc[4].pco[1], 6580)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[4].pco[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[4].pco[1])),
+            6580)
       << "incorrect value for apc[4].pco[1], expected 6580, is "
       << last_msg_->apc[4].pco[1];
-  EXPECT_EQ(last_msg_->apc[4].pco[2], -28589)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[4].pco[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[4].pco[2])),
+            -28589)
       << "incorrect value for apc[4].pco[2], expected -28589, is "
       << last_msg_->apc[4].pco[2];
-  EXPECT_EQ(last_msg_->apc[4].pcv[0], -9)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[4].pcv[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[4].pcv[0])),
+            -9)
       << "incorrect value for apc[4].pcv[0], expected -9, is "
       << last_msg_->apc[4].pcv[0];
-  EXPECT_EQ(last_msg_->apc[4].pcv[1], 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[4].pcv[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[4].pcv[1])),
+            12)
       << "incorrect value for apc[4].pcv[1], expected 12, is "
       << last_msg_->apc[4].pcv[1];
-  EXPECT_EQ(last_msg_->apc[4].pcv[2], 27)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[4].pcv[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[4].pcv[2])),
+            27)
       << "incorrect value for apc[4].pcv[2], expected 27, is "
       << last_msg_->apc[4].pcv[2];
-  EXPECT_EQ(last_msg_->apc[4].pcv[3], -57)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[4].pcv[3])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[4].pcv[3])),
+            -57)
       << "incorrect value for apc[4].pcv[3], expected -57, is "
       << last_msg_->apc[4].pcv[3];
-  EXPECT_EQ(last_msg_->apc[4].pcv[4], -83)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[4].pcv[4])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[4].pcv[4])),
+            -83)
       << "incorrect value for apc[4].pcv[4], expected -83, is "
       << last_msg_->apc[4].pcv[4];
-  EXPECT_EQ(last_msg_->apc[4].pcv[5], 74)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[4].pcv[5])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[4].pcv[5])),
+            74)
       << "incorrect value for apc[4].pcv[5], expected 74, is "
       << last_msg_->apc[4].pcv[5];
-  EXPECT_EQ(last_msg_->apc[4].pcv[6], 23)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[4].pcv[6])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[4].pcv[6])),
+            23)
       << "incorrect value for apc[4].pcv[6], expected 23, is "
       << last_msg_->apc[4].pcv[6];
-  EXPECT_EQ(last_msg_->apc[4].pcv[7], 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[4].pcv[7])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[4].pcv[7])),
+            4)
       << "incorrect value for apc[4].pcv[7], expected 4, is "
       << last_msg_->apc[4].pcv[7];
-  EXPECT_EQ(last_msg_->apc[4].pcv[8], -17)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[4].pcv[8])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[4].pcv[8])),
+            -17)
       << "incorrect value for apc[4].pcv[8], expected -17, is "
       << last_msg_->apc[4].pcv[8];
-  EXPECT_EQ(last_msg_->apc[4].pcv[9], 103)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[4].pcv[9])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[4].pcv[9])),
+            103)
       << "incorrect value for apc[4].pcv[9], expected 103, is "
       << last_msg_->apc[4].pcv[9];
-  EXPECT_EQ(last_msg_->apc[4].pcv[10], -33)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[4].pcv[10])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[4].pcv[10])),
+            -33)
       << "incorrect value for apc[4].pcv[10], expected -33, is "
       << last_msg_->apc[4].pcv[10];
-  EXPECT_EQ(last_msg_->apc[4].pcv[11], -36)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[4].pcv[11])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[4].pcv[11])),
+            -36)
       << "incorrect value for apc[4].pcv[11], expected -36, is "
       << last_msg_->apc[4].pcv[11];
-  EXPECT_EQ(last_msg_->apc[4].pcv[12], -117)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[4].pcv[12])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[4].pcv[12])),
+            -117)
       << "incorrect value for apc[4].pcv[12], expected -117, is "
       << last_msg_->apc[4].pcv[12];
-  EXPECT_EQ(last_msg_->apc[4].pcv[13], 91)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[4].pcv[13])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[4].pcv[13])),
+            91)
       << "incorrect value for apc[4].pcv[13], expected 91, is "
       << last_msg_->apc[4].pcv[13];
-  EXPECT_EQ(last_msg_->apc[4].pcv[14], 127)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[4].pcv[14])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[4].pcv[14])),
+            127)
       << "incorrect value for apc[4].pcv[14], expected 127, is "
       << last_msg_->apc[4].pcv[14];
-  EXPECT_EQ(last_msg_->apc[4].pcv[15], -42)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[4].pcv[15])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[4].pcv[15])),
+            -42)
       << "incorrect value for apc[4].pcv[15], expected -42, is "
       << last_msg_->apc[4].pcv[15];
-  EXPECT_EQ(last_msg_->apc[4].pcv[16], 86)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[4].pcv[16])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[4].pcv[16])),
+            86)
       << "incorrect value for apc[4].pcv[16], expected 86, is "
       << last_msg_->apc[4].pcv[16];
-  EXPECT_EQ(last_msg_->apc[4].pcv[17], 48)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[4].pcv[17])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[4].pcv[17])),
+            48)
       << "incorrect value for apc[4].pcv[17], expected 48, is "
       << last_msg_->apc[4].pcv[17];
-  EXPECT_EQ(last_msg_->apc[4].pcv[18], -53)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[4].pcv[18])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[4].pcv[18])),
+            -53)
       << "incorrect value for apc[4].pcv[18], expected -53, is "
       << last_msg_->apc[4].pcv[18];
-  EXPECT_EQ(last_msg_->apc[4].pcv[19], -28)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[4].pcv[19])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[4].pcv[19])),
+            -28)
       << "incorrect value for apc[4].pcv[19], expected -28, is "
       << last_msg_->apc[4].pcv[19];
-  EXPECT_EQ(last_msg_->apc[4].pcv[20], 99)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[4].pcv[20])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[4].pcv[20])),
+            99)
       << "incorrect value for apc[4].pcv[20], expected 99, is "
       << last_msg_->apc[4].pcv[20];
-  EXPECT_EQ(last_msg_->apc[4].sat_info, 147)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[4].sat_info)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[4].sat_info)),
+            147)
       << "incorrect value for apc[4].sat_info, expected 147, is "
       << last_msg_->apc[4].sat_info;
-  EXPECT_EQ(last_msg_->apc[4].sid.code, 110)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[4].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[4].sid.code)),
+            110)
       << "incorrect value for apc[4].sid.code, expected 110, is "
       << last_msg_->apc[4].sid.code;
-  EXPECT_EQ(last_msg_->apc[4].sid.sat, 249)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[4].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[4].sid.sat)),
+            249)
       << "incorrect value for apc[4].sid.sat, expected 249, is "
       << last_msg_->apc[4].sid.sat;
-  EXPECT_EQ(last_msg_->apc[4].svn, 41224)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[4].svn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[4].svn)),
+            41224)
       << "incorrect value for apc[4].svn, expected 41224, is "
       << last_msg_->apc[4].svn;
-  EXPECT_EQ(last_msg_->apc[5].pco[0], -21881)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[5].pco[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[5].pco[0])),
+            -21881)
       << "incorrect value for apc[5].pco[0], expected -21881, is "
       << last_msg_->apc[5].pco[0];
-  EXPECT_EQ(last_msg_->apc[5].pco[1], -9942)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[5].pco[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[5].pco[1])),
+            -9942)
       << "incorrect value for apc[5].pco[1], expected -9942, is "
       << last_msg_->apc[5].pco[1];
-  EXPECT_EQ(last_msg_->apc[5].pco[2], -5689)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[5].pco[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[5].pco[2])),
+            -5689)
       << "incorrect value for apc[5].pco[2], expected -5689, is "
       << last_msg_->apc[5].pco[2];
-  EXPECT_EQ(last_msg_->apc[5].pcv[0], 42)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[5].pcv[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[5].pcv[0])),
+            42)
       << "incorrect value for apc[5].pcv[0], expected 42, is "
       << last_msg_->apc[5].pcv[0];
-  EXPECT_EQ(last_msg_->apc[5].pcv[1], -86)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[5].pcv[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[5].pcv[1])),
+            -86)
       << "incorrect value for apc[5].pcv[1], expected -86, is "
       << last_msg_->apc[5].pcv[1];
-  EXPECT_EQ(last_msg_->apc[5].pcv[2], 78)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[5].pcv[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[5].pcv[2])),
+            78)
       << "incorrect value for apc[5].pcv[2], expected 78, is "
       << last_msg_->apc[5].pcv[2];
-  EXPECT_EQ(last_msg_->apc[5].pcv[3], -50)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[5].pcv[3])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[5].pcv[3])),
+            -50)
       << "incorrect value for apc[5].pcv[3], expected -50, is "
       << last_msg_->apc[5].pcv[3];
-  EXPECT_EQ(last_msg_->apc[5].pcv[4], 41)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[5].pcv[4])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[5].pcv[4])),
+            41)
       << "incorrect value for apc[5].pcv[4], expected 41, is "
       << last_msg_->apc[5].pcv[4];
-  EXPECT_EQ(last_msg_->apc[5].pcv[5], 43)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[5].pcv[5])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[5].pcv[5])),
+            43)
       << "incorrect value for apc[5].pcv[5], expected 43, is "
       << last_msg_->apc[5].pcv[5];
-  EXPECT_EQ(last_msg_->apc[5].pcv[6], 81)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[5].pcv[6])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[5].pcv[6])),
+            81)
       << "incorrect value for apc[5].pcv[6], expected 81, is "
       << last_msg_->apc[5].pcv[6];
-  EXPECT_EQ(last_msg_->apc[5].pcv[7], -9)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[5].pcv[7])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[5].pcv[7])),
+            -9)
       << "incorrect value for apc[5].pcv[7], expected -9, is "
       << last_msg_->apc[5].pcv[7];
-  EXPECT_EQ(last_msg_->apc[5].pcv[8], 99)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[5].pcv[8])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[5].pcv[8])),
+            99)
       << "incorrect value for apc[5].pcv[8], expected 99, is "
       << last_msg_->apc[5].pcv[8];
-  EXPECT_EQ(last_msg_->apc[5].pcv[9], -58)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[5].pcv[9])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[5].pcv[9])),
+            -58)
       << "incorrect value for apc[5].pcv[9], expected -58, is "
       << last_msg_->apc[5].pcv[9];
-  EXPECT_EQ(last_msg_->apc[5].pcv[10], -112)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[5].pcv[10])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[5].pcv[10])),
+            -112)
       << "incorrect value for apc[5].pcv[10], expected -112, is "
       << last_msg_->apc[5].pcv[10];
-  EXPECT_EQ(last_msg_->apc[5].pcv[11], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[5].pcv[11])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[5].pcv[11])),
+            2)
       << "incorrect value for apc[5].pcv[11], expected 2, is "
       << last_msg_->apc[5].pcv[11];
-  EXPECT_EQ(last_msg_->apc[5].pcv[12], -124)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[5].pcv[12])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[5].pcv[12])),
+            -124)
       << "incorrect value for apc[5].pcv[12], expected -124, is "
       << last_msg_->apc[5].pcv[12];
-  EXPECT_EQ(last_msg_->apc[5].pcv[13], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[5].pcv[13])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[5].pcv[13])),
+            2)
       << "incorrect value for apc[5].pcv[13], expected 2, is "
       << last_msg_->apc[5].pcv[13];
-  EXPECT_EQ(last_msg_->apc[5].pcv[14], -32)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[5].pcv[14])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[5].pcv[14])),
+            -32)
       << "incorrect value for apc[5].pcv[14], expected -32, is "
       << last_msg_->apc[5].pcv[14];
-  EXPECT_EQ(last_msg_->apc[5].pcv[15], -36)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[5].pcv[15])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[5].pcv[15])),
+            -36)
       << "incorrect value for apc[5].pcv[15], expected -36, is "
       << last_msg_->apc[5].pcv[15];
-  EXPECT_EQ(last_msg_->apc[5].pcv[16], -108)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[5].pcv[16])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[5].pcv[16])),
+            -108)
       << "incorrect value for apc[5].pcv[16], expected -108, is "
       << last_msg_->apc[5].pcv[16];
-  EXPECT_EQ(last_msg_->apc[5].pcv[17], 58)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[5].pcv[17])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[5].pcv[17])),
+            58)
       << "incorrect value for apc[5].pcv[17], expected 58, is "
       << last_msg_->apc[5].pcv[17];
-  EXPECT_EQ(last_msg_->apc[5].pcv[18], 85)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[5].pcv[18])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[5].pcv[18])),
+            85)
       << "incorrect value for apc[5].pcv[18], expected 85, is "
       << last_msg_->apc[5].pcv[18];
-  EXPECT_EQ(last_msg_->apc[5].pcv[19], -118)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[5].pcv[19])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[5].pcv[19])),
+            -118)
       << "incorrect value for apc[5].pcv[19], expected -118, is "
       << last_msg_->apc[5].pcv[19];
-  EXPECT_EQ(last_msg_->apc[5].pcv[20], -46)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[5].pcv[20])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[5].pcv[20])),
+            -46)
       << "incorrect value for apc[5].pcv[20], expected -46, is "
       << last_msg_->apc[5].pcv[20];
-  EXPECT_EQ(last_msg_->apc[5].sat_info, 159)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[5].sat_info)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[5].sat_info)),
+            159)
       << "incorrect value for apc[5].sat_info, expected 159, is "
       << last_msg_->apc[5].sat_info;
-  EXPECT_EQ(last_msg_->apc[5].sid.code, 83)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[5].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[5].sid.code)),
+            83)
       << "incorrect value for apc[5].sid.code, expected 83, is "
       << last_msg_->apc[5].sid.code;
-  EXPECT_EQ(last_msg_->apc[5].sid.sat, 45)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[5].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[5].sid.sat)),
+            45)
       << "incorrect value for apc[5].sid.sat, expected 45, is "
       << last_msg_->apc[5].sid.sat;
-  EXPECT_EQ(last_msg_->apc[5].svn, 64011)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[5].svn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[5].svn)),
+            64011)
       << "incorrect value for apc[5].svn, expected 64011, is "
       << last_msg_->apc[5].svn;
-  EXPECT_EQ(last_msg_->apc[6].pco[0], -14290)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[6].pco[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[6].pco[0])),
+            -14290)
       << "incorrect value for apc[6].pco[0], expected -14290, is "
       << last_msg_->apc[6].pco[0];
-  EXPECT_EQ(last_msg_->apc[6].pco[1], 30340)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[6].pco[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[6].pco[1])),
+            30340)
       << "incorrect value for apc[6].pco[1], expected 30340, is "
       << last_msg_->apc[6].pco[1];
-  EXPECT_EQ(last_msg_->apc[6].pco[2], 3569)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[6].pco[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[6].pco[2])),
+            3569)
       << "incorrect value for apc[6].pco[2], expected 3569, is "
       << last_msg_->apc[6].pco[2];
-  EXPECT_EQ(last_msg_->apc[6].pcv[0], 37)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[6].pcv[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[6].pcv[0])),
+            37)
       << "incorrect value for apc[6].pcv[0], expected 37, is "
       << last_msg_->apc[6].pcv[0];
-  EXPECT_EQ(last_msg_->apc[6].pcv[1], 62)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[6].pcv[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[6].pcv[1])),
+            62)
       << "incorrect value for apc[6].pcv[1], expected 62, is "
       << last_msg_->apc[6].pcv[1];
-  EXPECT_EQ(last_msg_->apc[6].pcv[2], 107)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[6].pcv[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[6].pcv[2])),
+            107)
       << "incorrect value for apc[6].pcv[2], expected 107, is "
       << last_msg_->apc[6].pcv[2];
-  EXPECT_EQ(last_msg_->apc[6].pcv[3], -3)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[6].pcv[3])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[6].pcv[3])),
+            -3)
       << "incorrect value for apc[6].pcv[3], expected -3, is "
       << last_msg_->apc[6].pcv[3];
-  EXPECT_EQ(last_msg_->apc[6].pcv[4], -66)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[6].pcv[4])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[6].pcv[4])),
+            -66)
       << "incorrect value for apc[6].pcv[4], expected -66, is "
       << last_msg_->apc[6].pcv[4];
-  EXPECT_EQ(last_msg_->apc[6].pcv[5], -120)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[6].pcv[5])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[6].pcv[5])),
+            -120)
       << "incorrect value for apc[6].pcv[5], expected -120, is "
       << last_msg_->apc[6].pcv[5];
-  EXPECT_EQ(last_msg_->apc[6].pcv[6], 66)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[6].pcv[6])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[6].pcv[6])),
+            66)
       << "incorrect value for apc[6].pcv[6], expected 66, is "
       << last_msg_->apc[6].pcv[6];
-  EXPECT_EQ(last_msg_->apc[6].pcv[7], 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[6].pcv[7])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[6].pcv[7])),
+            9)
       << "incorrect value for apc[6].pcv[7], expected 9, is "
       << last_msg_->apc[6].pcv[7];
-  EXPECT_EQ(last_msg_->apc[6].pcv[8], 84)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[6].pcv[8])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[6].pcv[8])),
+            84)
       << "incorrect value for apc[6].pcv[8], expected 84, is "
       << last_msg_->apc[6].pcv[8];
-  EXPECT_EQ(last_msg_->apc[6].pcv[9], -101)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[6].pcv[9])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[6].pcv[9])),
+            -101)
       << "incorrect value for apc[6].pcv[9], expected -101, is "
       << last_msg_->apc[6].pcv[9];
-  EXPECT_EQ(last_msg_->apc[6].pcv[10], 86)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[6].pcv[10])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[6].pcv[10])),
+            86)
       << "incorrect value for apc[6].pcv[10], expected 86, is "
       << last_msg_->apc[6].pcv[10];
-  EXPECT_EQ(last_msg_->apc[6].pcv[11], -76)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[6].pcv[11])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[6].pcv[11])),
+            -76)
       << "incorrect value for apc[6].pcv[11], expected -76, is "
       << last_msg_->apc[6].pcv[11];
-  EXPECT_EQ(last_msg_->apc[6].pcv[12], 41)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[6].pcv[12])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[6].pcv[12])),
+            41)
       << "incorrect value for apc[6].pcv[12], expected 41, is "
       << last_msg_->apc[6].pcv[12];
-  EXPECT_EQ(last_msg_->apc[6].pcv[13], -60)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[6].pcv[13])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[6].pcv[13])),
+            -60)
       << "incorrect value for apc[6].pcv[13], expected -60, is "
       << last_msg_->apc[6].pcv[13];
-  EXPECT_EQ(last_msg_->apc[6].pcv[14], 40)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[6].pcv[14])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[6].pcv[14])),
+            40)
       << "incorrect value for apc[6].pcv[14], expected 40, is "
       << last_msg_->apc[6].pcv[14];
-  EXPECT_EQ(last_msg_->apc[6].pcv[15], 119)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[6].pcv[15])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[6].pcv[15])),
+            119)
       << "incorrect value for apc[6].pcv[15], expected 119, is "
       << last_msg_->apc[6].pcv[15];
-  EXPECT_EQ(last_msg_->apc[6].pcv[16], 101)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[6].pcv[16])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[6].pcv[16])),
+            101)
       << "incorrect value for apc[6].pcv[16], expected 101, is "
       << last_msg_->apc[6].pcv[16];
-  EXPECT_EQ(last_msg_->apc[6].pcv[17], -4)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[6].pcv[17])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[6].pcv[17])),
+            -4)
       << "incorrect value for apc[6].pcv[17], expected -4, is "
       << last_msg_->apc[6].pcv[17];
-  EXPECT_EQ(last_msg_->apc[6].pcv[18], -33)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[6].pcv[18])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[6].pcv[18])),
+            -33)
       << "incorrect value for apc[6].pcv[18], expected -33, is "
       << last_msg_->apc[6].pcv[18];
-  EXPECT_EQ(last_msg_->apc[6].pcv[19], -112)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[6].pcv[19])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[6].pcv[19])),
+            -112)
       << "incorrect value for apc[6].pcv[19], expected -112, is "
       << last_msg_->apc[6].pcv[19];
-  EXPECT_EQ(last_msg_->apc[6].pcv[20], -103)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[6].pcv[20])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[6].pcv[20])),
+            -103)
       << "incorrect value for apc[6].pcv[20], expected -103, is "
       << last_msg_->apc[6].pcv[20];
-  EXPECT_EQ(last_msg_->apc[6].sat_info, 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[6].sat_info)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[6].sat_info)),
+            7)
       << "incorrect value for apc[6].sat_info, expected 7, is "
       << last_msg_->apc[6].sat_info;
-  EXPECT_EQ(last_msg_->apc[6].sid.code, 158)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[6].sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[6].sid.code)),
+            158)
       << "incorrect value for apc[6].sid.code, expected 158, is "
       << last_msg_->apc[6].sid.code;
-  EXPECT_EQ(last_msg_->apc[6].sid.sat, 200)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[6].sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[6].sid.sat)),
+            200)
       << "incorrect value for apc[6].sid.sat, expected 200, is "
       << last_msg_->apc[6].sid.sat;
-  EXPECT_EQ(last_msg_->apc[6].svn, 17310)
+  EXPECT_EQ(get_as<decltype(last_msg_->apc[6].svn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->apc[6].svn)),
+            17310)
       << "incorrect value for apc[6].svn, expected 17310, is "
       << last_msg_->apc[6].svn;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrStecCorrection.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrStecCorrection.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/ssr.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_ssr_MsgSsrStecCorrection0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -185,78 +192,143 @@ TEST_F(Test_legacy_auto_check_sbp_ssr_MsgSsrStecCorrection0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->header.num_msgs, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.num_msgs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.num_msgs)),
+            1)
       << "incorrect value for header.num_msgs, expected 1, is "
       << last_msg_->header.num_msgs;
-  EXPECT_EQ(last_msg_->header.seq_num, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.seq_num)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.seq_num)),
+            1)
       << "incorrect value for header.seq_num, expected 1, is "
       << last_msg_->header.seq_num;
-  EXPECT_EQ(last_msg_->header.sol_id, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.sol_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.sol_id)),
+            0)
       << "incorrect value for header.sol_id, expected 0, is "
       << last_msg_->header.sol_id;
-  EXPECT_EQ(last_msg_->header.time.tow, 180)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.time.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.time.tow)),
+            180)
       << "incorrect value for header.time.tow, expected 180, is "
       << last_msg_->header.time.tow;
-  EXPECT_EQ(last_msg_->header.time.wn, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.time.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.time.wn)),
+            3)
       << "incorrect value for header.time.wn, expected 3, is "
       << last_msg_->header.time.wn;
-  EXPECT_EQ(last_msg_->header.update_interval, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.update_interval)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->header.update_interval)),
+            10)
       << "incorrect value for header.update_interval, expected 10, is "
       << last_msg_->header.update_interval;
-  EXPECT_EQ(last_msg_->n_sats, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_sats)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_sats)),
+            2)
       << "incorrect value for n_sats, expected 2, is " << last_msg_->n_sats;
-  EXPECT_EQ(last_msg_->ssr_iod_atmo, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->ssr_iod_atmo)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ssr_iod_atmo)),
+            15)
       << "incorrect value for ssr_iod_atmo, expected 15, is "
       << last_msg_->ssr_iod_atmo;
-  EXPECT_EQ(last_msg_->stec_sat_list[0].stec_coeff[0], 63)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[0].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[0].stec_coeff[0])),
+            63)
       << "incorrect value for stec_sat_list[0].stec_coeff[0], expected 63, is "
       << last_msg_->stec_sat_list[0].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[0].stec_coeff[1], 62)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[0].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[0].stec_coeff[1])),
+            62)
       << "incorrect value for stec_sat_list[0].stec_coeff[1], expected 62, is "
       << last_msg_->stec_sat_list[0].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[0].stec_coeff[2], 61)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[0].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[0].stec_coeff[2])),
+            61)
       << "incorrect value for stec_sat_list[0].stec_coeff[2], expected 61, is "
       << last_msg_->stec_sat_list[0].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[0].stec_coeff[3], 60)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[0].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[0].stec_coeff[3])),
+            60)
       << "incorrect value for stec_sat_list[0].stec_coeff[3], expected 60, is "
       << last_msg_->stec_sat_list[0].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[0].stec_quality_indicator, 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[0].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[0].stec_quality_indicator)),
+      1)
       << "incorrect value for stec_sat_list[0].stec_quality_indicator, "
          "expected 1, is "
       << last_msg_->stec_sat_list[0].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[0].sv_id.constellation, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[0].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[0].sv_id.constellation)),
+            1)
       << "incorrect value for stec_sat_list[0].sv_id.constellation, expected "
          "1, is "
       << last_msg_->stec_sat_list[0].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[0].sv_id.satId, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[0].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[0].sv_id.satId)),
+            1)
       << "incorrect value for stec_sat_list[0].sv_id.satId, expected 1, is "
       << last_msg_->stec_sat_list[0].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[1].stec_coeff[0], 63)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[1].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[1].stec_coeff[0])),
+            63)
       << "incorrect value for stec_sat_list[1].stec_coeff[0], expected 63, is "
       << last_msg_->stec_sat_list[1].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[1].stec_coeff[1], 64)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[1].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[1].stec_coeff[1])),
+            64)
       << "incorrect value for stec_sat_list[1].stec_coeff[1], expected 64, is "
       << last_msg_->stec_sat_list[1].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[1].stec_coeff[2], 65)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[1].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[1].stec_coeff[2])),
+            65)
       << "incorrect value for stec_sat_list[1].stec_coeff[2], expected 65, is "
       << last_msg_->stec_sat_list[1].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[1].stec_coeff[3], 66)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[1].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[1].stec_coeff[3])),
+            66)
       << "incorrect value for stec_sat_list[1].stec_coeff[3], expected 66, is "
       << last_msg_->stec_sat_list[1].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[1].stec_quality_indicator, 5)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[1].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[1].stec_quality_indicator)),
+      5)
       << "incorrect value for stec_sat_list[1].stec_quality_indicator, "
          "expected 5, is "
       << last_msg_->stec_sat_list[1].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[1].sv_id.constellation, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[1].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[1].sv_id.constellation)),
+            15)
       << "incorrect value for stec_sat_list[1].sv_id.constellation, expected "
          "15, is "
       << last_msg_->stec_sat_list[1].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[1].sv_id.satId, 31)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[1].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[1].sv_id.satId)),
+            31)
       << "incorrect value for stec_sat_list[1].sv_id.satId, expected 31, is "
       << last_msg_->stec_sat_list[1].sv_id.satId;
-  EXPECT_EQ(last_msg_->tile_id, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->tile_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tile_id)),
+            10)
       << "incorrect value for tile_id, expected 10, is " << last_msg_->tile_id;
-  EXPECT_EQ(last_msg_->tile_set_id, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->tile_set_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tile_set_id)),
+            1)
       << "incorrect value for tile_set_id, expected 1, is "
       << last_msg_->tile_set_id;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrStecCorrectionDep.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrStecCorrectionDep.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/ssr.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_ssr_MsgSsrStecCorrectionDep0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -786,593 +793,1073 @@ TEST_F(Test_legacy_auto_check_sbp_ssr_MsgSsrStecCorrectionDep0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 38860);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->header.iod_atmo, 60)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.iod_atmo)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.iod_atmo)),
+            60)
       << "incorrect value for header.iod_atmo, expected 60, is "
       << last_msg_->header.iod_atmo;
-  EXPECT_EQ(last_msg_->header.num_msgs, 157)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.num_msgs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.num_msgs)),
+            157)
       << "incorrect value for header.num_msgs, expected 157, is "
       << last_msg_->header.num_msgs;
-  EXPECT_EQ(last_msg_->header.seq_num, 112)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.seq_num)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.seq_num)),
+            112)
       << "incorrect value for header.seq_num, expected 112, is "
       << last_msg_->header.seq_num;
-  EXPECT_EQ(last_msg_->header.tile_id, 30066)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.tile_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.tile_id)),
+            30066)
       << "incorrect value for header.tile_id, expected 30066, is "
       << last_msg_->header.tile_id;
-  EXPECT_EQ(last_msg_->header.tile_set_id, 58526)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->header.tile_set_id)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->header.tile_set_id)),
+      58526)
       << "incorrect value for header.tile_set_id, expected 58526, is "
       << last_msg_->header.tile_set_id;
-  EXPECT_EQ(last_msg_->header.time.tow, 714907186)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.time.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.time.tow)),
+            714907186)
       << "incorrect value for header.time.tow, expected 714907186, is "
       << last_msg_->header.time.tow;
-  EXPECT_EQ(last_msg_->header.time.wn, 40055)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.time.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.time.wn)),
+            40055)
       << "incorrect value for header.time.wn, expected 40055, is "
       << last_msg_->header.time.wn;
-  EXPECT_EQ(last_msg_->header.update_interval, 47)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.update_interval)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->header.update_interval)),
+            47)
       << "incorrect value for header.update_interval, expected 47, is "
       << last_msg_->header.update_interval;
-  EXPECT_EQ(last_msg_->stec_sat_list[0].stec_coeff[0], -5289)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[0].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[0].stec_coeff[0])),
+            -5289)
       << "incorrect value for stec_sat_list[0].stec_coeff[0], expected -5289, "
          "is "
       << last_msg_->stec_sat_list[0].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[0].stec_coeff[1], -20141)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[0].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[0].stec_coeff[1])),
+            -20141)
       << "incorrect value for stec_sat_list[0].stec_coeff[1], expected -20141, "
          "is "
       << last_msg_->stec_sat_list[0].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[0].stec_coeff[2], 966)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[0].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[0].stec_coeff[2])),
+            966)
       << "incorrect value for stec_sat_list[0].stec_coeff[2], expected 966, is "
       << last_msg_->stec_sat_list[0].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[0].stec_coeff[3], 2062)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[0].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[0].stec_coeff[3])),
+            2062)
       << "incorrect value for stec_sat_list[0].stec_coeff[3], expected 2062, "
          "is "
       << last_msg_->stec_sat_list[0].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[0].stec_quality_indicator, 70)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[0].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[0].stec_quality_indicator)),
+      70)
       << "incorrect value for stec_sat_list[0].stec_quality_indicator, "
          "expected 70, is "
       << last_msg_->stec_sat_list[0].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[0].sv_id.constellation, 40)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[0].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[0].sv_id.constellation)),
+            40)
       << "incorrect value for stec_sat_list[0].sv_id.constellation, expected "
          "40, is "
       << last_msg_->stec_sat_list[0].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[0].sv_id.satId, 132)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[0].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[0].sv_id.satId)),
+            132)
       << "incorrect value for stec_sat_list[0].sv_id.satId, expected 132, is "
       << last_msg_->stec_sat_list[0].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[1].stec_coeff[0], -19147)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[1].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[1].stec_coeff[0])),
+            -19147)
       << "incorrect value for stec_sat_list[1].stec_coeff[0], expected -19147, "
          "is "
       << last_msg_->stec_sat_list[1].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[1].stec_coeff[1], -20902)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[1].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[1].stec_coeff[1])),
+            -20902)
       << "incorrect value for stec_sat_list[1].stec_coeff[1], expected -20902, "
          "is "
       << last_msg_->stec_sat_list[1].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[1].stec_coeff[2], -26889)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[1].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[1].stec_coeff[2])),
+            -26889)
       << "incorrect value for stec_sat_list[1].stec_coeff[2], expected -26889, "
          "is "
       << last_msg_->stec_sat_list[1].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[1].stec_coeff[3], -21446)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[1].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[1].stec_coeff[3])),
+            -21446)
       << "incorrect value for stec_sat_list[1].stec_coeff[3], expected -21446, "
          "is "
       << last_msg_->stec_sat_list[1].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[1].stec_quality_indicator, 44)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[1].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[1].stec_quality_indicator)),
+      44)
       << "incorrect value for stec_sat_list[1].stec_quality_indicator, "
          "expected 44, is "
       << last_msg_->stec_sat_list[1].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[1].sv_id.constellation, 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[1].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[1].sv_id.constellation)),
+            12)
       << "incorrect value for stec_sat_list[1].sv_id.constellation, expected "
          "12, is "
       << last_msg_->stec_sat_list[1].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[1].sv_id.satId, 70)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[1].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[1].sv_id.satId)),
+            70)
       << "incorrect value for stec_sat_list[1].sv_id.satId, expected 70, is "
       << last_msg_->stec_sat_list[1].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[2].stec_coeff[0], 32176)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[2].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[2].stec_coeff[0])),
+            32176)
       << "incorrect value for stec_sat_list[2].stec_coeff[0], expected 32176, "
          "is "
       << last_msg_->stec_sat_list[2].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[2].stec_coeff[1], -20220)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[2].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[2].stec_coeff[1])),
+            -20220)
       << "incorrect value for stec_sat_list[2].stec_coeff[1], expected -20220, "
          "is "
       << last_msg_->stec_sat_list[2].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[2].stec_coeff[2], 29157)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[2].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[2].stec_coeff[2])),
+            29157)
       << "incorrect value for stec_sat_list[2].stec_coeff[2], expected 29157, "
          "is "
       << last_msg_->stec_sat_list[2].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[2].stec_coeff[3], 19726)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[2].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[2].stec_coeff[3])),
+            19726)
       << "incorrect value for stec_sat_list[2].stec_coeff[3], expected 19726, "
          "is "
       << last_msg_->stec_sat_list[2].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[2].stec_quality_indicator, 119)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[2].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[2].stec_quality_indicator)),
+      119)
       << "incorrect value for stec_sat_list[2].stec_quality_indicator, "
          "expected 119, is "
       << last_msg_->stec_sat_list[2].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[2].sv_id.constellation, 179)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[2].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[2].sv_id.constellation)),
+            179)
       << "incorrect value for stec_sat_list[2].sv_id.constellation, expected "
          "179, is "
       << last_msg_->stec_sat_list[2].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[2].sv_id.satId, 247)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[2].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[2].sv_id.satId)),
+            247)
       << "incorrect value for stec_sat_list[2].sv_id.satId, expected 247, is "
       << last_msg_->stec_sat_list[2].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[3].stec_coeff[0], -8651)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[3].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[3].stec_coeff[0])),
+            -8651)
       << "incorrect value for stec_sat_list[3].stec_coeff[0], expected -8651, "
          "is "
       << last_msg_->stec_sat_list[3].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[3].stec_coeff[1], -27973)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[3].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[3].stec_coeff[1])),
+            -27973)
       << "incorrect value for stec_sat_list[3].stec_coeff[1], expected -27973, "
          "is "
       << last_msg_->stec_sat_list[3].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[3].stec_coeff[2], 23546)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[3].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[3].stec_coeff[2])),
+            23546)
       << "incorrect value for stec_sat_list[3].stec_coeff[2], expected 23546, "
          "is "
       << last_msg_->stec_sat_list[3].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[3].stec_coeff[3], -10284)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[3].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[3].stec_coeff[3])),
+            -10284)
       << "incorrect value for stec_sat_list[3].stec_coeff[3], expected -10284, "
          "is "
       << last_msg_->stec_sat_list[3].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[3].stec_quality_indicator, 23)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[3].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[3].stec_quality_indicator)),
+      23)
       << "incorrect value for stec_sat_list[3].stec_quality_indicator, "
          "expected 23, is "
       << last_msg_->stec_sat_list[3].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[3].sv_id.constellation, 185)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[3].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[3].sv_id.constellation)),
+            185)
       << "incorrect value for stec_sat_list[3].sv_id.constellation, expected "
          "185, is "
       << last_msg_->stec_sat_list[3].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[3].sv_id.satId, 153)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[3].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[3].sv_id.satId)),
+            153)
       << "incorrect value for stec_sat_list[3].sv_id.satId, expected 153, is "
       << last_msg_->stec_sat_list[3].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[4].stec_coeff[0], 27486)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[4].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[4].stec_coeff[0])),
+            27486)
       << "incorrect value for stec_sat_list[4].stec_coeff[0], expected 27486, "
          "is "
       << last_msg_->stec_sat_list[4].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[4].stec_coeff[1], 23329)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[4].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[4].stec_coeff[1])),
+            23329)
       << "incorrect value for stec_sat_list[4].stec_coeff[1], expected 23329, "
          "is "
       << last_msg_->stec_sat_list[4].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[4].stec_coeff[2], 234)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[4].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[4].stec_coeff[2])),
+            234)
       << "incorrect value for stec_sat_list[4].stec_coeff[2], expected 234, is "
       << last_msg_->stec_sat_list[4].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[4].stec_coeff[3], -29739)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[4].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[4].stec_coeff[3])),
+            -29739)
       << "incorrect value for stec_sat_list[4].stec_coeff[3], expected -29739, "
          "is "
       << last_msg_->stec_sat_list[4].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[4].stec_quality_indicator, 250)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[4].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[4].stec_quality_indicator)),
+      250)
       << "incorrect value for stec_sat_list[4].stec_quality_indicator, "
          "expected 250, is "
       << last_msg_->stec_sat_list[4].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[4].sv_id.constellation, 107)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[4].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[4].sv_id.constellation)),
+            107)
       << "incorrect value for stec_sat_list[4].sv_id.constellation, expected "
          "107, is "
       << last_msg_->stec_sat_list[4].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[4].sv_id.satId, 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[4].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[4].sv_id.satId)),
+            14)
       << "incorrect value for stec_sat_list[4].sv_id.satId, expected 14, is "
       << last_msg_->stec_sat_list[4].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[5].stec_coeff[0], 18965)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[5].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[5].stec_coeff[0])),
+            18965)
       << "incorrect value for stec_sat_list[5].stec_coeff[0], expected 18965, "
          "is "
       << last_msg_->stec_sat_list[5].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[5].stec_coeff[1], -22098)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[5].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[5].stec_coeff[1])),
+            -22098)
       << "incorrect value for stec_sat_list[5].stec_coeff[1], expected -22098, "
          "is "
       << last_msg_->stec_sat_list[5].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[5].stec_coeff[2], 22077)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[5].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[5].stec_coeff[2])),
+            22077)
       << "incorrect value for stec_sat_list[5].stec_coeff[2], expected 22077, "
          "is "
       << last_msg_->stec_sat_list[5].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[5].stec_coeff[3], -29093)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[5].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[5].stec_coeff[3])),
+            -29093)
       << "incorrect value for stec_sat_list[5].stec_coeff[3], expected -29093, "
          "is "
       << last_msg_->stec_sat_list[5].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[5].stec_quality_indicator, 50)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[5].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[5].stec_quality_indicator)),
+      50)
       << "incorrect value for stec_sat_list[5].stec_quality_indicator, "
          "expected 50, is "
       << last_msg_->stec_sat_list[5].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[5].sv_id.constellation, 179)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[5].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[5].sv_id.constellation)),
+            179)
       << "incorrect value for stec_sat_list[5].sv_id.constellation, expected "
          "179, is "
       << last_msg_->stec_sat_list[5].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[5].sv_id.satId, 95)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[5].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[5].sv_id.satId)),
+            95)
       << "incorrect value for stec_sat_list[5].sv_id.satId, expected 95, is "
       << last_msg_->stec_sat_list[5].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[6].stec_coeff[0], -7898)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[6].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[6].stec_coeff[0])),
+            -7898)
       << "incorrect value for stec_sat_list[6].stec_coeff[0], expected -7898, "
          "is "
       << last_msg_->stec_sat_list[6].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[6].stec_coeff[1], 26002)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[6].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[6].stec_coeff[1])),
+            26002)
       << "incorrect value for stec_sat_list[6].stec_coeff[1], expected 26002, "
          "is "
       << last_msg_->stec_sat_list[6].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[6].stec_coeff[2], -29879)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[6].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[6].stec_coeff[2])),
+            -29879)
       << "incorrect value for stec_sat_list[6].stec_coeff[2], expected -29879, "
          "is "
       << last_msg_->stec_sat_list[6].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[6].stec_coeff[3], 30008)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[6].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[6].stec_coeff[3])),
+            30008)
       << "incorrect value for stec_sat_list[6].stec_coeff[3], expected 30008, "
          "is "
       << last_msg_->stec_sat_list[6].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[6].stec_quality_indicator, 9)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[6].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[6].stec_quality_indicator)),
+      9)
       << "incorrect value for stec_sat_list[6].stec_quality_indicator, "
          "expected 9, is "
       << last_msg_->stec_sat_list[6].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[6].sv_id.constellation, 108)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[6].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[6].sv_id.constellation)),
+            108)
       << "incorrect value for stec_sat_list[6].sv_id.constellation, expected "
          "108, is "
       << last_msg_->stec_sat_list[6].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[6].sv_id.satId, 51)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[6].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[6].sv_id.satId)),
+            51)
       << "incorrect value for stec_sat_list[6].sv_id.satId, expected 51, is "
       << last_msg_->stec_sat_list[6].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[7].stec_coeff[0], -12948)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[7].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[7].stec_coeff[0])),
+            -12948)
       << "incorrect value for stec_sat_list[7].stec_coeff[0], expected -12948, "
          "is "
       << last_msg_->stec_sat_list[7].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[7].stec_coeff[1], 4701)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[7].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[7].stec_coeff[1])),
+            4701)
       << "incorrect value for stec_sat_list[7].stec_coeff[1], expected 4701, "
          "is "
       << last_msg_->stec_sat_list[7].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[7].stec_coeff[2], -15597)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[7].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[7].stec_coeff[2])),
+            -15597)
       << "incorrect value for stec_sat_list[7].stec_coeff[2], expected -15597, "
          "is "
       << last_msg_->stec_sat_list[7].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[7].stec_coeff[3], -13791)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[7].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[7].stec_coeff[3])),
+            -13791)
       << "incorrect value for stec_sat_list[7].stec_coeff[3], expected -13791, "
          "is "
       << last_msg_->stec_sat_list[7].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[7].stec_quality_indicator, 213)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[7].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[7].stec_quality_indicator)),
+      213)
       << "incorrect value for stec_sat_list[7].stec_quality_indicator, "
          "expected 213, is "
       << last_msg_->stec_sat_list[7].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[7].sv_id.constellation, 37)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[7].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[7].sv_id.constellation)),
+            37)
       << "incorrect value for stec_sat_list[7].sv_id.constellation, expected "
          "37, is "
       << last_msg_->stec_sat_list[7].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[7].sv_id.satId, 82)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[7].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[7].sv_id.satId)),
+            82)
       << "incorrect value for stec_sat_list[7].sv_id.satId, expected 82, is "
       << last_msg_->stec_sat_list[7].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[8].stec_coeff[0], -17283)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[8].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[8].stec_coeff[0])),
+            -17283)
       << "incorrect value for stec_sat_list[8].stec_coeff[0], expected -17283, "
          "is "
       << last_msg_->stec_sat_list[8].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[8].stec_coeff[1], 14455)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[8].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[8].stec_coeff[1])),
+            14455)
       << "incorrect value for stec_sat_list[8].stec_coeff[1], expected 14455, "
          "is "
       << last_msg_->stec_sat_list[8].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[8].stec_coeff[2], -27067)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[8].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[8].stec_coeff[2])),
+            -27067)
       << "incorrect value for stec_sat_list[8].stec_coeff[2], expected -27067, "
          "is "
       << last_msg_->stec_sat_list[8].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[8].stec_coeff[3], 19606)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[8].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[8].stec_coeff[3])),
+            19606)
       << "incorrect value for stec_sat_list[8].stec_coeff[3], expected 19606, "
          "is "
       << last_msg_->stec_sat_list[8].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[8].stec_quality_indicator, 178)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[8].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[8].stec_quality_indicator)),
+      178)
       << "incorrect value for stec_sat_list[8].stec_quality_indicator, "
          "expected 178, is "
       << last_msg_->stec_sat_list[8].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[8].sv_id.constellation, 206)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[8].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[8].sv_id.constellation)),
+            206)
       << "incorrect value for stec_sat_list[8].sv_id.constellation, expected "
          "206, is "
       << last_msg_->stec_sat_list[8].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[8].sv_id.satId, 87)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[8].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[8].sv_id.satId)),
+            87)
       << "incorrect value for stec_sat_list[8].sv_id.satId, expected 87, is "
       << last_msg_->stec_sat_list[8].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[9].stec_coeff[0], -12215)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[9].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[9].stec_coeff[0])),
+            -12215)
       << "incorrect value for stec_sat_list[9].stec_coeff[0], expected -12215, "
          "is "
       << last_msg_->stec_sat_list[9].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[9].stec_coeff[1], -6072)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[9].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[9].stec_coeff[1])),
+            -6072)
       << "incorrect value for stec_sat_list[9].stec_coeff[1], expected -6072, "
          "is "
       << last_msg_->stec_sat_list[9].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[9].stec_coeff[2], -1528)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[9].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[9].stec_coeff[2])),
+            -1528)
       << "incorrect value for stec_sat_list[9].stec_coeff[2], expected -1528, "
          "is "
       << last_msg_->stec_sat_list[9].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[9].stec_coeff[3], -19765)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[9].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[9].stec_coeff[3])),
+            -19765)
       << "incorrect value for stec_sat_list[9].stec_coeff[3], expected -19765, "
          "is "
       << last_msg_->stec_sat_list[9].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[9].stec_quality_indicator, 18)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[9].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[9].stec_quality_indicator)),
+      18)
       << "incorrect value for stec_sat_list[9].stec_quality_indicator, "
          "expected 18, is "
       << last_msg_->stec_sat_list[9].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[9].sv_id.constellation, 131)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[9].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[9].sv_id.constellation)),
+            131)
       << "incorrect value for stec_sat_list[9].sv_id.constellation, expected "
          "131, is "
       << last_msg_->stec_sat_list[9].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[9].sv_id.satId, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[9].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[9].sv_id.satId)),
+            3)
       << "incorrect value for stec_sat_list[9].sv_id.satId, expected 3, is "
       << last_msg_->stec_sat_list[9].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[10].stec_coeff[0], 12630)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[10].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[10].stec_coeff[0])),
+            12630)
       << "incorrect value for stec_sat_list[10].stec_coeff[0], expected 12630, "
          "is "
       << last_msg_->stec_sat_list[10].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[10].stec_coeff[1], -19721)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[10].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[10].stec_coeff[1])),
+            -19721)
       << "incorrect value for stec_sat_list[10].stec_coeff[1], expected "
          "-19721, is "
       << last_msg_->stec_sat_list[10].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[10].stec_coeff[2], 14502)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[10].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[10].stec_coeff[2])),
+            14502)
       << "incorrect value for stec_sat_list[10].stec_coeff[2], expected 14502, "
          "is "
       << last_msg_->stec_sat_list[10].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[10].stec_coeff[3], 2591)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[10].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[10].stec_coeff[3])),
+            2591)
       << "incorrect value for stec_sat_list[10].stec_coeff[3], expected 2591, "
          "is "
       << last_msg_->stec_sat_list[10].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[10].stec_quality_indicator, 252)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[10].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[10].stec_quality_indicator)),
+      252)
       << "incorrect value for stec_sat_list[10].stec_quality_indicator, "
          "expected 252, is "
       << last_msg_->stec_sat_list[10].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[10].sv_id.constellation, 163)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[10].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[10].sv_id.constellation)),
+            163)
       << "incorrect value for stec_sat_list[10].sv_id.constellation, expected "
          "163, is "
       << last_msg_->stec_sat_list[10].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[10].sv_id.satId, 170)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[10].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[10].sv_id.satId)),
+            170)
       << "incorrect value for stec_sat_list[10].sv_id.satId, expected 170, is "
       << last_msg_->stec_sat_list[10].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[11].stec_coeff[0], -23340)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[11].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[11].stec_coeff[0])),
+            -23340)
       << "incorrect value for stec_sat_list[11].stec_coeff[0], expected "
          "-23340, is "
       << last_msg_->stec_sat_list[11].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[11].stec_coeff[1], -24063)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[11].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[11].stec_coeff[1])),
+            -24063)
       << "incorrect value for stec_sat_list[11].stec_coeff[1], expected "
          "-24063, is "
       << last_msg_->stec_sat_list[11].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[11].stec_coeff[2], 4650)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[11].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[11].stec_coeff[2])),
+            4650)
       << "incorrect value for stec_sat_list[11].stec_coeff[2], expected 4650, "
          "is "
       << last_msg_->stec_sat_list[11].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[11].stec_coeff[3], -22148)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[11].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[11].stec_coeff[3])),
+            -22148)
       << "incorrect value for stec_sat_list[11].stec_coeff[3], expected "
          "-22148, is "
       << last_msg_->stec_sat_list[11].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[11].stec_quality_indicator, 241)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[11].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[11].stec_quality_indicator)),
+      241)
       << "incorrect value for stec_sat_list[11].stec_quality_indicator, "
          "expected 241, is "
       << last_msg_->stec_sat_list[11].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[11].sv_id.constellation, 213)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[11].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[11].sv_id.constellation)),
+            213)
       << "incorrect value for stec_sat_list[11].sv_id.constellation, expected "
          "213, is "
       << last_msg_->stec_sat_list[11].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[11].sv_id.satId, 119)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[11].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[11].sv_id.satId)),
+            119)
       << "incorrect value for stec_sat_list[11].sv_id.satId, expected 119, is "
       << last_msg_->stec_sat_list[11].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[12].stec_coeff[0], 5944)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[12].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[12].stec_coeff[0])),
+            5944)
       << "incorrect value for stec_sat_list[12].stec_coeff[0], expected 5944, "
          "is "
       << last_msg_->stec_sat_list[12].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[12].stec_coeff[1], 32142)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[12].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[12].stec_coeff[1])),
+            32142)
       << "incorrect value for stec_sat_list[12].stec_coeff[1], expected 32142, "
          "is "
       << last_msg_->stec_sat_list[12].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[12].stec_coeff[2], 30760)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[12].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[12].stec_coeff[2])),
+            30760)
       << "incorrect value for stec_sat_list[12].stec_coeff[2], expected 30760, "
          "is "
       << last_msg_->stec_sat_list[12].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[12].stec_coeff[3], 11587)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[12].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[12].stec_coeff[3])),
+            11587)
       << "incorrect value for stec_sat_list[12].stec_coeff[3], expected 11587, "
          "is "
       << last_msg_->stec_sat_list[12].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[12].stec_quality_indicator, 26)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[12].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[12].stec_quality_indicator)),
+      26)
       << "incorrect value for stec_sat_list[12].stec_quality_indicator, "
          "expected 26, is "
       << last_msg_->stec_sat_list[12].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[12].sv_id.constellation, 158)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[12].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[12].sv_id.constellation)),
+            158)
       << "incorrect value for stec_sat_list[12].sv_id.constellation, expected "
          "158, is "
       << last_msg_->stec_sat_list[12].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[12].sv_id.satId, 121)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[12].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[12].sv_id.satId)),
+            121)
       << "incorrect value for stec_sat_list[12].sv_id.satId, expected 121, is "
       << last_msg_->stec_sat_list[12].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[13].stec_coeff[0], 3095)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[13].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[13].stec_coeff[0])),
+            3095)
       << "incorrect value for stec_sat_list[13].stec_coeff[0], expected 3095, "
          "is "
       << last_msg_->stec_sat_list[13].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[13].stec_coeff[1], 22769)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[13].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[13].stec_coeff[1])),
+            22769)
       << "incorrect value for stec_sat_list[13].stec_coeff[1], expected 22769, "
          "is "
       << last_msg_->stec_sat_list[13].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[13].stec_coeff[2], -4283)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[13].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[13].stec_coeff[2])),
+            -4283)
       << "incorrect value for stec_sat_list[13].stec_coeff[2], expected -4283, "
          "is "
       << last_msg_->stec_sat_list[13].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[13].stec_coeff[3], 14844)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[13].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[13].stec_coeff[3])),
+            14844)
       << "incorrect value for stec_sat_list[13].stec_coeff[3], expected 14844, "
          "is "
       << last_msg_->stec_sat_list[13].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[13].stec_quality_indicator, 110)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[13].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[13].stec_quality_indicator)),
+      110)
       << "incorrect value for stec_sat_list[13].stec_quality_indicator, "
          "expected 110, is "
       << last_msg_->stec_sat_list[13].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[13].sv_id.constellation, 235)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[13].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[13].sv_id.constellation)),
+            235)
       << "incorrect value for stec_sat_list[13].sv_id.constellation, expected "
          "235, is "
       << last_msg_->stec_sat_list[13].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[13].sv_id.satId, 126)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[13].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[13].sv_id.satId)),
+            126)
       << "incorrect value for stec_sat_list[13].sv_id.satId, expected 126, is "
       << last_msg_->stec_sat_list[13].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[14].stec_coeff[0], -21032)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[14].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[14].stec_coeff[0])),
+            -21032)
       << "incorrect value for stec_sat_list[14].stec_coeff[0], expected "
          "-21032, is "
       << last_msg_->stec_sat_list[14].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[14].stec_coeff[1], -19726)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[14].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[14].stec_coeff[1])),
+            -19726)
       << "incorrect value for stec_sat_list[14].stec_coeff[1], expected "
          "-19726, is "
       << last_msg_->stec_sat_list[14].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[14].stec_coeff[2], 1297)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[14].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[14].stec_coeff[2])),
+            1297)
       << "incorrect value for stec_sat_list[14].stec_coeff[2], expected 1297, "
          "is "
       << last_msg_->stec_sat_list[14].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[14].stec_coeff[3], -22049)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[14].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[14].stec_coeff[3])),
+            -22049)
       << "incorrect value for stec_sat_list[14].stec_coeff[3], expected "
          "-22049, is "
       << last_msg_->stec_sat_list[14].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[14].stec_quality_indicator, 201)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[14].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[14].stec_quality_indicator)),
+      201)
       << "incorrect value for stec_sat_list[14].stec_quality_indicator, "
          "expected 201, is "
       << last_msg_->stec_sat_list[14].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[14].sv_id.constellation, 44)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[14].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[14].sv_id.constellation)),
+            44)
       << "incorrect value for stec_sat_list[14].sv_id.constellation, expected "
          "44, is "
       << last_msg_->stec_sat_list[14].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[14].sv_id.satId, 93)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[14].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[14].sv_id.satId)),
+            93)
       << "incorrect value for stec_sat_list[14].sv_id.satId, expected 93, is "
       << last_msg_->stec_sat_list[14].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[15].stec_coeff[0], 619)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[15].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[15].stec_coeff[0])),
+            619)
       << "incorrect value for stec_sat_list[15].stec_coeff[0], expected 619, "
          "is "
       << last_msg_->stec_sat_list[15].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[15].stec_coeff[1], -5744)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[15].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[15].stec_coeff[1])),
+            -5744)
       << "incorrect value for stec_sat_list[15].stec_coeff[1], expected -5744, "
          "is "
       << last_msg_->stec_sat_list[15].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[15].stec_coeff[2], 22542)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[15].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[15].stec_coeff[2])),
+            22542)
       << "incorrect value for stec_sat_list[15].stec_coeff[2], expected 22542, "
          "is "
       << last_msg_->stec_sat_list[15].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[15].stec_coeff[3], -12000)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[15].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[15].stec_coeff[3])),
+            -12000)
       << "incorrect value for stec_sat_list[15].stec_coeff[3], expected "
          "-12000, is "
       << last_msg_->stec_sat_list[15].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[15].stec_quality_indicator, 77)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[15].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[15].stec_quality_indicator)),
+      77)
       << "incorrect value for stec_sat_list[15].stec_quality_indicator, "
          "expected 77, is "
       << last_msg_->stec_sat_list[15].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[15].sv_id.constellation, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[15].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[15].sv_id.constellation)),
+            3)
       << "incorrect value for stec_sat_list[15].sv_id.constellation, expected "
          "3, is "
       << last_msg_->stec_sat_list[15].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[15].sv_id.satId, 192)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[15].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[15].sv_id.satId)),
+            192)
       << "incorrect value for stec_sat_list[15].sv_id.satId, expected 192, is "
       << last_msg_->stec_sat_list[15].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[16].stec_coeff[0], 10651)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[16].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[16].stec_coeff[0])),
+            10651)
       << "incorrect value for stec_sat_list[16].stec_coeff[0], expected 10651, "
          "is "
       << last_msg_->stec_sat_list[16].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[16].stec_coeff[1], -2889)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[16].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[16].stec_coeff[1])),
+            -2889)
       << "incorrect value for stec_sat_list[16].stec_coeff[1], expected -2889, "
          "is "
       << last_msg_->stec_sat_list[16].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[16].stec_coeff[2], 21150)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[16].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[16].stec_coeff[2])),
+            21150)
       << "incorrect value for stec_sat_list[16].stec_coeff[2], expected 21150, "
          "is "
       << last_msg_->stec_sat_list[16].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[16].stec_coeff[3], 26421)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[16].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[16].stec_coeff[3])),
+            26421)
       << "incorrect value for stec_sat_list[16].stec_coeff[3], expected 26421, "
          "is "
       << last_msg_->stec_sat_list[16].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[16].stec_quality_indicator, 123)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[16].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[16].stec_quality_indicator)),
+      123)
       << "incorrect value for stec_sat_list[16].stec_quality_indicator, "
          "expected 123, is "
       << last_msg_->stec_sat_list[16].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[16].sv_id.constellation, 17)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[16].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[16].sv_id.constellation)),
+            17)
       << "incorrect value for stec_sat_list[16].sv_id.constellation, expected "
          "17, is "
       << last_msg_->stec_sat_list[16].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[16].sv_id.satId, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[16].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[16].sv_id.satId)),
+            1)
       << "incorrect value for stec_sat_list[16].sv_id.satId, expected 1, is "
       << last_msg_->stec_sat_list[16].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[17].stec_coeff[0], -19165)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[17].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[17].stec_coeff[0])),
+            -19165)
       << "incorrect value for stec_sat_list[17].stec_coeff[0], expected "
          "-19165, is "
       << last_msg_->stec_sat_list[17].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[17].stec_coeff[1], 30229)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[17].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[17].stec_coeff[1])),
+            30229)
       << "incorrect value for stec_sat_list[17].stec_coeff[1], expected 30229, "
          "is "
       << last_msg_->stec_sat_list[17].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[17].stec_coeff[2], -1282)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[17].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[17].stec_coeff[2])),
+            -1282)
       << "incorrect value for stec_sat_list[17].stec_coeff[2], expected -1282, "
          "is "
       << last_msg_->stec_sat_list[17].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[17].stec_coeff[3], -18382)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[17].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[17].stec_coeff[3])),
+            -18382)
       << "incorrect value for stec_sat_list[17].stec_coeff[3], expected "
          "-18382, is "
       << last_msg_->stec_sat_list[17].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[17].stec_quality_indicator, 185)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[17].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[17].stec_quality_indicator)),
+      185)
       << "incorrect value for stec_sat_list[17].stec_quality_indicator, "
          "expected 185, is "
       << last_msg_->stec_sat_list[17].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[17].sv_id.constellation, 202)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[17].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[17].sv_id.constellation)),
+            202)
       << "incorrect value for stec_sat_list[17].sv_id.constellation, expected "
          "202, is "
       << last_msg_->stec_sat_list[17].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[17].sv_id.satId, 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[17].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[17].sv_id.satId)),
+            14)
       << "incorrect value for stec_sat_list[17].sv_id.satId, expected 14, is "
       << last_msg_->stec_sat_list[17].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[18].stec_coeff[0], -23752)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[18].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[18].stec_coeff[0])),
+            -23752)
       << "incorrect value for stec_sat_list[18].stec_coeff[0], expected "
          "-23752, is "
       << last_msg_->stec_sat_list[18].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[18].stec_coeff[1], 32433)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[18].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[18].stec_coeff[1])),
+            32433)
       << "incorrect value for stec_sat_list[18].stec_coeff[1], expected 32433, "
          "is "
       << last_msg_->stec_sat_list[18].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[18].stec_coeff[2], 20441)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[18].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[18].stec_coeff[2])),
+            20441)
       << "incorrect value for stec_sat_list[18].stec_coeff[2], expected 20441, "
          "is "
       << last_msg_->stec_sat_list[18].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[18].stec_coeff[3], -4181)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[18].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[18].stec_coeff[3])),
+            -4181)
       << "incorrect value for stec_sat_list[18].stec_coeff[3], expected -4181, "
          "is "
       << last_msg_->stec_sat_list[18].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[18].stec_quality_indicator, 45)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[18].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[18].stec_quality_indicator)),
+      45)
       << "incorrect value for stec_sat_list[18].stec_quality_indicator, "
          "expected 45, is "
       << last_msg_->stec_sat_list[18].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[18].sv_id.constellation, 31)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[18].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[18].sv_id.constellation)),
+            31)
       << "incorrect value for stec_sat_list[18].sv_id.constellation, expected "
          "31, is "
       << last_msg_->stec_sat_list[18].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[18].sv_id.satId, 50)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[18].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[18].sv_id.satId)),
+            50)
       << "incorrect value for stec_sat_list[18].sv_id.satId, expected 50, is "
       << last_msg_->stec_sat_list[18].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[19].stec_coeff[0], -13968)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[19].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[19].stec_coeff[0])),
+            -13968)
       << "incorrect value for stec_sat_list[19].stec_coeff[0], expected "
          "-13968, is "
       << last_msg_->stec_sat_list[19].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[19].stec_coeff[1], -29322)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[19].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[19].stec_coeff[1])),
+            -29322)
       << "incorrect value for stec_sat_list[19].stec_coeff[1], expected "
          "-29322, is "
       << last_msg_->stec_sat_list[19].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[19].stec_coeff[2], -23790)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[19].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[19].stec_coeff[2])),
+            -23790)
       << "incorrect value for stec_sat_list[19].stec_coeff[2], expected "
          "-23790, is "
       << last_msg_->stec_sat_list[19].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[19].stec_coeff[3], 9063)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[19].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[19].stec_coeff[3])),
+            9063)
       << "incorrect value for stec_sat_list[19].stec_coeff[3], expected 9063, "
          "is "
       << last_msg_->stec_sat_list[19].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[19].stec_quality_indicator, 238)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[19].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[19].stec_quality_indicator)),
+      238)
       << "incorrect value for stec_sat_list[19].stec_quality_indicator, "
          "expected 238, is "
       << last_msg_->stec_sat_list[19].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[19].sv_id.constellation, 188)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[19].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[19].sv_id.constellation)),
+            188)
       << "incorrect value for stec_sat_list[19].sv_id.constellation, expected "
          "188, is "
       << last_msg_->stec_sat_list[19].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[19].sv_id.satId, 237)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[19].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[19].sv_id.satId)),
+            237)
       << "incorrect value for stec_sat_list[19].sv_id.satId, expected 237, is "
       << last_msg_->stec_sat_list[19].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[20].stec_coeff[0], 4737)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[20].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[20].stec_coeff[0])),
+            4737)
       << "incorrect value for stec_sat_list[20].stec_coeff[0], expected 4737, "
          "is "
       << last_msg_->stec_sat_list[20].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[20].stec_coeff[1], 21877)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[20].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[20].stec_coeff[1])),
+            21877)
       << "incorrect value for stec_sat_list[20].stec_coeff[1], expected 21877, "
          "is "
       << last_msg_->stec_sat_list[20].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[20].stec_coeff[2], 20414)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[20].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[20].stec_coeff[2])),
+            20414)
       << "incorrect value for stec_sat_list[20].stec_coeff[2], expected 20414, "
          "is "
       << last_msg_->stec_sat_list[20].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[20].stec_coeff[3], -10286)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[20].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[20].stec_coeff[3])),
+            -10286)
       << "incorrect value for stec_sat_list[20].stec_coeff[3], expected "
          "-10286, is "
       << last_msg_->stec_sat_list[20].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[20].stec_quality_indicator, 82)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[20].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[20].stec_quality_indicator)),
+      82)
       << "incorrect value for stec_sat_list[20].stec_quality_indicator, "
          "expected 82, is "
       << last_msg_->stec_sat_list[20].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[20].sv_id.constellation, 21)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[20].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[20].sv_id.constellation)),
+            21)
       << "incorrect value for stec_sat_list[20].sv_id.constellation, expected "
          "21, is "
       << last_msg_->stec_sat_list[20].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[20].sv_id.satId, 63)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[20].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[20].sv_id.satId)),
+            63)
       << "incorrect value for stec_sat_list[20].sv_id.satId, expected 63, is "
       << last_msg_->stec_sat_list[20].sv_id.satId;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrStecCorrectionDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrStecCorrectionDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/ssr.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_ssr_MsgSsrStecCorrectionDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -816,614 +823,1111 @@ TEST_F(Test_legacy_auto_check_sbp_ssr_MsgSsrStecCorrectionDepA0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1831);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->header.iod_atmo, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.iod_atmo)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.iod_atmo)),
+            4)
       << "incorrect value for header.iod_atmo, expected 4, is "
       << last_msg_->header.iod_atmo;
-  EXPECT_EQ(last_msg_->header.num_msgs, 147)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.num_msgs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.num_msgs)),
+            147)
       << "incorrect value for header.num_msgs, expected 147, is "
       << last_msg_->header.num_msgs;
-  EXPECT_EQ(last_msg_->header.seq_num, 123)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.seq_num)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.seq_num)),
+            123)
       << "incorrect value for header.seq_num, expected 123, is "
       << last_msg_->header.seq_num;
-  EXPECT_EQ(last_msg_->header.time.tow, 3905179974)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.time.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.time.tow)),
+            3905179974)
       << "incorrect value for header.time.tow, expected 3905179974, is "
       << last_msg_->header.time.tow;
-  EXPECT_EQ(last_msg_->header.time.wn, 11193)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.time.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->header.time.wn)),
+            11193)
       << "incorrect value for header.time.wn, expected 11193, is "
       << last_msg_->header.time.wn;
-  EXPECT_EQ(last_msg_->header.update_interval, 39)
+  EXPECT_EQ(get_as<decltype(last_msg_->header.update_interval)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->header.update_interval)),
+            39)
       << "incorrect value for header.update_interval, expected 39, is "
       << last_msg_->header.update_interval;
-  EXPECT_EQ(last_msg_->stec_sat_list[0].stec_coeff[0], -1951)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[0].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[0].stec_coeff[0])),
+            -1951)
       << "incorrect value for stec_sat_list[0].stec_coeff[0], expected -1951, "
          "is "
       << last_msg_->stec_sat_list[0].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[0].stec_coeff[1], -9854)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[0].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[0].stec_coeff[1])),
+            -9854)
       << "incorrect value for stec_sat_list[0].stec_coeff[1], expected -9854, "
          "is "
       << last_msg_->stec_sat_list[0].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[0].stec_coeff[2], 27353)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[0].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[0].stec_coeff[2])),
+            27353)
       << "incorrect value for stec_sat_list[0].stec_coeff[2], expected 27353, "
          "is "
       << last_msg_->stec_sat_list[0].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[0].stec_coeff[3], 3130)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[0].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[0].stec_coeff[3])),
+            3130)
       << "incorrect value for stec_sat_list[0].stec_coeff[3], expected 3130, "
          "is "
       << last_msg_->stec_sat_list[0].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[0].stec_quality_indicator, 111)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[0].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[0].stec_quality_indicator)),
+      111)
       << "incorrect value for stec_sat_list[0].stec_quality_indicator, "
          "expected 111, is "
       << last_msg_->stec_sat_list[0].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[0].sv_id.constellation, 19)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[0].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[0].sv_id.constellation)),
+            19)
       << "incorrect value for stec_sat_list[0].sv_id.constellation, expected "
          "19, is "
       << last_msg_->stec_sat_list[0].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[0].sv_id.satId, 126)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[0].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[0].sv_id.satId)),
+            126)
       << "incorrect value for stec_sat_list[0].sv_id.satId, expected 126, is "
       << last_msg_->stec_sat_list[0].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[1].stec_coeff[0], 24401)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[1].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[1].stec_coeff[0])),
+            24401)
       << "incorrect value for stec_sat_list[1].stec_coeff[0], expected 24401, "
          "is "
       << last_msg_->stec_sat_list[1].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[1].stec_coeff[1], 4182)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[1].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[1].stec_coeff[1])),
+            4182)
       << "incorrect value for stec_sat_list[1].stec_coeff[1], expected 4182, "
          "is "
       << last_msg_->stec_sat_list[1].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[1].stec_coeff[2], 21543)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[1].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[1].stec_coeff[2])),
+            21543)
       << "incorrect value for stec_sat_list[1].stec_coeff[2], expected 21543, "
          "is "
       << last_msg_->stec_sat_list[1].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[1].stec_coeff[3], -12060)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[1].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[1].stec_coeff[3])),
+            -12060)
       << "incorrect value for stec_sat_list[1].stec_coeff[3], expected -12060, "
          "is "
       << last_msg_->stec_sat_list[1].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[1].stec_quality_indicator, 171)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[1].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[1].stec_quality_indicator)),
+      171)
       << "incorrect value for stec_sat_list[1].stec_quality_indicator, "
          "expected 171, is "
       << last_msg_->stec_sat_list[1].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[1].sv_id.constellation, 230)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[1].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[1].sv_id.constellation)),
+            230)
       << "incorrect value for stec_sat_list[1].sv_id.constellation, expected "
          "230, is "
       << last_msg_->stec_sat_list[1].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[1].sv_id.satId, 65)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[1].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[1].sv_id.satId)),
+            65)
       << "incorrect value for stec_sat_list[1].sv_id.satId, expected 65, is "
       << last_msg_->stec_sat_list[1].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[2].stec_coeff[0], -13469)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[2].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[2].stec_coeff[0])),
+            -13469)
       << "incorrect value for stec_sat_list[2].stec_coeff[0], expected -13469, "
          "is "
       << last_msg_->stec_sat_list[2].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[2].stec_coeff[1], -18883)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[2].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[2].stec_coeff[1])),
+            -18883)
       << "incorrect value for stec_sat_list[2].stec_coeff[1], expected -18883, "
          "is "
       << last_msg_->stec_sat_list[2].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[2].stec_coeff[2], 32066)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[2].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[2].stec_coeff[2])),
+            32066)
       << "incorrect value for stec_sat_list[2].stec_coeff[2], expected 32066, "
          "is "
       << last_msg_->stec_sat_list[2].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[2].stec_coeff[3], 971)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[2].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[2].stec_coeff[3])),
+            971)
       << "incorrect value for stec_sat_list[2].stec_coeff[3], expected 971, is "
       << last_msg_->stec_sat_list[2].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[2].stec_quality_indicator, 219)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[2].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[2].stec_quality_indicator)),
+      219)
       << "incorrect value for stec_sat_list[2].stec_quality_indicator, "
          "expected 219, is "
       << last_msg_->stec_sat_list[2].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[2].sv_id.constellation, 81)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[2].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[2].sv_id.constellation)),
+            81)
       << "incorrect value for stec_sat_list[2].sv_id.constellation, expected "
          "81, is "
       << last_msg_->stec_sat_list[2].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[2].sv_id.satId, 201)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[2].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[2].sv_id.satId)),
+            201)
       << "incorrect value for stec_sat_list[2].sv_id.satId, expected 201, is "
       << last_msg_->stec_sat_list[2].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[3].stec_coeff[0], 32220)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[3].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[3].stec_coeff[0])),
+            32220)
       << "incorrect value for stec_sat_list[3].stec_coeff[0], expected 32220, "
          "is "
       << last_msg_->stec_sat_list[3].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[3].stec_coeff[1], 5436)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[3].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[3].stec_coeff[1])),
+            5436)
       << "incorrect value for stec_sat_list[3].stec_coeff[1], expected 5436, "
          "is "
       << last_msg_->stec_sat_list[3].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[3].stec_coeff[2], -9635)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[3].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[3].stec_coeff[2])),
+            -9635)
       << "incorrect value for stec_sat_list[3].stec_coeff[2], expected -9635, "
          "is "
       << last_msg_->stec_sat_list[3].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[3].stec_coeff[3], -24841)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[3].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[3].stec_coeff[3])),
+            -24841)
       << "incorrect value for stec_sat_list[3].stec_coeff[3], expected -24841, "
          "is "
       << last_msg_->stec_sat_list[3].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[3].stec_quality_indicator, 100)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[3].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[3].stec_quality_indicator)),
+      100)
       << "incorrect value for stec_sat_list[3].stec_quality_indicator, "
          "expected 100, is "
       << last_msg_->stec_sat_list[3].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[3].sv_id.constellation, 44)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[3].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[3].sv_id.constellation)),
+            44)
       << "incorrect value for stec_sat_list[3].sv_id.constellation, expected "
          "44, is "
       << last_msg_->stec_sat_list[3].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[3].sv_id.satId, 193)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[3].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[3].sv_id.satId)),
+            193)
       << "incorrect value for stec_sat_list[3].sv_id.satId, expected 193, is "
       << last_msg_->stec_sat_list[3].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[4].stec_coeff[0], 3718)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[4].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[4].stec_coeff[0])),
+            3718)
       << "incorrect value for stec_sat_list[4].stec_coeff[0], expected 3718, "
          "is "
       << last_msg_->stec_sat_list[4].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[4].stec_coeff[1], 12497)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[4].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[4].stec_coeff[1])),
+            12497)
       << "incorrect value for stec_sat_list[4].stec_coeff[1], expected 12497, "
          "is "
       << last_msg_->stec_sat_list[4].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[4].stec_coeff[2], -10482)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[4].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[4].stec_coeff[2])),
+            -10482)
       << "incorrect value for stec_sat_list[4].stec_coeff[2], expected -10482, "
          "is "
       << last_msg_->stec_sat_list[4].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[4].stec_coeff[3], -27495)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[4].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[4].stec_coeff[3])),
+            -27495)
       << "incorrect value for stec_sat_list[4].stec_coeff[3], expected -27495, "
          "is "
       << last_msg_->stec_sat_list[4].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[4].stec_quality_indicator, 129)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[4].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[4].stec_quality_indicator)),
+      129)
       << "incorrect value for stec_sat_list[4].stec_quality_indicator, "
          "expected 129, is "
       << last_msg_->stec_sat_list[4].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[4].sv_id.constellation, 93)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[4].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[4].sv_id.constellation)),
+            93)
       << "incorrect value for stec_sat_list[4].sv_id.constellation, expected "
          "93, is "
       << last_msg_->stec_sat_list[4].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[4].sv_id.satId, 207)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[4].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[4].sv_id.satId)),
+            207)
       << "incorrect value for stec_sat_list[4].sv_id.satId, expected 207, is "
       << last_msg_->stec_sat_list[4].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[5].stec_coeff[0], -4940)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[5].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[5].stec_coeff[0])),
+            -4940)
       << "incorrect value for stec_sat_list[5].stec_coeff[0], expected -4940, "
          "is "
       << last_msg_->stec_sat_list[5].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[5].stec_coeff[1], -13875)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[5].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[5].stec_coeff[1])),
+            -13875)
       << "incorrect value for stec_sat_list[5].stec_coeff[1], expected -13875, "
          "is "
       << last_msg_->stec_sat_list[5].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[5].stec_coeff[2], 801)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[5].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[5].stec_coeff[2])),
+            801)
       << "incorrect value for stec_sat_list[5].stec_coeff[2], expected 801, is "
       << last_msg_->stec_sat_list[5].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[5].stec_coeff[3], -13066)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[5].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[5].stec_coeff[3])),
+            -13066)
       << "incorrect value for stec_sat_list[5].stec_coeff[3], expected -13066, "
          "is "
       << last_msg_->stec_sat_list[5].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[5].stec_quality_indicator, 225)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[5].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[5].stec_quality_indicator)),
+      225)
       << "incorrect value for stec_sat_list[5].stec_quality_indicator, "
          "expected 225, is "
       << last_msg_->stec_sat_list[5].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[5].sv_id.constellation, 72)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[5].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[5].sv_id.constellation)),
+            72)
       << "incorrect value for stec_sat_list[5].sv_id.constellation, expected "
          "72, is "
       << last_msg_->stec_sat_list[5].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[5].sv_id.satId, 147)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[5].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[5].sv_id.satId)),
+            147)
       << "incorrect value for stec_sat_list[5].sv_id.satId, expected 147, is "
       << last_msg_->stec_sat_list[5].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[6].stec_coeff[0], -15868)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[6].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[6].stec_coeff[0])),
+            -15868)
       << "incorrect value for stec_sat_list[6].stec_coeff[0], expected -15868, "
          "is "
       << last_msg_->stec_sat_list[6].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[6].stec_coeff[1], -2369)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[6].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[6].stec_coeff[1])),
+            -2369)
       << "incorrect value for stec_sat_list[6].stec_coeff[1], expected -2369, "
          "is "
       << last_msg_->stec_sat_list[6].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[6].stec_coeff[2], -9396)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[6].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[6].stec_coeff[2])),
+            -9396)
       << "incorrect value for stec_sat_list[6].stec_coeff[2], expected -9396, "
          "is "
       << last_msg_->stec_sat_list[6].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[6].stec_coeff[3], -16609)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[6].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[6].stec_coeff[3])),
+            -16609)
       << "incorrect value for stec_sat_list[6].stec_coeff[3], expected -16609, "
          "is "
       << last_msg_->stec_sat_list[6].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[6].stec_quality_indicator, 98)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[6].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[6].stec_quality_indicator)),
+      98)
       << "incorrect value for stec_sat_list[6].stec_quality_indicator, "
          "expected 98, is "
       << last_msg_->stec_sat_list[6].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[6].sv_id.constellation, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[6].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[6].sv_id.constellation)),
+            3)
       << "incorrect value for stec_sat_list[6].sv_id.constellation, expected "
          "3, is "
       << last_msg_->stec_sat_list[6].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[6].sv_id.satId, 19)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[6].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[6].sv_id.satId)),
+            19)
       << "incorrect value for stec_sat_list[6].sv_id.satId, expected 19, is "
       << last_msg_->stec_sat_list[6].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[7].stec_coeff[0], -1265)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[7].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[7].stec_coeff[0])),
+            -1265)
       << "incorrect value for stec_sat_list[7].stec_coeff[0], expected -1265, "
          "is "
       << last_msg_->stec_sat_list[7].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[7].stec_coeff[1], 4897)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[7].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[7].stec_coeff[1])),
+            4897)
       << "incorrect value for stec_sat_list[7].stec_coeff[1], expected 4897, "
          "is "
       << last_msg_->stec_sat_list[7].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[7].stec_coeff[2], 13920)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[7].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[7].stec_coeff[2])),
+            13920)
       << "incorrect value for stec_sat_list[7].stec_coeff[2], expected 13920, "
          "is "
       << last_msg_->stec_sat_list[7].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[7].stec_coeff[3], -28102)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[7].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[7].stec_coeff[3])),
+            -28102)
       << "incorrect value for stec_sat_list[7].stec_coeff[3], expected -28102, "
          "is "
       << last_msg_->stec_sat_list[7].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[7].stec_quality_indicator, 177)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[7].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[7].stec_quality_indicator)),
+      177)
       << "incorrect value for stec_sat_list[7].stec_quality_indicator, "
          "expected 177, is "
       << last_msg_->stec_sat_list[7].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[7].sv_id.constellation, 79)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[7].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[7].sv_id.constellation)),
+            79)
       << "incorrect value for stec_sat_list[7].sv_id.constellation, expected "
          "79, is "
       << last_msg_->stec_sat_list[7].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[7].sv_id.satId, 113)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[7].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[7].sv_id.satId)),
+            113)
       << "incorrect value for stec_sat_list[7].sv_id.satId, expected 113, is "
       << last_msg_->stec_sat_list[7].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[8].stec_coeff[0], 5448)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[8].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[8].stec_coeff[0])),
+            5448)
       << "incorrect value for stec_sat_list[8].stec_coeff[0], expected 5448, "
          "is "
       << last_msg_->stec_sat_list[8].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[8].stec_coeff[1], -11359)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[8].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[8].stec_coeff[1])),
+            -11359)
       << "incorrect value for stec_sat_list[8].stec_coeff[1], expected -11359, "
          "is "
       << last_msg_->stec_sat_list[8].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[8].stec_coeff[2], 5574)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[8].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[8].stec_coeff[2])),
+            5574)
       << "incorrect value for stec_sat_list[8].stec_coeff[2], expected 5574, "
          "is "
       << last_msg_->stec_sat_list[8].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[8].stec_coeff[3], 28654)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[8].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[8].stec_coeff[3])),
+            28654)
       << "incorrect value for stec_sat_list[8].stec_coeff[3], expected 28654, "
          "is "
       << last_msg_->stec_sat_list[8].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[8].stec_quality_indicator, 249)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[8].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[8].stec_quality_indicator)),
+      249)
       << "incorrect value for stec_sat_list[8].stec_quality_indicator, "
          "expected 249, is "
       << last_msg_->stec_sat_list[8].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[8].sv_id.constellation, 100)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[8].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[8].sv_id.constellation)),
+            100)
       << "incorrect value for stec_sat_list[8].sv_id.constellation, expected "
          "100, is "
       << last_msg_->stec_sat_list[8].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[8].sv_id.satId, 210)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[8].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[8].sv_id.satId)),
+            210)
       << "incorrect value for stec_sat_list[8].sv_id.satId, expected 210, is "
       << last_msg_->stec_sat_list[8].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[9].stec_coeff[0], -10783)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[9].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[9].stec_coeff[0])),
+            -10783)
       << "incorrect value for stec_sat_list[9].stec_coeff[0], expected -10783, "
          "is "
       << last_msg_->stec_sat_list[9].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[9].stec_coeff[1], 18179)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[9].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[9].stec_coeff[1])),
+            18179)
       << "incorrect value for stec_sat_list[9].stec_coeff[1], expected 18179, "
          "is "
       << last_msg_->stec_sat_list[9].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[9].stec_coeff[2], 16371)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[9].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[9].stec_coeff[2])),
+            16371)
       << "incorrect value for stec_sat_list[9].stec_coeff[2], expected 16371, "
          "is "
       << last_msg_->stec_sat_list[9].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[9].stec_coeff[3], -5055)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[9].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[9].stec_coeff[3])),
+            -5055)
       << "incorrect value for stec_sat_list[9].stec_coeff[3], expected -5055, "
          "is "
       << last_msg_->stec_sat_list[9].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[9].stec_quality_indicator, 227)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[9].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[9].stec_quality_indicator)),
+      227)
       << "incorrect value for stec_sat_list[9].stec_quality_indicator, "
          "expected 227, is "
       << last_msg_->stec_sat_list[9].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[9].sv_id.constellation, 36)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[9].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[9].sv_id.constellation)),
+            36)
       << "incorrect value for stec_sat_list[9].sv_id.constellation, expected "
          "36, is "
       << last_msg_->stec_sat_list[9].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[9].sv_id.satId, 107)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[9].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[9].sv_id.satId)),
+            107)
       << "incorrect value for stec_sat_list[9].sv_id.satId, expected 107, is "
       << last_msg_->stec_sat_list[9].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[10].stec_coeff[0], 4009)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[10].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[10].stec_coeff[0])),
+            4009)
       << "incorrect value for stec_sat_list[10].stec_coeff[0], expected 4009, "
          "is "
       << last_msg_->stec_sat_list[10].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[10].stec_coeff[1], 1462)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[10].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[10].stec_coeff[1])),
+            1462)
       << "incorrect value for stec_sat_list[10].stec_coeff[1], expected 1462, "
          "is "
       << last_msg_->stec_sat_list[10].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[10].stec_coeff[2], -19216)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[10].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[10].stec_coeff[2])),
+            -19216)
       << "incorrect value for stec_sat_list[10].stec_coeff[2], expected "
          "-19216, is "
       << last_msg_->stec_sat_list[10].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[10].stec_coeff[3], 31241)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[10].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[10].stec_coeff[3])),
+            31241)
       << "incorrect value for stec_sat_list[10].stec_coeff[3], expected 31241, "
          "is "
       << last_msg_->stec_sat_list[10].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[10].stec_quality_indicator, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[10].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[10].stec_quality_indicator)),
+      0)
       << "incorrect value for stec_sat_list[10].stec_quality_indicator, "
          "expected 0, is "
       << last_msg_->stec_sat_list[10].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[10].sv_id.constellation, 77)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[10].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[10].sv_id.constellation)),
+            77)
       << "incorrect value for stec_sat_list[10].sv_id.constellation, expected "
          "77, is "
       << last_msg_->stec_sat_list[10].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[10].sv_id.satId, 92)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[10].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[10].sv_id.satId)),
+            92)
       << "incorrect value for stec_sat_list[10].sv_id.satId, expected 92, is "
       << last_msg_->stec_sat_list[10].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[11].stec_coeff[0], 26727)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[11].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[11].stec_coeff[0])),
+            26727)
       << "incorrect value for stec_sat_list[11].stec_coeff[0], expected 26727, "
          "is "
       << last_msg_->stec_sat_list[11].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[11].stec_coeff[1], -16898)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[11].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[11].stec_coeff[1])),
+            -16898)
       << "incorrect value for stec_sat_list[11].stec_coeff[1], expected "
          "-16898, is "
       << last_msg_->stec_sat_list[11].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[11].stec_coeff[2], 28241)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[11].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[11].stec_coeff[2])),
+            28241)
       << "incorrect value for stec_sat_list[11].stec_coeff[2], expected 28241, "
          "is "
       << last_msg_->stec_sat_list[11].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[11].stec_coeff[3], 12546)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[11].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[11].stec_coeff[3])),
+            12546)
       << "incorrect value for stec_sat_list[11].stec_coeff[3], expected 12546, "
          "is "
       << last_msg_->stec_sat_list[11].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[11].stec_quality_indicator, 6)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[11].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[11].stec_quality_indicator)),
+      6)
       << "incorrect value for stec_sat_list[11].stec_quality_indicator, "
          "expected 6, is "
       << last_msg_->stec_sat_list[11].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[11].sv_id.constellation, 232)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[11].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[11].sv_id.constellation)),
+            232)
       << "incorrect value for stec_sat_list[11].sv_id.constellation, expected "
          "232, is "
       << last_msg_->stec_sat_list[11].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[11].sv_id.satId, 86)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[11].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[11].sv_id.satId)),
+            86)
       << "incorrect value for stec_sat_list[11].sv_id.satId, expected 86, is "
       << last_msg_->stec_sat_list[11].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[12].stec_coeff[0], 12855)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[12].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[12].stec_coeff[0])),
+            12855)
       << "incorrect value for stec_sat_list[12].stec_coeff[0], expected 12855, "
          "is "
       << last_msg_->stec_sat_list[12].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[12].stec_coeff[1], 1461)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[12].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[12].stec_coeff[1])),
+            1461)
       << "incorrect value for stec_sat_list[12].stec_coeff[1], expected 1461, "
          "is "
       << last_msg_->stec_sat_list[12].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[12].stec_coeff[2], 20603)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[12].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[12].stec_coeff[2])),
+            20603)
       << "incorrect value for stec_sat_list[12].stec_coeff[2], expected 20603, "
          "is "
       << last_msg_->stec_sat_list[12].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[12].stec_coeff[3], -3023)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[12].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[12].stec_coeff[3])),
+            -3023)
       << "incorrect value for stec_sat_list[12].stec_coeff[3], expected -3023, "
          "is "
       << last_msg_->stec_sat_list[12].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[12].stec_quality_indicator, 216)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[12].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[12].stec_quality_indicator)),
+      216)
       << "incorrect value for stec_sat_list[12].stec_quality_indicator, "
          "expected 216, is "
       << last_msg_->stec_sat_list[12].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[12].sv_id.constellation, 84)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[12].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[12].sv_id.constellation)),
+            84)
       << "incorrect value for stec_sat_list[12].sv_id.constellation, expected "
          "84, is "
       << last_msg_->stec_sat_list[12].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[12].sv_id.satId, 202)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[12].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[12].sv_id.satId)),
+            202)
       << "incorrect value for stec_sat_list[12].sv_id.satId, expected 202, is "
       << last_msg_->stec_sat_list[12].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[13].stec_coeff[0], -6492)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[13].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[13].stec_coeff[0])),
+            -6492)
       << "incorrect value for stec_sat_list[13].stec_coeff[0], expected -6492, "
          "is "
       << last_msg_->stec_sat_list[13].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[13].stec_coeff[1], 16952)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[13].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[13].stec_coeff[1])),
+            16952)
       << "incorrect value for stec_sat_list[13].stec_coeff[1], expected 16952, "
          "is "
       << last_msg_->stec_sat_list[13].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[13].stec_coeff[2], -22404)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[13].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[13].stec_coeff[2])),
+            -22404)
       << "incorrect value for stec_sat_list[13].stec_coeff[2], expected "
          "-22404, is "
       << last_msg_->stec_sat_list[13].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[13].stec_coeff[3], -29893)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[13].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[13].stec_coeff[3])),
+            -29893)
       << "incorrect value for stec_sat_list[13].stec_coeff[3], expected "
          "-29893, is "
       << last_msg_->stec_sat_list[13].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[13].stec_quality_indicator, 125)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[13].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[13].stec_quality_indicator)),
+      125)
       << "incorrect value for stec_sat_list[13].stec_quality_indicator, "
          "expected 125, is "
       << last_msg_->stec_sat_list[13].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[13].sv_id.constellation, 188)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[13].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[13].sv_id.constellation)),
+            188)
       << "incorrect value for stec_sat_list[13].sv_id.constellation, expected "
          "188, is "
       << last_msg_->stec_sat_list[13].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[13].sv_id.satId, 224)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[13].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[13].sv_id.satId)),
+            224)
       << "incorrect value for stec_sat_list[13].sv_id.satId, expected 224, is "
       << last_msg_->stec_sat_list[13].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[14].stec_coeff[0], -10053)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[14].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[14].stec_coeff[0])),
+            -10053)
       << "incorrect value for stec_sat_list[14].stec_coeff[0], expected "
          "-10053, is "
       << last_msg_->stec_sat_list[14].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[14].stec_coeff[1], -24897)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[14].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[14].stec_coeff[1])),
+            -24897)
       << "incorrect value for stec_sat_list[14].stec_coeff[1], expected "
          "-24897, is "
       << last_msg_->stec_sat_list[14].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[14].stec_coeff[2], 23629)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[14].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[14].stec_coeff[2])),
+            23629)
       << "incorrect value for stec_sat_list[14].stec_coeff[2], expected 23629, "
          "is "
       << last_msg_->stec_sat_list[14].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[14].stec_coeff[3], -710)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[14].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[14].stec_coeff[3])),
+            -710)
       << "incorrect value for stec_sat_list[14].stec_coeff[3], expected -710, "
          "is "
       << last_msg_->stec_sat_list[14].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[14].stec_quality_indicator, 51)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[14].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[14].stec_quality_indicator)),
+      51)
       << "incorrect value for stec_sat_list[14].stec_quality_indicator, "
          "expected 51, is "
       << last_msg_->stec_sat_list[14].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[14].sv_id.constellation, 118)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[14].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[14].sv_id.constellation)),
+            118)
       << "incorrect value for stec_sat_list[14].sv_id.constellation, expected "
          "118, is "
       << last_msg_->stec_sat_list[14].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[14].sv_id.satId, 106)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[14].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[14].sv_id.satId)),
+            106)
       << "incorrect value for stec_sat_list[14].sv_id.satId, expected 106, is "
       << last_msg_->stec_sat_list[14].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[15].stec_coeff[0], -26103)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[15].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[15].stec_coeff[0])),
+            -26103)
       << "incorrect value for stec_sat_list[15].stec_coeff[0], expected "
          "-26103, is "
       << last_msg_->stec_sat_list[15].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[15].stec_coeff[1], -9539)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[15].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[15].stec_coeff[1])),
+            -9539)
       << "incorrect value for stec_sat_list[15].stec_coeff[1], expected -9539, "
          "is "
       << last_msg_->stec_sat_list[15].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[15].stec_coeff[2], -11971)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[15].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[15].stec_coeff[2])),
+            -11971)
       << "incorrect value for stec_sat_list[15].stec_coeff[2], expected "
          "-11971, is "
       << last_msg_->stec_sat_list[15].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[15].stec_coeff[3], 20993)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[15].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[15].stec_coeff[3])),
+            20993)
       << "incorrect value for stec_sat_list[15].stec_coeff[3], expected 20993, "
          "is "
       << last_msg_->stec_sat_list[15].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[15].stec_quality_indicator, 165)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[15].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[15].stec_quality_indicator)),
+      165)
       << "incorrect value for stec_sat_list[15].stec_quality_indicator, "
          "expected 165, is "
       << last_msg_->stec_sat_list[15].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[15].sv_id.constellation, 150)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[15].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[15].sv_id.constellation)),
+            150)
       << "incorrect value for stec_sat_list[15].sv_id.constellation, expected "
          "150, is "
       << last_msg_->stec_sat_list[15].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[15].sv_id.satId, 132)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[15].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[15].sv_id.satId)),
+            132)
       << "incorrect value for stec_sat_list[15].sv_id.satId, expected 132, is "
       << last_msg_->stec_sat_list[15].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[16].stec_coeff[0], -18891)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[16].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[16].stec_coeff[0])),
+            -18891)
       << "incorrect value for stec_sat_list[16].stec_coeff[0], expected "
          "-18891, is "
       << last_msg_->stec_sat_list[16].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[16].stec_coeff[1], -16272)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[16].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[16].stec_coeff[1])),
+            -16272)
       << "incorrect value for stec_sat_list[16].stec_coeff[1], expected "
          "-16272, is "
       << last_msg_->stec_sat_list[16].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[16].stec_coeff[2], -22578)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[16].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[16].stec_coeff[2])),
+            -22578)
       << "incorrect value for stec_sat_list[16].stec_coeff[2], expected "
          "-22578, is "
       << last_msg_->stec_sat_list[16].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[16].stec_coeff[3], -2915)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[16].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[16].stec_coeff[3])),
+            -2915)
       << "incorrect value for stec_sat_list[16].stec_coeff[3], expected -2915, "
          "is "
       << last_msg_->stec_sat_list[16].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[16].stec_quality_indicator, 23)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[16].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[16].stec_quality_indicator)),
+      23)
       << "incorrect value for stec_sat_list[16].stec_quality_indicator, "
          "expected 23, is "
       << last_msg_->stec_sat_list[16].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[16].sv_id.constellation, 196)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[16].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[16].sv_id.constellation)),
+            196)
       << "incorrect value for stec_sat_list[16].sv_id.constellation, expected "
          "196, is "
       << last_msg_->stec_sat_list[16].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[16].sv_id.satId, 181)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[16].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[16].sv_id.satId)),
+            181)
       << "incorrect value for stec_sat_list[16].sv_id.satId, expected 181, is "
       << last_msg_->stec_sat_list[16].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[17].stec_coeff[0], 15833)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[17].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[17].stec_coeff[0])),
+            15833)
       << "incorrect value for stec_sat_list[17].stec_coeff[0], expected 15833, "
          "is "
       << last_msg_->stec_sat_list[17].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[17].stec_coeff[1], 24920)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[17].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[17].stec_coeff[1])),
+            24920)
       << "incorrect value for stec_sat_list[17].stec_coeff[1], expected 24920, "
          "is "
       << last_msg_->stec_sat_list[17].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[17].stec_coeff[2], -13879)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[17].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[17].stec_coeff[2])),
+            -13879)
       << "incorrect value for stec_sat_list[17].stec_coeff[2], expected "
          "-13879, is "
       << last_msg_->stec_sat_list[17].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[17].stec_coeff[3], -1206)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[17].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[17].stec_coeff[3])),
+            -1206)
       << "incorrect value for stec_sat_list[17].stec_coeff[3], expected -1206, "
          "is "
       << last_msg_->stec_sat_list[17].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[17].stec_quality_indicator, 189)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[17].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[17].stec_quality_indicator)),
+      189)
       << "incorrect value for stec_sat_list[17].stec_quality_indicator, "
          "expected 189, is "
       << last_msg_->stec_sat_list[17].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[17].sv_id.constellation, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[17].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[17].sv_id.constellation)),
+            1)
       << "incorrect value for stec_sat_list[17].sv_id.constellation, expected "
          "1, is "
       << last_msg_->stec_sat_list[17].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[17].sv_id.satId, 35)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[17].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[17].sv_id.satId)),
+            35)
       << "incorrect value for stec_sat_list[17].sv_id.satId, expected 35, is "
       << last_msg_->stec_sat_list[17].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[18].stec_coeff[0], 14008)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[18].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[18].stec_coeff[0])),
+            14008)
       << "incorrect value for stec_sat_list[18].stec_coeff[0], expected 14008, "
          "is "
       << last_msg_->stec_sat_list[18].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[18].stec_coeff[1], 18996)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[18].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[18].stec_coeff[1])),
+            18996)
       << "incorrect value for stec_sat_list[18].stec_coeff[1], expected 18996, "
          "is "
       << last_msg_->stec_sat_list[18].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[18].stec_coeff[2], 2798)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[18].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[18].stec_coeff[2])),
+            2798)
       << "incorrect value for stec_sat_list[18].stec_coeff[2], expected 2798, "
          "is "
       << last_msg_->stec_sat_list[18].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[18].stec_coeff[3], 5761)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[18].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[18].stec_coeff[3])),
+            5761)
       << "incorrect value for stec_sat_list[18].stec_coeff[3], expected 5761, "
          "is "
       << last_msg_->stec_sat_list[18].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[18].stec_quality_indicator, 104)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[18].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[18].stec_quality_indicator)),
+      104)
       << "incorrect value for stec_sat_list[18].stec_quality_indicator, "
          "expected 104, is "
       << last_msg_->stec_sat_list[18].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[18].sv_id.constellation, 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[18].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[18].sv_id.constellation)),
+            14)
       << "incorrect value for stec_sat_list[18].sv_id.constellation, expected "
          "14, is "
       << last_msg_->stec_sat_list[18].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[18].sv_id.satId, 217)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[18].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[18].sv_id.satId)),
+            217)
       << "incorrect value for stec_sat_list[18].sv_id.satId, expected 217, is "
       << last_msg_->stec_sat_list[18].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[19].stec_coeff[0], -25256)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[19].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[19].stec_coeff[0])),
+            -25256)
       << "incorrect value for stec_sat_list[19].stec_coeff[0], expected "
          "-25256, is "
       << last_msg_->stec_sat_list[19].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[19].stec_coeff[1], -15330)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[19].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[19].stec_coeff[1])),
+            -15330)
       << "incorrect value for stec_sat_list[19].stec_coeff[1], expected "
          "-15330, is "
       << last_msg_->stec_sat_list[19].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[19].stec_coeff[2], 6831)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[19].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[19].stec_coeff[2])),
+            6831)
       << "incorrect value for stec_sat_list[19].stec_coeff[2], expected 6831, "
          "is "
       << last_msg_->stec_sat_list[19].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[19].stec_coeff[3], 8780)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[19].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[19].stec_coeff[3])),
+            8780)
       << "incorrect value for stec_sat_list[19].stec_coeff[3], expected 8780, "
          "is "
       << last_msg_->stec_sat_list[19].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[19].stec_quality_indicator, 109)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[19].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[19].stec_quality_indicator)),
+      109)
       << "incorrect value for stec_sat_list[19].stec_quality_indicator, "
          "expected 109, is "
       << last_msg_->stec_sat_list[19].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[19].sv_id.constellation, 226)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[19].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[19].sv_id.constellation)),
+            226)
       << "incorrect value for stec_sat_list[19].sv_id.constellation, expected "
          "226, is "
       << last_msg_->stec_sat_list[19].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[19].sv_id.satId, 178)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[19].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[19].sv_id.satId)),
+            178)
       << "incorrect value for stec_sat_list[19].sv_id.satId, expected 178, is "
       << last_msg_->stec_sat_list[19].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[20].stec_coeff[0], 3304)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[20].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[20].stec_coeff[0])),
+            3304)
       << "incorrect value for stec_sat_list[20].stec_coeff[0], expected 3304, "
          "is "
       << last_msg_->stec_sat_list[20].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[20].stec_coeff[1], -2893)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[20].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[20].stec_coeff[1])),
+            -2893)
       << "incorrect value for stec_sat_list[20].stec_coeff[1], expected -2893, "
          "is "
       << last_msg_->stec_sat_list[20].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[20].stec_coeff[2], -25841)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[20].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[20].stec_coeff[2])),
+            -25841)
       << "incorrect value for stec_sat_list[20].stec_coeff[2], expected "
          "-25841, is "
       << last_msg_->stec_sat_list[20].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[20].stec_coeff[3], -13628)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[20].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[20].stec_coeff[3])),
+            -13628)
       << "incorrect value for stec_sat_list[20].stec_coeff[3], expected "
          "-13628, is "
       << last_msg_->stec_sat_list[20].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[20].stec_quality_indicator, 154)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[20].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[20].stec_quality_indicator)),
+      154)
       << "incorrect value for stec_sat_list[20].stec_quality_indicator, "
          "expected 154, is "
       << last_msg_->stec_sat_list[20].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[20].sv_id.constellation, 220)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[20].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[20].sv_id.constellation)),
+            220)
       << "incorrect value for stec_sat_list[20].sv_id.constellation, expected "
          "220, is "
       << last_msg_->stec_sat_list[20].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[20].sv_id.satId, 116)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[20].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[20].sv_id.satId)),
+            116)
       << "incorrect value for stec_sat_list[20].sv_id.satId, expected 116, is "
       << last_msg_->stec_sat_list[20].sv_id.satId;
-  EXPECT_EQ(last_msg_->stec_sat_list[21].stec_coeff[0], -10742)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[21].stec_coeff[0])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[21].stec_coeff[0])),
+            -10742)
       << "incorrect value for stec_sat_list[21].stec_coeff[0], expected "
          "-10742, is "
       << last_msg_->stec_sat_list[21].stec_coeff[0];
-  EXPECT_EQ(last_msg_->stec_sat_list[21].stec_coeff[1], 10098)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[21].stec_coeff[1])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[21].stec_coeff[1])),
+            10098)
       << "incorrect value for stec_sat_list[21].stec_coeff[1], expected 10098, "
          "is "
       << last_msg_->stec_sat_list[21].stec_coeff[1];
-  EXPECT_EQ(last_msg_->stec_sat_list[21].stec_coeff[2], 7413)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[21].stec_coeff[2])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[21].stec_coeff[2])),
+            7413)
       << "incorrect value for stec_sat_list[21].stec_coeff[2], expected 7413, "
          "is "
       << last_msg_->stec_sat_list[21].stec_coeff[2];
-  EXPECT_EQ(last_msg_->stec_sat_list[21].stec_coeff[3], 17645)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[21].stec_coeff[3])>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[21].stec_coeff[3])),
+            17645)
       << "incorrect value for stec_sat_list[21].stec_coeff[3], expected 17645, "
          "is "
       << last_msg_->stec_sat_list[21].stec_coeff[3];
-  EXPECT_EQ(last_msg_->stec_sat_list[21].stec_quality_indicator, 115)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->stec_sat_list[21].stec_quality_indicator)>(
+          reinterpret_cast<const uint8_t *>(
+              &last_msg_->stec_sat_list[21].stec_quality_indicator)),
+      115)
       << "incorrect value for stec_sat_list[21].stec_quality_indicator, "
          "expected 115, is "
       << last_msg_->stec_sat_list[21].stec_quality_indicator;
-  EXPECT_EQ(last_msg_->stec_sat_list[21].sv_id.constellation, 70)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[21].sv_id.constellation)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[21].sv_id.constellation)),
+            70)
       << "incorrect value for stec_sat_list[21].sv_id.constellation, expected "
          "70, is "
       << last_msg_->stec_sat_list[21].sv_id.constellation;
-  EXPECT_EQ(last_msg_->stec_sat_list[21].sv_id.satId, 72)
+  EXPECT_EQ(get_as<decltype(last_msg_->stec_sat_list[21].sv_id.satId)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->stec_sat_list[21].sv_id.satId)),
+            72)
       << "incorrect value for stec_sat_list[21].sv_id.satId, expected 72, is "
       << last_msg_->stec_sat_list[21].sv_id.satId;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrTileDefinition.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrTileDefinition.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/ssr.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_ssr_MsgSsrTileDefinition0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -127,41 +134,69 @@ TEST_F(Test_legacy_auto_check_sbp_ssr_MsgSsrTileDefinition0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 0);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->bitmask, 1234567890)
+  EXPECT_EQ(get_as<decltype(last_msg_->bitmask)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->bitmask)),
+            1234567890)
       << "incorrect value for bitmask, expected 1234567890, is "
       << last_msg_->bitmask;
-  EXPECT_EQ(last_msg_->cols, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->cols)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cols)),
+            6)
       << "incorrect value for cols, expected 6, is " << last_msg_->cols;
-  EXPECT_EQ(last_msg_->corner_nw_lat, 7354)
+  EXPECT_EQ(get_as<decltype(last_msg_->corner_nw_lat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->corner_nw_lat)),
+            7354)
       << "incorrect value for corner_nw_lat, expected 7354, is "
       << last_msg_->corner_nw_lat;
-  EXPECT_EQ(last_msg_->corner_nw_lon, -22725)
+  EXPECT_EQ(get_as<decltype(last_msg_->corner_nw_lon)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->corner_nw_lon)),
+            -22725)
       << "incorrect value for corner_nw_lon, expected -22725, is "
       << last_msg_->corner_nw_lon;
-  EXPECT_EQ(last_msg_->iod_atmo, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->iod_atmo)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->iod_atmo)),
+            3)
       << "incorrect value for iod_atmo, expected 3, is " << last_msg_->iod_atmo;
-  EXPECT_EQ(last_msg_->rows, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->rows)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rows)),
+            6)
       << "incorrect value for rows, expected 6, is " << last_msg_->rows;
-  EXPECT_EQ(last_msg_->sol_id, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->sol_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sol_id)),
+            2)
       << "incorrect value for sol_id, expected 2, is " << last_msg_->sol_id;
-  EXPECT_EQ(last_msg_->spacing_lat, 100)
+  EXPECT_EQ(get_as<decltype(last_msg_->spacing_lat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->spacing_lat)),
+            100)
       << "incorrect value for spacing_lat, expected 100, is "
       << last_msg_->spacing_lat;
-  EXPECT_EQ(last_msg_->spacing_lon, 100)
+  EXPECT_EQ(get_as<decltype(last_msg_->spacing_lon)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->spacing_lon)),
+            100)
       << "incorrect value for spacing_lon, expected 100, is "
       << last_msg_->spacing_lon;
-  EXPECT_EQ(last_msg_->tile_id, 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->tile_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tile_id)),
+            5)
       << "incorrect value for tile_id, expected 5, is " << last_msg_->tile_id;
-  EXPECT_EQ(last_msg_->tile_set_id, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->tile_set_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tile_set_id)),
+            4)
       << "incorrect value for tile_set_id, expected 4, is "
       << last_msg_->tile_set_id;
-  EXPECT_EQ(last_msg_->time.tow, 604799)
+  EXPECT_EQ(get_as<decltype(last_msg_->time.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->time.tow)),
+            604799)
       << "incorrect value for time.tow, expected 604799, is "
       << last_msg_->time.tow;
-  EXPECT_EQ(last_msg_->time.wn, 2222)
+  EXPECT_EQ(get_as<decltype(last_msg_->time.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->time.wn)),
+            2222)
       << "incorrect value for time.wn, expected 2222, is "
       << last_msg_->time.wn;
-  EXPECT_EQ(last_msg_->update_interval, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->update_interval)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->update_interval)),
+            1)
       << "incorrect value for update_interval, expected 1, is "
       << last_msg_->update_interval;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrTileDefinitionDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrTileDefinitionDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/ssr.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_ssr_MsgSsrTileDefinitionDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -121,29 +128,47 @@ TEST_F(Test_legacy_auto_check_sbp_ssr_MsgSsrTileDefinitionDepA0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 34248);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->bitmask, 11259375)
+  EXPECT_EQ(get_as<decltype(last_msg_->bitmask)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->bitmask)),
+            11259375)
       << "incorrect value for bitmask, expected 11259375, is "
       << last_msg_->bitmask;
-  EXPECT_EQ(last_msg_->cols, 48917)
+  EXPECT_EQ(get_as<decltype(last_msg_->cols)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cols)),
+            48917)
       << "incorrect value for cols, expected 48917, is " << last_msg_->cols;
-  EXPECT_EQ(last_msg_->corner_nw_lat, -18168)
+  EXPECT_EQ(get_as<decltype(last_msg_->corner_nw_lat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->corner_nw_lat)),
+            -18168)
       << "incorrect value for corner_nw_lat, expected -18168, is "
       << last_msg_->corner_nw_lat;
-  EXPECT_EQ(last_msg_->corner_nw_lon, -19191)
+  EXPECT_EQ(get_as<decltype(last_msg_->corner_nw_lon)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->corner_nw_lon)),
+            -19191)
       << "incorrect value for corner_nw_lon, expected -19191, is "
       << last_msg_->corner_nw_lon;
-  EXPECT_EQ(last_msg_->rows, 36863)
+  EXPECT_EQ(get_as<decltype(last_msg_->rows)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rows)),
+            36863)
       << "incorrect value for rows, expected 36863, is " << last_msg_->rows;
-  EXPECT_EQ(last_msg_->spacing_lat, 61602)
+  EXPECT_EQ(get_as<decltype(last_msg_->spacing_lat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->spacing_lat)),
+            61602)
       << "incorrect value for spacing_lat, expected 61602, is "
       << last_msg_->spacing_lat;
-  EXPECT_EQ(last_msg_->spacing_lon, 4929)
+  EXPECT_EQ(get_as<decltype(last_msg_->spacing_lon)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->spacing_lon)),
+            4929)
       << "incorrect value for spacing_lon, expected 4929, is "
       << last_msg_->spacing_lon;
-  EXPECT_EQ(last_msg_->tile_id, 63410)
+  EXPECT_EQ(get_as<decltype(last_msg_->tile_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tile_id)),
+            63410)
       << "incorrect value for tile_id, expected 63410, is "
       << last_msg_->tile_id;
-  EXPECT_EQ(last_msg_->tile_set_id, 48697)
+  EXPECT_EQ(get_as<decltype(last_msg_->tile_set_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tile_set_id)),
+            48697)
       << "incorrect value for tile_set_id, expected 48697, is "
       << last_msg_->tile_set_id;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrTileDefinitionDepB.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_ssr_MsgSsrTileDefinitionDepB.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/ssr.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_ssr_MsgSsrTileDefinitionDepB0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -122,31 +129,51 @@ TEST_F(Test_legacy_auto_check_sbp_ssr_MsgSsrTileDefinitionDepB0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->bitmask, 1234567890)
+  EXPECT_EQ(get_as<decltype(last_msg_->bitmask)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->bitmask)),
+            1234567890)
       << "incorrect value for bitmask, expected 1234567890, is "
       << last_msg_->bitmask;
-  EXPECT_EQ(last_msg_->cols, 32768)
+  EXPECT_EQ(get_as<decltype(last_msg_->cols)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cols)),
+            32768)
       << "incorrect value for cols, expected 32768, is " << last_msg_->cols;
-  EXPECT_EQ(last_msg_->corner_nw_lat, 1024)
+  EXPECT_EQ(get_as<decltype(last_msg_->corner_nw_lat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->corner_nw_lat)),
+            1024)
       << "incorrect value for corner_nw_lat, expected 1024, is "
       << last_msg_->corner_nw_lat;
-  EXPECT_EQ(last_msg_->corner_nw_lon, 2048)
+  EXPECT_EQ(get_as<decltype(last_msg_->corner_nw_lon)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->corner_nw_lon)),
+            2048)
       << "incorrect value for corner_nw_lon, expected 2048, is "
       << last_msg_->corner_nw_lon;
-  EXPECT_EQ(last_msg_->rows, 16384)
+  EXPECT_EQ(get_as<decltype(last_msg_->rows)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->rows)),
+            16384)
       << "incorrect value for rows, expected 16384, is " << last_msg_->rows;
-  EXPECT_EQ(last_msg_->spacing_lat, 4096)
+  EXPECT_EQ(get_as<decltype(last_msg_->spacing_lat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->spacing_lat)),
+            4096)
       << "incorrect value for spacing_lat, expected 4096, is "
       << last_msg_->spacing_lat;
-  EXPECT_EQ(last_msg_->spacing_lon, 8192)
+  EXPECT_EQ(get_as<decltype(last_msg_->spacing_lon)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->spacing_lon)),
+            8192)
       << "incorrect value for spacing_lon, expected 8192, is "
       << last_msg_->spacing_lon;
-  EXPECT_EQ(last_msg_->ssr_sol_id, 31)
+  EXPECT_EQ(get_as<decltype(last_msg_->ssr_sol_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ssr_sol_id)),
+            31)
       << "incorrect value for ssr_sol_id, expected 31, is "
       << last_msg_->ssr_sol_id;
-  EXPECT_EQ(last_msg_->tile_id, 512)
+  EXPECT_EQ(get_as<decltype(last_msg_->tile_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tile_id)),
+            512)
       << "incorrect value for tile_id, expected 512, is " << last_msg_->tile_id;
-  EXPECT_EQ(last_msg_->tile_set_id, 256)
+  EXPECT_EQ(get_as<decltype(last_msg_->tile_set_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tile_set_id)),
+            256)
       << "incorrect value for tile_set_id, expected 256, is "
       << last_msg_->tile_set_id;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_system_MsgCsacTelemetry.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_system_MsgCsacTelemetry.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/system.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_system_MsgCsacTelemetry0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -121,7 +128,9 @@ TEST_F(Test_legacy_auto_check_sbp_system_MsgCsacTelemetry0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 43508);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->id, 105)
+  EXPECT_EQ(get_as<decltype(last_msg_->id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->id)),
+            105)
       << "incorrect value for id, expected 105, is " << last_msg_->id;
   {
     const char check_string[] = {(char)115, (char)111, (char)109,

--- a/c/test/legacy/cpp/auto_check_sbp_system_MsgCsacTelemetryLabels.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_system_MsgCsacTelemetryLabels.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/system.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_system_MsgCsacTelemetryLabels0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -123,7 +130,9 @@ TEST_F(Test_legacy_auto_check_sbp_system_MsgCsacTelemetryLabels0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 51291);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->id, 186)
+  EXPECT_EQ(get_as<decltype(last_msg_->id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->id)),
+            186)
       << "incorrect value for id, expected 186, is " << last_msg_->id;
   {
     const char check_string[] = {(char)115, (char)111, (char)109, (char)101,

--- a/c/test/legacy/cpp/auto_check_sbp_system_MsgDgnssStatus.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_system_MsgDgnssStatus.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/system.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_system_MsgDgnssStatus0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -121,11 +128,17 @@ TEST_F(Test_legacy_auto_check_sbp_system_MsgDgnssStatus0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->latency, 50)
+  EXPECT_EQ(get_as<decltype(last_msg_->latency)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->latency)),
+            50)
       << "incorrect value for latency, expected 50, is " << last_msg_->latency;
-  EXPECT_EQ(last_msg_->num_signals, 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->num_signals)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->num_signals)),
+            12)
       << "incorrect value for num_signals, expected 12, is "
       << last_msg_->num_signals;
   {

--- a/c/test/legacy/cpp/auto_check_sbp_system_MsgGnssTimeOffset.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_system_MsgGnssTimeOffset.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/system.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_system_MsgGnssTimeOffset0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -114,14 +121,22 @@ TEST_F(Test_legacy_auto_check_sbp_system_MsgGnssTimeOffset0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 3862);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 221)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            221)
       << "incorrect value for flags, expected 221, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->microseconds, 9494)
+  EXPECT_EQ(get_as<decltype(last_msg_->microseconds)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->microseconds)),
+            9494)
       << "incorrect value for microseconds, expected 9494, is "
       << last_msg_->microseconds;
-  EXPECT_EQ(last_msg_->milliseconds, 1728664402)
+  EXPECT_EQ(get_as<decltype(last_msg_->milliseconds)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->milliseconds)),
+            1728664402)
       << "incorrect value for milliseconds, expected 1728664402, is "
       << last_msg_->milliseconds;
-  EXPECT_EQ(last_msg_->weeks, 14857)
+  EXPECT_EQ(get_as<decltype(last_msg_->weeks)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->weeks)),
+            14857)
       << "incorrect value for weeks, expected 14857, is " << last_msg_->weeks;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_system_MsgGroupMeta.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_system_MsgGroupMeta.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/system.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_system_MsgGroupMeta0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -128,20 +135,32 @@ TEST_F(Test_legacy_auto_check_sbp_system_MsgGroupMeta0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 61166);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            2)
       << "incorrect value for flags, expected 2, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->group_id, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->group_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->group_id)),
+            1)
       << "incorrect value for group_id, expected 1, is " << last_msg_->group_id;
-  EXPECT_EQ(last_msg_->group_msgs[0], 65290)
+  EXPECT_EQ(get_as<decltype(last_msg_->group_msgs[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->group_msgs[0])),
+            65290)
       << "incorrect value for group_msgs[0], expected 65290, is "
       << last_msg_->group_msgs[0];
-  EXPECT_EQ(last_msg_->group_msgs[1], 522)
+  EXPECT_EQ(get_as<decltype(last_msg_->group_msgs[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->group_msgs[1])),
+            522)
       << "incorrect value for group_msgs[1], expected 522, is "
       << last_msg_->group_msgs[1];
-  EXPECT_EQ(last_msg_->group_msgs[2], 65282)
+  EXPECT_EQ(get_as<decltype(last_msg_->group_msgs[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->group_msgs[2])),
+            65282)
       << "incorrect value for group_msgs[2], expected 65282, is "
       << last_msg_->group_msgs[2];
-  EXPECT_EQ(last_msg_->n_group_msgs, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_group_msgs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_group_msgs)),
+            3)
       << "incorrect value for n_group_msgs, expected 3, is "
       << last_msg_->n_group_msgs;
 }
@@ -300,53 +319,87 @@ TEST_F(Test_legacy_auto_check_sbp_system_MsgGroupMeta1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 789);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            1)
       << "incorrect value for flags, expected 1, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->group_id, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->group_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->group_id)),
+            1)
       << "incorrect value for group_id, expected 1, is " << last_msg_->group_id;
-  EXPECT_EQ(last_msg_->group_msgs[0], 258)
+  EXPECT_EQ(get_as<decltype(last_msg_->group_msgs[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->group_msgs[0])),
+            258)
       << "incorrect value for group_msgs[0], expected 258, is "
       << last_msg_->group_msgs[0];
-  EXPECT_EQ(last_msg_->group_msgs[1], 259)
+  EXPECT_EQ(get_as<decltype(last_msg_->group_msgs[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->group_msgs[1])),
+            259)
       << "incorrect value for group_msgs[1], expected 259, is "
       << last_msg_->group_msgs[1];
-  EXPECT_EQ(last_msg_->group_msgs[2], 522)
+  EXPECT_EQ(get_as<decltype(last_msg_->group_msgs[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->group_msgs[2])),
+            522)
       << "incorrect value for group_msgs[2], expected 522, is "
       << last_msg_->group_msgs[2];
-  EXPECT_EQ(last_msg_->group_msgs[3], 529)
+  EXPECT_EQ(get_as<decltype(last_msg_->group_msgs[3])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->group_msgs[3])),
+            529)
       << "incorrect value for group_msgs[3], expected 529, is "
       << last_msg_->group_msgs[3];
-  EXPECT_EQ(last_msg_->group_msgs[4], 521)
+  EXPECT_EQ(get_as<decltype(last_msg_->group_msgs[4])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->group_msgs[4])),
+            521)
       << "incorrect value for group_msgs[4], expected 521, is "
       << last_msg_->group_msgs[4];
-  EXPECT_EQ(last_msg_->group_msgs[5], 532)
+  EXPECT_EQ(get_as<decltype(last_msg_->group_msgs[5])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->group_msgs[5])),
+            532)
       << "incorrect value for group_msgs[5], expected 532, is "
       << last_msg_->group_msgs[5];
-  EXPECT_EQ(last_msg_->group_msgs[6], 526)
+  EXPECT_EQ(get_as<decltype(last_msg_->group_msgs[6])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->group_msgs[6])),
+            526)
       << "incorrect value for group_msgs[6], expected 526, is "
       << last_msg_->group_msgs[6];
-  EXPECT_EQ(last_msg_->group_msgs[7], 530)
+  EXPECT_EQ(get_as<decltype(last_msg_->group_msgs[7])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->group_msgs[7])),
+            530)
       << "incorrect value for group_msgs[7], expected 530, is "
       << last_msg_->group_msgs[7];
-  EXPECT_EQ(last_msg_->group_msgs[8], 525)
+  EXPECT_EQ(get_as<decltype(last_msg_->group_msgs[8])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->group_msgs[8])),
+            525)
       << "incorrect value for group_msgs[8], expected 525, is "
       << last_msg_->group_msgs[8];
-  EXPECT_EQ(last_msg_->group_msgs[9], 533)
+  EXPECT_EQ(get_as<decltype(last_msg_->group_msgs[9])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->group_msgs[9])),
+            533)
       << "incorrect value for group_msgs[9], expected 533, is "
       << last_msg_->group_msgs[9];
-  EXPECT_EQ(last_msg_->group_msgs[10], 545)
+  EXPECT_EQ(get_as<decltype(last_msg_->group_msgs[10])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->group_msgs[10])),
+            545)
       << "incorrect value for group_msgs[10], expected 545, is "
       << last_msg_->group_msgs[10];
-  EXPECT_EQ(last_msg_->group_msgs[11], 65283)
+  EXPECT_EQ(get_as<decltype(last_msg_->group_msgs[11])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->group_msgs[11])),
+            65283)
       << "incorrect value for group_msgs[11], expected 65283, is "
       << last_msg_->group_msgs[11];
-  EXPECT_EQ(last_msg_->group_msgs[12], 65286)
+  EXPECT_EQ(get_as<decltype(last_msg_->group_msgs[12])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->group_msgs[12])),
+            65286)
       << "incorrect value for group_msgs[12], expected 65286, is "
       << last_msg_->group_msgs[12];
-  EXPECT_EQ(last_msg_->group_msgs[13], 65294)
+  EXPECT_EQ(get_as<decltype(last_msg_->group_msgs[13])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->group_msgs[13])),
+            65294)
       << "incorrect value for group_msgs[13], expected 65294, is "
       << last_msg_->group_msgs[13];
-  EXPECT_EQ(last_msg_->n_group_msgs, 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_group_msgs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_group_msgs)),
+            14)
       << "incorrect value for n_group_msgs, expected 14, is "
       << last_msg_->n_group_msgs;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_system_MsgHeartbeat.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_system_MsgHeartbeat.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/system.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_system_MsgHeartbeat0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -111,7 +118,9 @@ TEST_F(Test_legacy_auto_check_sbp_system_MsgHeartbeat0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 55286);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 12800)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            12800)
       << "incorrect value for flags, expected 12800, is " << last_msg_->flags;
 }
 class Test_legacy_auto_check_sbp_system_MsgHeartbeat1
@@ -195,6 +204,8 @@ TEST_F(Test_legacy_auto_check_sbp_system_MsgHeartbeat1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_system_MsgInsStatus.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_system_MsgInsStatus.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/system.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_system_MsgInsStatus0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -110,7 +117,9 @@ TEST_F(Test_legacy_auto_check_sbp_system_MsgInsStatus0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 789);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 536870921)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            536870921)
       << "incorrect value for flags, expected 536870921, is "
       << last_msg_->flags;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_system_MsgInsUpdates.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_system_MsgInsUpdates.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/system.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_system_MsgInsUpdates0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -116,19 +123,33 @@ TEST_F(Test_legacy_auto_check_sbp_system_MsgInsUpdates0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 789);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->gnsspos, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->gnsspos)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->gnsspos)),
+            0)
       << "incorrect value for gnsspos, expected 0, is " << last_msg_->gnsspos;
-  EXPECT_EQ(last_msg_->gnssvel, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->gnssvel)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->gnssvel)),
+            0)
       << "incorrect value for gnssvel, expected 0, is " << last_msg_->gnssvel;
-  EXPECT_EQ(last_msg_->nhc, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->nhc)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->nhc)),
+            0)
       << "incorrect value for nhc, expected 0, is " << last_msg_->nhc;
-  EXPECT_EQ(last_msg_->speed, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->speed)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->speed)),
+            0)
       << "incorrect value for speed, expected 0, is " << last_msg_->speed;
-  EXPECT_EQ(last_msg_->tow, 504489300)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            504489300)
       << "incorrect value for tow, expected 504489300, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->wheelticks, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->wheelticks)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->wheelticks)),
+            0)
       << "incorrect value for wheelticks, expected 0, is "
       << last_msg_->wheelticks;
-  EXPECT_EQ(last_msg_->zerovel, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->zerovel)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->zerovel)),
+            0)
       << "incorrect value for zerovel, expected 0, is " << last_msg_->zerovel;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_system_MsgPpsTime.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_system_MsgPpsTime.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/system.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_system_MsgPpsTime0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -112,9 +119,13 @@ TEST_F(Test_legacy_auto_check_sbp_system_MsgPpsTime0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 53726);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 255)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            255)
       << "incorrect value for flags, expected 255, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->time, 690508632716)
+  EXPECT_EQ(get_as<decltype(last_msg_->time)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->time)),
+            690508632716)
       << "incorrect value for time, expected 690508632716, is "
       << last_msg_->time;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_system_MsgSensorAidEvent.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_system_MsgSensorAidEvent.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/system.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_system_MsgSensorAidEvent0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -120,26 +127,44 @@ TEST_F(Test_legacy_auto_check_sbp_system_MsgSensorAidEvent0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            0)
       << "incorrect value for flags, expected 0, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->n_accepted_meas, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_accepted_meas)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_accepted_meas)),
+            0)
       << "incorrect value for n_accepted_meas, expected 0, is "
       << last_msg_->n_accepted_meas;
-  EXPECT_EQ(last_msg_->n_attempted_meas, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->n_attempted_meas)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->n_attempted_meas)),
+      0)
       << "incorrect value for n_attempted_meas, expected 0, is "
       << last_msg_->n_attempted_meas;
-  EXPECT_EQ(last_msg_->n_available_meas, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->n_available_meas)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->n_available_meas)),
+      0)
       << "incorrect value for n_available_meas, expected 0, is "
       << last_msg_->n_available_meas;
-  EXPECT_EQ(last_msg_->sensor_id, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sensor_id)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sensor_id)),
+            0)
       << "incorrect value for sensor_id, expected 0, is "
       << last_msg_->sensor_id;
-  EXPECT_EQ(last_msg_->sensor_state, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sensor_state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sensor_state)),
+            0)
       << "incorrect value for sensor_state, expected 0, is "
       << last_msg_->sensor_state;
-  EXPECT_EQ(last_msg_->sensor_type, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sensor_type)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sensor_type)),
+            0)
       << "incorrect value for sensor_type, expected 0, is "
       << last_msg_->sensor_type;
-  EXPECT_EQ(last_msg_->time, 326825520)
+  EXPECT_EQ(get_as<decltype(last_msg_->time)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->time)),
+            326825520)
       << "incorrect value for time, expected 326825520, is " << last_msg_->time;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_system_MsgStartup.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_system_MsgStartup.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/system.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_system_MsgStartup0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -112,11 +119,17 @@ TEST_F(Test_legacy_auto_check_sbp_system_MsgStartup0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->cause, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->cause)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cause)),
+            0)
       << "incorrect value for cause, expected 0, is " << last_msg_->cause;
-  EXPECT_EQ(last_msg_->reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved)),
+            0)
       << "incorrect value for reserved, expected 0, is " << last_msg_->reserved;
-  EXPECT_EQ(last_msg_->startup_type, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->startup_type)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->startup_type)),
+            0)
       << "incorrect value for startup_type, expected 0, is "
       << last_msg_->startup_type;
 }
@@ -203,11 +216,17 @@ TEST_F(Test_legacy_auto_check_sbp_system_MsgStartup1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 1219);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->cause, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->cause)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cause)),
+            0)
       << "incorrect value for cause, expected 0, is " << last_msg_->cause;
-  EXPECT_EQ(last_msg_->reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->reserved)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->reserved)),
+            0)
       << "incorrect value for reserved, expected 0, is " << last_msg_->reserved;
-  EXPECT_EQ(last_msg_->startup_type, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->startup_type)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->startup_type)),
+            0)
       << "incorrect value for startup_type, expected 0, is "
       << last_msg_->startup_type;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_system_MsgStatusJournal.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_system_MsgStatusJournal.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/system.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_system_MsgStatusJournal0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -140,52 +147,99 @@ TEST_F(Test_legacy_auto_check_sbp_system_MsgStatusJournal0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->journal[0].report.component, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->journal[0].report.component)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->journal[0].report.component)),
+            6)
       << "incorrect value for journal[0].report.component, expected 6, is "
       << last_msg_->journal[0].report.component;
-  EXPECT_EQ(last_msg_->journal[0].report.generic, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->journal[0].report.generic)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->journal[0].report.generic)),
+            1)
       << "incorrect value for journal[0].report.generic, expected 1, is "
       << last_msg_->journal[0].report.generic;
-  EXPECT_EQ(last_msg_->journal[0].report.specific, 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->journal[0].report.specific)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->journal[0].report.specific)),
+            13)
       << "incorrect value for journal[0].report.specific, expected 13, is "
       << last_msg_->journal[0].report.specific;
-  EXPECT_EQ(last_msg_->journal[0].uptime, 4242)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->journal[0].uptime)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->journal[0].uptime)),
+      4242)
       << "incorrect value for journal[0].uptime, expected 4242, is "
       << last_msg_->journal[0].uptime;
-  EXPECT_EQ(last_msg_->journal[1].report.component, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->journal[1].report.component)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->journal[1].report.component)),
+            6)
       << "incorrect value for journal[1].report.component, expected 6, is "
       << last_msg_->journal[1].report.component;
-  EXPECT_EQ(last_msg_->journal[1].report.generic, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->journal[1].report.generic)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->journal[1].report.generic)),
+            1)
       << "incorrect value for journal[1].report.generic, expected 1, is "
       << last_msg_->journal[1].report.generic;
-  EXPECT_EQ(last_msg_->journal[1].report.specific, 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->journal[1].report.specific)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->journal[1].report.specific)),
+            14)
       << "incorrect value for journal[1].report.specific, expected 14, is "
       << last_msg_->journal[1].report.specific;
-  EXPECT_EQ(last_msg_->journal[1].uptime, 5050)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->journal[1].uptime)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->journal[1].uptime)),
+      5050)
       << "incorrect value for journal[1].uptime, expected 5050, is "
       << last_msg_->journal[1].uptime;
-  EXPECT_EQ(last_msg_->journal[2].report.component, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->journal[2].report.component)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->journal[2].report.component)),
+            6)
       << "incorrect value for journal[2].report.component, expected 6, is "
       << last_msg_->journal[2].report.component;
-  EXPECT_EQ(last_msg_->journal[2].report.generic, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->journal[2].report.generic)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->journal[2].report.generic)),
+            1)
       << "incorrect value for journal[2].report.generic, expected 1, is "
       << last_msg_->journal[2].report.generic;
-  EXPECT_EQ(last_msg_->journal[2].report.specific, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->journal[2].report.specific)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->journal[2].report.specific)),
+            15)
       << "incorrect value for journal[2].report.specific, expected 15, is "
       << last_msg_->journal[2].report.specific;
-  EXPECT_EQ(last_msg_->journal[2].uptime, 8888)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->journal[2].uptime)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->journal[2].uptime)),
+      8888)
       << "incorrect value for journal[2].uptime, expected 8888, is "
       << last_msg_->journal[2].uptime;
-  EXPECT_EQ(last_msg_->reporting_system, 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->reporting_system)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->reporting_system)),
+      1)
       << "incorrect value for reporting_system, expected 1, is "
       << last_msg_->reporting_system;
-  EXPECT_EQ(last_msg_->sbp_version, 1025)
+  EXPECT_EQ(get_as<decltype(last_msg_->sbp_version)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sbp_version)),
+            1025)
       << "incorrect value for sbp_version, expected 1025, is "
       << last_msg_->sbp_version;
-  EXPECT_EQ(last_msg_->sequence_descriptor, 16)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sequence_descriptor)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sequence_descriptor)),
+      16)
       << "incorrect value for sequence_descriptor, expected 16, is "
       << last_msg_->sequence_descriptor;
-  EXPECT_EQ(last_msg_->total_status_reports, 100)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->total_status_reports)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->total_status_reports)),
+      100)
       << "incorrect value for total_status_reports, expected 100, is "
       << last_msg_->total_status_reports;
 }
@@ -283,28 +337,51 @@ TEST_F(Test_legacy_auto_check_sbp_system_MsgStatusJournal1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 35027);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->journal[0].report.component, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->journal[0].report.component)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->journal[0].report.component)),
+            6)
       << "incorrect value for journal[0].report.component, expected 6, is "
       << last_msg_->journal[0].report.component;
-  EXPECT_EQ(last_msg_->journal[0].report.generic, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->journal[0].report.generic)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->journal[0].report.generic)),
+            1)
       << "incorrect value for journal[0].report.generic, expected 1, is "
       << last_msg_->journal[0].report.generic;
-  EXPECT_EQ(last_msg_->journal[0].report.specific, 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->journal[0].report.specific)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->journal[0].report.specific)),
+            13)
       << "incorrect value for journal[0].report.specific, expected 13, is "
       << last_msg_->journal[0].report.specific;
-  EXPECT_EQ(last_msg_->journal[0].uptime, 4242)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->journal[0].uptime)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->journal[0].uptime)),
+      4242)
       << "incorrect value for journal[0].uptime, expected 4242, is "
       << last_msg_->journal[0].uptime;
-  EXPECT_EQ(last_msg_->reporting_system, 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->reporting_system)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->reporting_system)),
+      1)
       << "incorrect value for reporting_system, expected 1, is "
       << last_msg_->reporting_system;
-  EXPECT_EQ(last_msg_->sbp_version, 1025)
+  EXPECT_EQ(get_as<decltype(last_msg_->sbp_version)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sbp_version)),
+            1025)
       << "incorrect value for sbp_version, expected 1025, is "
       << last_msg_->sbp_version;
-  EXPECT_EQ(last_msg_->sequence_descriptor, 16)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sequence_descriptor)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sequence_descriptor)),
+      16)
       << "incorrect value for sequence_descriptor, expected 16, is "
       << last_msg_->sequence_descriptor;
-  EXPECT_EQ(last_msg_->total_status_reports, 100)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->total_status_reports)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->total_status_reports)),
+      100)
       << "incorrect value for total_status_reports, expected 100, is "
       << last_msg_->total_status_reports;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_system_MsgStatusReport.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_system_MsgStatusReport.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/system.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_system_MsgStatusReport0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -551,556 +558,1105 @@ TEST_F(Test_legacy_auto_check_sbp_system_MsgStatusReport0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 21510);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->reporting_system, 64850)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->reporting_system)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->reporting_system)),
+      64850)
       << "incorrect value for reporting_system, expected 64850, is "
       << last_msg_->reporting_system;
-  EXPECT_EQ(last_msg_->sbp_version, 24497)
+  EXPECT_EQ(get_as<decltype(last_msg_->sbp_version)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sbp_version)),
+            24497)
       << "incorrect value for sbp_version, expected 24497, is "
       << last_msg_->sbp_version;
-  EXPECT_EQ(last_msg_->sequence, 1519336451)
+  EXPECT_EQ(get_as<decltype(last_msg_->sequence)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sequence)),
+            1519336451)
       << "incorrect value for sequence, expected 1519336451, is "
       << last_msg_->sequence;
-  EXPECT_EQ(last_msg_->status[0].component, 52215)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[0].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[0].component)),
+      52215)
       << "incorrect value for status[0].component, expected 52215, is "
       << last_msg_->status[0].component;
-  EXPECT_EQ(last_msg_->status[0].generic, 221)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[0].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[0].generic)),
+      221)
       << "incorrect value for status[0].generic, expected 221, is "
       << last_msg_->status[0].generic;
-  EXPECT_EQ(last_msg_->status[0].specific, 198)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[0].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[0].specific)),
+      198)
       << "incorrect value for status[0].specific, expected 198, is "
       << last_msg_->status[0].specific;
-  EXPECT_EQ(last_msg_->status[1].component, 53148)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[1].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[1].component)),
+      53148)
       << "incorrect value for status[1].component, expected 53148, is "
       << last_msg_->status[1].component;
-  EXPECT_EQ(last_msg_->status[1].generic, 217)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[1].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[1].generic)),
+      217)
       << "incorrect value for status[1].generic, expected 217, is "
       << last_msg_->status[1].generic;
-  EXPECT_EQ(last_msg_->status[1].specific, 238)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[1].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[1].specific)),
+      238)
       << "incorrect value for status[1].specific, expected 238, is "
       << last_msg_->status[1].specific;
-  EXPECT_EQ(last_msg_->status[2].component, 34978)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[2].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[2].component)),
+      34978)
       << "incorrect value for status[2].component, expected 34978, is "
       << last_msg_->status[2].component;
-  EXPECT_EQ(last_msg_->status[2].generic, 154)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[2].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[2].generic)),
+      154)
       << "incorrect value for status[2].generic, expected 154, is "
       << last_msg_->status[2].generic;
-  EXPECT_EQ(last_msg_->status[2].specific, 11)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[2].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[2].specific)),
+      11)
       << "incorrect value for status[2].specific, expected 11, is "
       << last_msg_->status[2].specific;
-  EXPECT_EQ(last_msg_->status[3].component, 60530)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[3].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[3].component)),
+      60530)
       << "incorrect value for status[3].component, expected 60530, is "
       << last_msg_->status[3].component;
-  EXPECT_EQ(last_msg_->status[3].generic, 134)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[3].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[3].generic)),
+      134)
       << "incorrect value for status[3].generic, expected 134, is "
       << last_msg_->status[3].generic;
-  EXPECT_EQ(last_msg_->status[3].specific, 235)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[3].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[3].specific)),
+      235)
       << "incorrect value for status[3].specific, expected 235, is "
       << last_msg_->status[3].specific;
-  EXPECT_EQ(last_msg_->status[4].component, 34060)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[4].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[4].component)),
+      34060)
       << "incorrect value for status[4].component, expected 34060, is "
       << last_msg_->status[4].component;
-  EXPECT_EQ(last_msg_->status[4].generic, 9)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[4].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[4].generic)),
+      9)
       << "incorrect value for status[4].generic, expected 9, is "
       << last_msg_->status[4].generic;
-  EXPECT_EQ(last_msg_->status[4].specific, 30)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[4].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[4].specific)),
+      30)
       << "incorrect value for status[4].specific, expected 30, is "
       << last_msg_->status[4].specific;
-  EXPECT_EQ(last_msg_->status[5].component, 37295)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[5].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[5].component)),
+      37295)
       << "incorrect value for status[5].component, expected 37295, is "
       << last_msg_->status[5].component;
-  EXPECT_EQ(last_msg_->status[5].generic, 26)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[5].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[5].generic)),
+      26)
       << "incorrect value for status[5].generic, expected 26, is "
       << last_msg_->status[5].generic;
-  EXPECT_EQ(last_msg_->status[5].specific, 114)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[5].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[5].specific)),
+      114)
       << "incorrect value for status[5].specific, expected 114, is "
       << last_msg_->status[5].specific;
-  EXPECT_EQ(last_msg_->status[6].component, 5335)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[6].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[6].component)),
+      5335)
       << "incorrect value for status[6].component, expected 5335, is "
       << last_msg_->status[6].component;
-  EXPECT_EQ(last_msg_->status[6].generic, 146)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[6].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[6].generic)),
+      146)
       << "incorrect value for status[6].generic, expected 146, is "
       << last_msg_->status[6].generic;
-  EXPECT_EQ(last_msg_->status[6].specific, 249)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[6].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[6].specific)),
+      249)
       << "incorrect value for status[6].specific, expected 249, is "
       << last_msg_->status[6].specific;
-  EXPECT_EQ(last_msg_->status[7].component, 13878)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[7].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[7].component)),
+      13878)
       << "incorrect value for status[7].component, expected 13878, is "
       << last_msg_->status[7].component;
-  EXPECT_EQ(last_msg_->status[7].generic, 133)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[7].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[7].generic)),
+      133)
       << "incorrect value for status[7].generic, expected 133, is "
       << last_msg_->status[7].generic;
-  EXPECT_EQ(last_msg_->status[7].specific, 193)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[7].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[7].specific)),
+      193)
       << "incorrect value for status[7].specific, expected 193, is "
       << last_msg_->status[7].specific;
-  EXPECT_EQ(last_msg_->status[8].component, 47722)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[8].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[8].component)),
+      47722)
       << "incorrect value for status[8].component, expected 47722, is "
       << last_msg_->status[8].component;
-  EXPECT_EQ(last_msg_->status[8].generic, 210)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[8].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[8].generic)),
+      210)
       << "incorrect value for status[8].generic, expected 210, is "
       << last_msg_->status[8].generic;
-  EXPECT_EQ(last_msg_->status[8].specific, 183)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[8].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[8].specific)),
+      183)
       << "incorrect value for status[8].specific, expected 183, is "
       << last_msg_->status[8].specific;
-  EXPECT_EQ(last_msg_->status[9].component, 33024)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[9].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[9].component)),
+      33024)
       << "incorrect value for status[9].component, expected 33024, is "
       << last_msg_->status[9].component;
-  EXPECT_EQ(last_msg_->status[9].generic, 5)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[9].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[9].generic)),
+      5)
       << "incorrect value for status[9].generic, expected 5, is "
       << last_msg_->status[9].generic;
-  EXPECT_EQ(last_msg_->status[9].specific, 248)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[9].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[9].specific)),
+      248)
       << "incorrect value for status[9].specific, expected 248, is "
       << last_msg_->status[9].specific;
-  EXPECT_EQ(last_msg_->status[10].component, 38369)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[10].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[10].component)),
+      38369)
       << "incorrect value for status[10].component, expected 38369, is "
       << last_msg_->status[10].component;
-  EXPECT_EQ(last_msg_->status[10].generic, 135)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[10].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[10].generic)),
+      135)
       << "incorrect value for status[10].generic, expected 135, is "
       << last_msg_->status[10].generic;
-  EXPECT_EQ(last_msg_->status[10].specific, 127)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[10].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[10].specific)),
+      127)
       << "incorrect value for status[10].specific, expected 127, is "
       << last_msg_->status[10].specific;
-  EXPECT_EQ(last_msg_->status[11].component, 6658)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[11].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[11].component)),
+      6658)
       << "incorrect value for status[11].component, expected 6658, is "
       << last_msg_->status[11].component;
-  EXPECT_EQ(last_msg_->status[11].generic, 88)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[11].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[11].generic)),
+      88)
       << "incorrect value for status[11].generic, expected 88, is "
       << last_msg_->status[11].generic;
-  EXPECT_EQ(last_msg_->status[11].specific, 92)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[11].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[11].specific)),
+      92)
       << "incorrect value for status[11].specific, expected 92, is "
       << last_msg_->status[11].specific;
-  EXPECT_EQ(last_msg_->status[12].component, 26378)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[12].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[12].component)),
+      26378)
       << "incorrect value for status[12].component, expected 26378, is "
       << last_msg_->status[12].component;
-  EXPECT_EQ(last_msg_->status[12].generic, 73)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[12].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[12].generic)),
+      73)
       << "incorrect value for status[12].generic, expected 73, is "
       << last_msg_->status[12].generic;
-  EXPECT_EQ(last_msg_->status[12].specific, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[12].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[12].specific)),
+      3)
       << "incorrect value for status[12].specific, expected 3, is "
       << last_msg_->status[12].specific;
-  EXPECT_EQ(last_msg_->status[13].component, 17511)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[13].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[13].component)),
+      17511)
       << "incorrect value for status[13].component, expected 17511, is "
       << last_msg_->status[13].component;
-  EXPECT_EQ(last_msg_->status[13].generic, 76)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[13].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[13].generic)),
+      76)
       << "incorrect value for status[13].generic, expected 76, is "
       << last_msg_->status[13].generic;
-  EXPECT_EQ(last_msg_->status[13].specific, 184)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[13].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[13].specific)),
+      184)
       << "incorrect value for status[13].specific, expected 184, is "
       << last_msg_->status[13].specific;
-  EXPECT_EQ(last_msg_->status[14].component, 52769)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[14].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[14].component)),
+      52769)
       << "incorrect value for status[14].component, expected 52769, is "
       << last_msg_->status[14].component;
-  EXPECT_EQ(last_msg_->status[14].generic, 194)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[14].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[14].generic)),
+      194)
       << "incorrect value for status[14].generic, expected 194, is "
       << last_msg_->status[14].generic;
-  EXPECT_EQ(last_msg_->status[14].specific, 163)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[14].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[14].specific)),
+      163)
       << "incorrect value for status[14].specific, expected 163, is "
       << last_msg_->status[14].specific;
-  EXPECT_EQ(last_msg_->status[15].component, 7803)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[15].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[15].component)),
+      7803)
       << "incorrect value for status[15].component, expected 7803, is "
       << last_msg_->status[15].component;
-  EXPECT_EQ(last_msg_->status[15].generic, 151)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[15].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[15].generic)),
+      151)
       << "incorrect value for status[15].generic, expected 151, is "
       << last_msg_->status[15].generic;
-  EXPECT_EQ(last_msg_->status[15].specific, 176)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[15].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[15].specific)),
+      176)
       << "incorrect value for status[15].specific, expected 176, is "
       << last_msg_->status[15].specific;
-  EXPECT_EQ(last_msg_->status[16].component, 44181)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[16].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[16].component)),
+      44181)
       << "incorrect value for status[16].component, expected 44181, is "
       << last_msg_->status[16].component;
-  EXPECT_EQ(last_msg_->status[16].generic, 184)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[16].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[16].generic)),
+      184)
       << "incorrect value for status[16].generic, expected 184, is "
       << last_msg_->status[16].generic;
-  EXPECT_EQ(last_msg_->status[16].specific, 231)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[16].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[16].specific)),
+      231)
       << "incorrect value for status[16].specific, expected 231, is "
       << last_msg_->status[16].specific;
-  EXPECT_EQ(last_msg_->status[17].component, 58998)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[17].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[17].component)),
+      58998)
       << "incorrect value for status[17].component, expected 58998, is "
       << last_msg_->status[17].component;
-  EXPECT_EQ(last_msg_->status[17].generic, 200)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[17].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[17].generic)),
+      200)
       << "incorrect value for status[17].generic, expected 200, is "
       << last_msg_->status[17].generic;
-  EXPECT_EQ(last_msg_->status[17].specific, 168)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[17].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[17].specific)),
+      168)
       << "incorrect value for status[17].specific, expected 168, is "
       << last_msg_->status[17].specific;
-  EXPECT_EQ(last_msg_->status[18].component, 28004)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[18].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[18].component)),
+      28004)
       << "incorrect value for status[18].component, expected 28004, is "
       << last_msg_->status[18].component;
-  EXPECT_EQ(last_msg_->status[18].generic, 10)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[18].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[18].generic)),
+      10)
       << "incorrect value for status[18].generic, expected 10, is "
       << last_msg_->status[18].generic;
-  EXPECT_EQ(last_msg_->status[18].specific, 233)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[18].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[18].specific)),
+      233)
       << "incorrect value for status[18].specific, expected 233, is "
       << last_msg_->status[18].specific;
-  EXPECT_EQ(last_msg_->status[19].component, 15364)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[19].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[19].component)),
+      15364)
       << "incorrect value for status[19].component, expected 15364, is "
       << last_msg_->status[19].component;
-  EXPECT_EQ(last_msg_->status[19].generic, 247)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[19].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[19].generic)),
+      247)
       << "incorrect value for status[19].generic, expected 247, is "
       << last_msg_->status[19].generic;
-  EXPECT_EQ(last_msg_->status[19].specific, 82)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[19].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[19].specific)),
+      82)
       << "incorrect value for status[19].specific, expected 82, is "
       << last_msg_->status[19].specific;
-  EXPECT_EQ(last_msg_->status[20].component, 42711)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[20].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[20].component)),
+      42711)
       << "incorrect value for status[20].component, expected 42711, is "
       << last_msg_->status[20].component;
-  EXPECT_EQ(last_msg_->status[20].generic, 28)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[20].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[20].generic)),
+      28)
       << "incorrect value for status[20].generic, expected 28, is "
       << last_msg_->status[20].generic;
-  EXPECT_EQ(last_msg_->status[20].specific, 138)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[20].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[20].specific)),
+      138)
       << "incorrect value for status[20].specific, expected 138, is "
       << last_msg_->status[20].specific;
-  EXPECT_EQ(last_msg_->status[21].component, 11630)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[21].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[21].component)),
+      11630)
       << "incorrect value for status[21].component, expected 11630, is "
       << last_msg_->status[21].component;
-  EXPECT_EQ(last_msg_->status[21].generic, 98)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[21].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[21].generic)),
+      98)
       << "incorrect value for status[21].generic, expected 98, is "
       << last_msg_->status[21].generic;
-  EXPECT_EQ(last_msg_->status[21].specific, 218)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[21].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[21].specific)),
+      218)
       << "incorrect value for status[21].specific, expected 218, is "
       << last_msg_->status[21].specific;
-  EXPECT_EQ(last_msg_->status[22].component, 46068)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[22].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[22].component)),
+      46068)
       << "incorrect value for status[22].component, expected 46068, is "
       << last_msg_->status[22].component;
-  EXPECT_EQ(last_msg_->status[22].generic, 126)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[22].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[22].generic)),
+      126)
       << "incorrect value for status[22].generic, expected 126, is "
       << last_msg_->status[22].generic;
-  EXPECT_EQ(last_msg_->status[22].specific, 107)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[22].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[22].specific)),
+      107)
       << "incorrect value for status[22].specific, expected 107, is "
       << last_msg_->status[22].specific;
-  EXPECT_EQ(last_msg_->status[23].component, 31836)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[23].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[23].component)),
+      31836)
       << "incorrect value for status[23].component, expected 31836, is "
       << last_msg_->status[23].component;
-  EXPECT_EQ(last_msg_->status[23].generic, 94)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[23].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[23].generic)),
+      94)
       << "incorrect value for status[23].generic, expected 94, is "
       << last_msg_->status[23].generic;
-  EXPECT_EQ(last_msg_->status[23].specific, 157)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[23].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[23].specific)),
+      157)
       << "incorrect value for status[23].specific, expected 157, is "
       << last_msg_->status[23].specific;
-  EXPECT_EQ(last_msg_->status[24].component, 47914)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[24].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[24].component)),
+      47914)
       << "incorrect value for status[24].component, expected 47914, is "
       << last_msg_->status[24].component;
-  EXPECT_EQ(last_msg_->status[24].generic, 124)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[24].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[24].generic)),
+      124)
       << "incorrect value for status[24].generic, expected 124, is "
       << last_msg_->status[24].generic;
-  EXPECT_EQ(last_msg_->status[24].specific, 6)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[24].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[24].specific)),
+      6)
       << "incorrect value for status[24].specific, expected 6, is "
       << last_msg_->status[24].specific;
-  EXPECT_EQ(last_msg_->status[25].component, 63329)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[25].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[25].component)),
+      63329)
       << "incorrect value for status[25].component, expected 63329, is "
       << last_msg_->status[25].component;
-  EXPECT_EQ(last_msg_->status[25].generic, 160)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[25].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[25].generic)),
+      160)
       << "incorrect value for status[25].generic, expected 160, is "
       << last_msg_->status[25].generic;
-  EXPECT_EQ(last_msg_->status[25].specific, 188)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[25].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[25].specific)),
+      188)
       << "incorrect value for status[25].specific, expected 188, is "
       << last_msg_->status[25].specific;
-  EXPECT_EQ(last_msg_->status[26].component, 30830)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[26].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[26].component)),
+      30830)
       << "incorrect value for status[26].component, expected 30830, is "
       << last_msg_->status[26].component;
-  EXPECT_EQ(last_msg_->status[26].generic, 254)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[26].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[26].generic)),
+      254)
       << "incorrect value for status[26].generic, expected 254, is "
       << last_msg_->status[26].generic;
-  EXPECT_EQ(last_msg_->status[26].specific, 214)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[26].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[26].specific)),
+      214)
       << "incorrect value for status[26].specific, expected 214, is "
       << last_msg_->status[26].specific;
-  EXPECT_EQ(last_msg_->status[27].component, 13166)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[27].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[27].component)),
+      13166)
       << "incorrect value for status[27].component, expected 13166, is "
       << last_msg_->status[27].component;
-  EXPECT_EQ(last_msg_->status[27].generic, 240)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[27].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[27].generic)),
+      240)
       << "incorrect value for status[27].generic, expected 240, is "
       << last_msg_->status[27].generic;
-  EXPECT_EQ(last_msg_->status[27].specific, 164)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[27].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[27].specific)),
+      164)
       << "incorrect value for status[27].specific, expected 164, is "
       << last_msg_->status[27].specific;
-  EXPECT_EQ(last_msg_->status[28].component, 4755)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[28].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[28].component)),
+      4755)
       << "incorrect value for status[28].component, expected 4755, is "
       << last_msg_->status[28].component;
-  EXPECT_EQ(last_msg_->status[28].generic, 74)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[28].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[28].generic)),
+      74)
       << "incorrect value for status[28].generic, expected 74, is "
       << last_msg_->status[28].generic;
-  EXPECT_EQ(last_msg_->status[28].specific, 178)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[28].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[28].specific)),
+      178)
       << "incorrect value for status[28].specific, expected 178, is "
       << last_msg_->status[28].specific;
-  EXPECT_EQ(last_msg_->status[29].component, 1091)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[29].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[29].component)),
+      1091)
       << "incorrect value for status[29].component, expected 1091, is "
       << last_msg_->status[29].component;
-  EXPECT_EQ(last_msg_->status[29].generic, 27)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[29].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[29].generic)),
+      27)
       << "incorrect value for status[29].generic, expected 27, is "
       << last_msg_->status[29].generic;
-  EXPECT_EQ(last_msg_->status[29].specific, 73)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[29].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[29].specific)),
+      73)
       << "incorrect value for status[29].specific, expected 73, is "
       << last_msg_->status[29].specific;
-  EXPECT_EQ(last_msg_->status[30].component, 16574)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[30].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[30].component)),
+      16574)
       << "incorrect value for status[30].component, expected 16574, is "
       << last_msg_->status[30].component;
-  EXPECT_EQ(last_msg_->status[30].generic, 179)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[30].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[30].generic)),
+      179)
       << "incorrect value for status[30].generic, expected 179, is "
       << last_msg_->status[30].generic;
-  EXPECT_EQ(last_msg_->status[30].specific, 146)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[30].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[30].specific)),
+      146)
       << "incorrect value for status[30].specific, expected 146, is "
       << last_msg_->status[30].specific;
-  EXPECT_EQ(last_msg_->status[31].component, 39293)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[31].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[31].component)),
+      39293)
       << "incorrect value for status[31].component, expected 39293, is "
       << last_msg_->status[31].component;
-  EXPECT_EQ(last_msg_->status[31].generic, 192)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[31].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[31].generic)),
+      192)
       << "incorrect value for status[31].generic, expected 192, is "
       << last_msg_->status[31].generic;
-  EXPECT_EQ(last_msg_->status[31].specific, 46)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[31].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[31].specific)),
+      46)
       << "incorrect value for status[31].specific, expected 46, is "
       << last_msg_->status[31].specific;
-  EXPECT_EQ(last_msg_->status[32].component, 17098)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[32].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[32].component)),
+      17098)
       << "incorrect value for status[32].component, expected 17098, is "
       << last_msg_->status[32].component;
-  EXPECT_EQ(last_msg_->status[32].generic, 248)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[32].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[32].generic)),
+      248)
       << "incorrect value for status[32].generic, expected 248, is "
       << last_msg_->status[32].generic;
-  EXPECT_EQ(last_msg_->status[32].specific, 46)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[32].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[32].specific)),
+      46)
       << "incorrect value for status[32].specific, expected 46, is "
       << last_msg_->status[32].specific;
-  EXPECT_EQ(last_msg_->status[33].component, 41256)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[33].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[33].component)),
+      41256)
       << "incorrect value for status[33].component, expected 41256, is "
       << last_msg_->status[33].component;
-  EXPECT_EQ(last_msg_->status[33].generic, 173)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[33].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[33].generic)),
+      173)
       << "incorrect value for status[33].generic, expected 173, is "
       << last_msg_->status[33].generic;
-  EXPECT_EQ(last_msg_->status[33].specific, 242)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[33].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[33].specific)),
+      242)
       << "incorrect value for status[33].specific, expected 242, is "
       << last_msg_->status[33].specific;
-  EXPECT_EQ(last_msg_->status[34].component, 982)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[34].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[34].component)),
+      982)
       << "incorrect value for status[34].component, expected 982, is "
       << last_msg_->status[34].component;
-  EXPECT_EQ(last_msg_->status[34].generic, 11)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[34].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[34].generic)),
+      11)
       << "incorrect value for status[34].generic, expected 11, is "
       << last_msg_->status[34].generic;
-  EXPECT_EQ(last_msg_->status[34].specific, 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[34].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[34].specific)),
+      1)
       << "incorrect value for status[34].specific, expected 1, is "
       << last_msg_->status[34].specific;
-  EXPECT_EQ(last_msg_->status[35].component, 18038)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[35].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[35].component)),
+      18038)
       << "incorrect value for status[35].component, expected 18038, is "
       << last_msg_->status[35].component;
-  EXPECT_EQ(last_msg_->status[35].generic, 162)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[35].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[35].generic)),
+      162)
       << "incorrect value for status[35].generic, expected 162, is "
       << last_msg_->status[35].generic;
-  EXPECT_EQ(last_msg_->status[35].specific, 61)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[35].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[35].specific)),
+      61)
       << "incorrect value for status[35].specific, expected 61, is "
       << last_msg_->status[35].specific;
-  EXPECT_EQ(last_msg_->status[36].component, 7090)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[36].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[36].component)),
+      7090)
       << "incorrect value for status[36].component, expected 7090, is "
       << last_msg_->status[36].component;
-  EXPECT_EQ(last_msg_->status[36].generic, 156)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[36].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[36].generic)),
+      156)
       << "incorrect value for status[36].generic, expected 156, is "
       << last_msg_->status[36].generic;
-  EXPECT_EQ(last_msg_->status[36].specific, 40)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[36].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[36].specific)),
+      40)
       << "incorrect value for status[36].specific, expected 40, is "
       << last_msg_->status[36].specific;
-  EXPECT_EQ(last_msg_->status[37].component, 29119)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[37].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[37].component)),
+      29119)
       << "incorrect value for status[37].component, expected 29119, is "
       << last_msg_->status[37].component;
-  EXPECT_EQ(last_msg_->status[37].generic, 230)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[37].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[37].generic)),
+      230)
       << "incorrect value for status[37].generic, expected 230, is "
       << last_msg_->status[37].generic;
-  EXPECT_EQ(last_msg_->status[37].specific, 200)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[37].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[37].specific)),
+      200)
       << "incorrect value for status[37].specific, expected 200, is "
       << last_msg_->status[37].specific;
-  EXPECT_EQ(last_msg_->status[38].component, 2120)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[38].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[38].component)),
+      2120)
       << "incorrect value for status[38].component, expected 2120, is "
       << last_msg_->status[38].component;
-  EXPECT_EQ(last_msg_->status[38].generic, 215)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[38].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[38].generic)),
+      215)
       << "incorrect value for status[38].generic, expected 215, is "
       << last_msg_->status[38].generic;
-  EXPECT_EQ(last_msg_->status[38].specific, 245)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[38].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[38].specific)),
+      245)
       << "incorrect value for status[38].specific, expected 245, is "
       << last_msg_->status[38].specific;
-  EXPECT_EQ(last_msg_->status[39].component, 15182)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[39].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[39].component)),
+      15182)
       << "incorrect value for status[39].component, expected 15182, is "
       << last_msg_->status[39].component;
-  EXPECT_EQ(last_msg_->status[39].generic, 222)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[39].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[39].generic)),
+      222)
       << "incorrect value for status[39].generic, expected 222, is "
       << last_msg_->status[39].generic;
-  EXPECT_EQ(last_msg_->status[39].specific, 250)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[39].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[39].specific)),
+      250)
       << "incorrect value for status[39].specific, expected 250, is "
       << last_msg_->status[39].specific;
-  EXPECT_EQ(last_msg_->status[40].component, 8307)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[40].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[40].component)),
+      8307)
       << "incorrect value for status[40].component, expected 8307, is "
       << last_msg_->status[40].component;
-  EXPECT_EQ(last_msg_->status[40].generic, 33)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[40].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[40].generic)),
+      33)
       << "incorrect value for status[40].generic, expected 33, is "
       << last_msg_->status[40].generic;
-  EXPECT_EQ(last_msg_->status[40].specific, 30)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[40].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[40].specific)),
+      30)
       << "incorrect value for status[40].specific, expected 30, is "
       << last_msg_->status[40].specific;
-  EXPECT_EQ(last_msg_->status[41].component, 43731)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[41].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[41].component)),
+      43731)
       << "incorrect value for status[41].component, expected 43731, is "
       << last_msg_->status[41].component;
-  EXPECT_EQ(last_msg_->status[41].generic, 145)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[41].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[41].generic)),
+      145)
       << "incorrect value for status[41].generic, expected 145, is "
       << last_msg_->status[41].generic;
-  EXPECT_EQ(last_msg_->status[41].specific, 92)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[41].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[41].specific)),
+      92)
       << "incorrect value for status[41].specific, expected 92, is "
       << last_msg_->status[41].specific;
-  EXPECT_EQ(last_msg_->status[42].component, 19357)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[42].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[42].component)),
+      19357)
       << "incorrect value for status[42].component, expected 19357, is "
       << last_msg_->status[42].component;
-  EXPECT_EQ(last_msg_->status[42].generic, 24)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[42].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[42].generic)),
+      24)
       << "incorrect value for status[42].generic, expected 24, is "
       << last_msg_->status[42].generic;
-  EXPECT_EQ(last_msg_->status[42].specific, 169)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[42].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[42].specific)),
+      169)
       << "incorrect value for status[42].specific, expected 169, is "
       << last_msg_->status[42].specific;
-  EXPECT_EQ(last_msg_->status[43].component, 14086)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[43].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[43].component)),
+      14086)
       << "incorrect value for status[43].component, expected 14086, is "
       << last_msg_->status[43].component;
-  EXPECT_EQ(last_msg_->status[43].generic, 62)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[43].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[43].generic)),
+      62)
       << "incorrect value for status[43].generic, expected 62, is "
       << last_msg_->status[43].generic;
-  EXPECT_EQ(last_msg_->status[43].specific, 8)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[43].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[43].specific)),
+      8)
       << "incorrect value for status[43].specific, expected 8, is "
       << last_msg_->status[43].specific;
-  EXPECT_EQ(last_msg_->status[44].component, 21099)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[44].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[44].component)),
+      21099)
       << "incorrect value for status[44].component, expected 21099, is "
       << last_msg_->status[44].component;
-  EXPECT_EQ(last_msg_->status[44].generic, 140)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[44].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[44].generic)),
+      140)
       << "incorrect value for status[44].generic, expected 140, is "
       << last_msg_->status[44].generic;
-  EXPECT_EQ(last_msg_->status[44].specific, 49)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[44].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[44].specific)),
+      49)
       << "incorrect value for status[44].specific, expected 49, is "
       << last_msg_->status[44].specific;
-  EXPECT_EQ(last_msg_->status[45].component, 31411)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[45].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[45].component)),
+      31411)
       << "incorrect value for status[45].component, expected 31411, is "
       << last_msg_->status[45].component;
-  EXPECT_EQ(last_msg_->status[45].generic, 90)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[45].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[45].generic)),
+      90)
       << "incorrect value for status[45].generic, expected 90, is "
       << last_msg_->status[45].generic;
-  EXPECT_EQ(last_msg_->status[45].specific, 71)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[45].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[45].specific)),
+      71)
       << "incorrect value for status[45].specific, expected 71, is "
       << last_msg_->status[45].specific;
-  EXPECT_EQ(last_msg_->status[46].component, 22556)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[46].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[46].component)),
+      22556)
       << "incorrect value for status[46].component, expected 22556, is "
       << last_msg_->status[46].component;
-  EXPECT_EQ(last_msg_->status[46].generic, 103)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[46].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[46].generic)),
+      103)
       << "incorrect value for status[46].generic, expected 103, is "
       << last_msg_->status[46].generic;
-  EXPECT_EQ(last_msg_->status[46].specific, 51)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[46].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[46].specific)),
+      51)
       << "incorrect value for status[46].specific, expected 51, is "
       << last_msg_->status[46].specific;
-  EXPECT_EQ(last_msg_->status[47].component, 18609)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[47].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[47].component)),
+      18609)
       << "incorrect value for status[47].component, expected 18609, is "
       << last_msg_->status[47].component;
-  EXPECT_EQ(last_msg_->status[47].generic, 93)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[47].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[47].generic)),
+      93)
       << "incorrect value for status[47].generic, expected 93, is "
       << last_msg_->status[47].generic;
-  EXPECT_EQ(last_msg_->status[47].specific, 39)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[47].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[47].specific)),
+      39)
       << "incorrect value for status[47].specific, expected 39, is "
       << last_msg_->status[47].specific;
-  EXPECT_EQ(last_msg_->status[48].component, 2964)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[48].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[48].component)),
+      2964)
       << "incorrect value for status[48].component, expected 2964, is "
       << last_msg_->status[48].component;
-  EXPECT_EQ(last_msg_->status[48].generic, 202)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[48].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[48].generic)),
+      202)
       << "incorrect value for status[48].generic, expected 202, is "
       << last_msg_->status[48].generic;
-  EXPECT_EQ(last_msg_->status[48].specific, 42)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[48].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[48].specific)),
+      42)
       << "incorrect value for status[48].specific, expected 42, is "
       << last_msg_->status[48].specific;
-  EXPECT_EQ(last_msg_->status[49].component, 23586)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[49].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[49].component)),
+      23586)
       << "incorrect value for status[49].component, expected 23586, is "
       << last_msg_->status[49].component;
-  EXPECT_EQ(last_msg_->status[49].generic, 204)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[49].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[49].generic)),
+      204)
       << "incorrect value for status[49].generic, expected 204, is "
       << last_msg_->status[49].generic;
-  EXPECT_EQ(last_msg_->status[49].specific, 102)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[49].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[49].specific)),
+      102)
       << "incorrect value for status[49].specific, expected 102, is "
       << last_msg_->status[49].specific;
-  EXPECT_EQ(last_msg_->status[50].component, 25117)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[50].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[50].component)),
+      25117)
       << "incorrect value for status[50].component, expected 25117, is "
       << last_msg_->status[50].component;
-  EXPECT_EQ(last_msg_->status[50].generic, 249)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[50].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[50].generic)),
+      249)
       << "incorrect value for status[50].generic, expected 249, is "
       << last_msg_->status[50].generic;
-  EXPECT_EQ(last_msg_->status[50].specific, 91)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[50].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[50].specific)),
+      91)
       << "incorrect value for status[50].specific, expected 91, is "
       << last_msg_->status[50].specific;
-  EXPECT_EQ(last_msg_->status[51].component, 24454)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[51].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[51].component)),
+      24454)
       << "incorrect value for status[51].component, expected 24454, is "
       << last_msg_->status[51].component;
-  EXPECT_EQ(last_msg_->status[51].generic, 23)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[51].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[51].generic)),
+      23)
       << "incorrect value for status[51].generic, expected 23, is "
       << last_msg_->status[51].generic;
-  EXPECT_EQ(last_msg_->status[51].specific, 248)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[51].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[51].specific)),
+      248)
       << "incorrect value for status[51].specific, expected 248, is "
       << last_msg_->status[51].specific;
-  EXPECT_EQ(last_msg_->status[52].component, 5312)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[52].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[52].component)),
+      5312)
       << "incorrect value for status[52].component, expected 5312, is "
       << last_msg_->status[52].component;
-  EXPECT_EQ(last_msg_->status[52].generic, 83)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[52].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[52].generic)),
+      83)
       << "incorrect value for status[52].generic, expected 83, is "
       << last_msg_->status[52].generic;
-  EXPECT_EQ(last_msg_->status[52].specific, 195)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[52].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[52].specific)),
+      195)
       << "incorrect value for status[52].specific, expected 195, is "
       << last_msg_->status[52].specific;
-  EXPECT_EQ(last_msg_->status[53].component, 46175)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[53].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[53].component)),
+      46175)
       << "incorrect value for status[53].component, expected 46175, is "
       << last_msg_->status[53].component;
-  EXPECT_EQ(last_msg_->status[53].generic, 54)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[53].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[53].generic)),
+      54)
       << "incorrect value for status[53].generic, expected 54, is "
       << last_msg_->status[53].generic;
-  EXPECT_EQ(last_msg_->status[53].specific, 36)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[53].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[53].specific)),
+      36)
       << "incorrect value for status[53].specific, expected 36, is "
       << last_msg_->status[53].specific;
-  EXPECT_EQ(last_msg_->status[54].component, 19386)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[54].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[54].component)),
+      19386)
       << "incorrect value for status[54].component, expected 19386, is "
       << last_msg_->status[54].component;
-  EXPECT_EQ(last_msg_->status[54].generic, 64)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[54].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[54].generic)),
+      64)
       << "incorrect value for status[54].generic, expected 64, is "
       << last_msg_->status[54].generic;
-  EXPECT_EQ(last_msg_->status[54].specific, 20)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[54].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[54].specific)),
+      20)
       << "incorrect value for status[54].specific, expected 20, is "
       << last_msg_->status[54].specific;
-  EXPECT_EQ(last_msg_->status[55].component, 34205)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[55].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[55].component)),
+      34205)
       << "incorrect value for status[55].component, expected 34205, is "
       << last_msg_->status[55].component;
-  EXPECT_EQ(last_msg_->status[55].generic, 12)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[55].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[55].generic)),
+      12)
       << "incorrect value for status[55].generic, expected 12, is "
       << last_msg_->status[55].generic;
-  EXPECT_EQ(last_msg_->status[55].specific, 149)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[55].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[55].specific)),
+      149)
       << "incorrect value for status[55].specific, expected 149, is "
       << last_msg_->status[55].specific;
-  EXPECT_EQ(last_msg_->status[56].component, 3612)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[56].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[56].component)),
+      3612)
       << "incorrect value for status[56].component, expected 3612, is "
       << last_msg_->status[56].component;
-  EXPECT_EQ(last_msg_->status[56].generic, 185)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[56].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[56].generic)),
+      185)
       << "incorrect value for status[56].generic, expected 185, is "
       << last_msg_->status[56].generic;
-  EXPECT_EQ(last_msg_->status[56].specific, 129)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[56].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[56].specific)),
+      129)
       << "incorrect value for status[56].specific, expected 129, is "
       << last_msg_->status[56].specific;
-  EXPECT_EQ(last_msg_->status[57].component, 61285)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[57].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[57].component)),
+      61285)
       << "incorrect value for status[57].component, expected 61285, is "
       << last_msg_->status[57].component;
-  EXPECT_EQ(last_msg_->status[57].generic, 74)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[57].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[57].generic)),
+      74)
       << "incorrect value for status[57].generic, expected 74, is "
       << last_msg_->status[57].generic;
-  EXPECT_EQ(last_msg_->status[57].specific, 248)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[57].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[57].specific)),
+      248)
       << "incorrect value for status[57].specific, expected 248, is "
       << last_msg_->status[57].specific;
-  EXPECT_EQ(last_msg_->status[58].component, 7925)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[58].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[58].component)),
+      7925)
       << "incorrect value for status[58].component, expected 7925, is "
       << last_msg_->status[58].component;
-  EXPECT_EQ(last_msg_->status[58].generic, 228)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[58].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[58].generic)),
+      228)
       << "incorrect value for status[58].generic, expected 228, is "
       << last_msg_->status[58].generic;
-  EXPECT_EQ(last_msg_->status[58].specific, 88)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[58].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[58].specific)),
+      88)
       << "incorrect value for status[58].specific, expected 88, is "
       << last_msg_->status[58].specific;
-  EXPECT_EQ(last_msg_->status[59].component, 54414)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[59].component)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[59].component)),
+      54414)
       << "incorrect value for status[59].component, expected 54414, is "
       << last_msg_->status[59].component;
-  EXPECT_EQ(last_msg_->status[59].generic, 53)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[59].generic)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[59].generic)),
+      53)
       << "incorrect value for status[59].generic, expected 53, is "
       << last_msg_->status[59].generic;
-  EXPECT_EQ(last_msg_->status[59].specific, 224)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->status[59].specific)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->status[59].specific)),
+      224)
       << "incorrect value for status[59].specific, expected 224, is "
       << last_msg_->status[59].specific;
-  EXPECT_EQ(last_msg_->uptime, 1657804265)
+  EXPECT_EQ(get_as<decltype(last_msg_->uptime)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->uptime)),
+            1657804265)
       << "incorrect value for uptime, expected 1657804265, is "
       << last_msg_->uptime;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_telemetry_MsgTelSv.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_telemetry_MsgTelSv.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/telemetry.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_telemetry_MsgTelSv0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -128,43 +135,79 @@ TEST_F(Test_legacy_auto_check_sbp_telemetry_MsgTelSv0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 9876);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->n_obs, 16)
+  EXPECT_EQ(get_as<decltype(last_msg_->n_obs)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->n_obs)),
+            16)
       << "incorrect value for n_obs, expected 16, is " << last_msg_->n_obs;
-  EXPECT_EQ(last_msg_->origin_flags, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->origin_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->origin_flags)),
+            1)
       << "incorrect value for origin_flags, expected 1, is "
       << last_msg_->origin_flags;
-  EXPECT_EQ(last_msg_->sv_tel[0].availability_flags, 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->sv_tel[0].availability_flags)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sv_tel[0].availability_flags)),
+            5)
       << "incorrect value for sv_tel[0].availability_flags, expected 5, is "
       << last_msg_->sv_tel[0].availability_flags;
-  EXPECT_EQ(last_msg_->sv_tel[0].az, 40)
+  EXPECT_EQ(get_as<decltype(last_msg_->sv_tel[0].az)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sv_tel[0].az)),
+            40)
       << "incorrect value for sv_tel[0].az, expected 40, is "
       << last_msg_->sv_tel[0].az;
-  EXPECT_EQ(last_msg_->sv_tel[0].correction_flags, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->sv_tel[0].correction_flags)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sv_tel[0].correction_flags)),
+            1)
       << "incorrect value for sv_tel[0].correction_flags, expected 1, is "
       << last_msg_->sv_tel[0].correction_flags;
-  EXPECT_EQ(last_msg_->sv_tel[0].el, 50)
+  EXPECT_EQ(get_as<decltype(last_msg_->sv_tel[0].el)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sv_tel[0].el)),
+            50)
       << "incorrect value for sv_tel[0].el, expected 50, is "
       << last_msg_->sv_tel[0].el;
-  EXPECT_EQ(last_msg_->sv_tel[0].ephemeris_flags, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->sv_tel[0].ephemeris_flags)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sv_tel[0].ephemeris_flags)),
+            1)
       << "incorrect value for sv_tel[0].ephemeris_flags, expected 1, is "
       << last_msg_->sv_tel[0].ephemeris_flags;
-  EXPECT_EQ(last_msg_->sv_tel[0].outlier_flags, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->sv_tel[0].outlier_flags)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sv_tel[0].outlier_flags)),
+            1)
       << "incorrect value for sv_tel[0].outlier_flags, expected 1, is "
       << last_msg_->sv_tel[0].outlier_flags;
-  EXPECT_EQ(last_msg_->sv_tel[0].phase_residual, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->sv_tel[0].phase_residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sv_tel[0].phase_residual)),
+            1)
       << "incorrect value for sv_tel[0].phase_residual, expected 1, is "
       << last_msg_->sv_tel[0].phase_residual;
-  EXPECT_EQ(last_msg_->sv_tel[0].pseudorange_residual, -30)
+  EXPECT_EQ(get_as<decltype(last_msg_->sv_tel[0].pseudorange_residual)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->sv_tel[0].pseudorange_residual)),
+            -30)
       << "incorrect value for sv_tel[0].pseudorange_residual, expected -30, is "
       << last_msg_->sv_tel[0].pseudorange_residual;
-  EXPECT_EQ(last_msg_->sv_tel[0].sid.code, 12)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sv_tel[0].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sv_tel[0].sid.code)),
+      12)
       << "incorrect value for sv_tel[0].sid.code, expected 12, is "
       << last_msg_->sv_tel[0].sid.code;
-  EXPECT_EQ(last_msg_->sv_tel[0].sid.sat, 33)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->sv_tel[0].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->sv_tel[0].sid.sat)),
+      33)
       << "incorrect value for sv_tel[0].sid.sat, expected 33, is "
       << last_msg_->sv_tel[0].sid.sat;
-  EXPECT_EQ(last_msg_->tow, 406773200)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            406773200)
       << "incorrect value for tow, expected 406773200, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->wn, 2223)
+  EXPECT_EQ(get_as<decltype(last_msg_->wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->wn)),
+            2223)
       << "incorrect value for wn, expected 2223, is " << last_msg_->wn;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_tracking_MsgMeasurementState.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_tracking_MsgMeasurementState.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/tracking.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_tracking_MsgMeasurementState0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -680,715 +687,1347 @@ TEST_F(Test_legacy_auto_check_sbp_tracking_MsgMeasurementState0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 31183);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->states[0].cn0, 162)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[0].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[0].cn0)),
+            162)
       << "incorrect value for states[0].cn0, expected 162, is "
       << last_msg_->states[0].cn0;
-  EXPECT_EQ(last_msg_->states[0].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[0].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[0].mesid.code)),
+      0)
       << "incorrect value for states[0].mesid.code, expected 0, is "
       << last_msg_->states[0].mesid.code;
-  EXPECT_EQ(last_msg_->states[0].mesid.sat, 29)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[0].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[0].mesid.sat)),
+      29)
       << "incorrect value for states[0].mesid.sat, expected 29, is "
       << last_msg_->states[0].mesid.sat;
-  EXPECT_EQ(last_msg_->states[1].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[1].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[1].cn0)),
+            0)
       << "incorrect value for states[1].cn0, expected 0, is "
       << last_msg_->states[1].cn0;
-  EXPECT_EQ(last_msg_->states[1].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[1].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[1].mesid.code)),
+      0)
       << "incorrect value for states[1].mesid.code, expected 0, is "
       << last_msg_->states[1].mesid.code;
-  EXPECT_EQ(last_msg_->states[1].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[1].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[1].mesid.sat)),
+      0)
       << "incorrect value for states[1].mesid.sat, expected 0, is "
       << last_msg_->states[1].mesid.sat;
-  EXPECT_EQ(last_msg_->states[2].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[2].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[2].cn0)),
+            0)
       << "incorrect value for states[2].cn0, expected 0, is "
       << last_msg_->states[2].cn0;
-  EXPECT_EQ(last_msg_->states[2].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[2].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[2].mesid.code)),
+      0)
       << "incorrect value for states[2].mesid.code, expected 0, is "
       << last_msg_->states[2].mesid.code;
-  EXPECT_EQ(last_msg_->states[2].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[2].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[2].mesid.sat)),
+      0)
       << "incorrect value for states[2].mesid.sat, expected 0, is "
       << last_msg_->states[2].mesid.sat;
-  EXPECT_EQ(last_msg_->states[3].cn0, 201)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[3].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[3].cn0)),
+            201)
       << "incorrect value for states[3].cn0, expected 201, is "
       << last_msg_->states[3].cn0;
-  EXPECT_EQ(last_msg_->states[3].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[3].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[3].mesid.code)),
+      0)
       << "incorrect value for states[3].mesid.code, expected 0, is "
       << last_msg_->states[3].mesid.code;
-  EXPECT_EQ(last_msg_->states[3].mesid.sat, 27)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[3].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[3].mesid.sat)),
+      27)
       << "incorrect value for states[3].mesid.sat, expected 27, is "
       << last_msg_->states[3].mesid.sat;
-  EXPECT_EQ(last_msg_->states[4].cn0, 168)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[4].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[4].cn0)),
+            168)
       << "incorrect value for states[4].cn0, expected 168, is "
       << last_msg_->states[4].cn0;
-  EXPECT_EQ(last_msg_->states[4].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[4].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[4].mesid.code)),
+      0)
       << "incorrect value for states[4].mesid.code, expected 0, is "
       << last_msg_->states[4].mesid.code;
-  EXPECT_EQ(last_msg_->states[4].mesid.sat, 20)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[4].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[4].mesid.sat)),
+      20)
       << "incorrect value for states[4].mesid.sat, expected 20, is "
       << last_msg_->states[4].mesid.sat;
-  EXPECT_EQ(last_msg_->states[5].cn0, 184)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[5].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[5].cn0)),
+            184)
       << "incorrect value for states[5].cn0, expected 184, is "
       << last_msg_->states[5].cn0;
-  EXPECT_EQ(last_msg_->states[5].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[5].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[5].mesid.code)),
+      0)
       << "incorrect value for states[5].mesid.code, expected 0, is "
       << last_msg_->states[5].mesid.code;
-  EXPECT_EQ(last_msg_->states[5].mesid.sat, 32)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[5].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[5].mesid.sat)),
+      32)
       << "incorrect value for states[5].mesid.sat, expected 32, is "
       << last_msg_->states[5].mesid.sat;
-  EXPECT_EQ(last_msg_->states[6].cn0, 187)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[6].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[6].cn0)),
+            187)
       << "incorrect value for states[6].cn0, expected 187, is "
       << last_msg_->states[6].cn0;
-  EXPECT_EQ(last_msg_->states[6].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[6].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[6].mesid.code)),
+      0)
       << "incorrect value for states[6].mesid.code, expected 0, is "
       << last_msg_->states[6].mesid.code;
-  EXPECT_EQ(last_msg_->states[6].mesid.sat, 15)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[6].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[6].mesid.sat)),
+      15)
       << "incorrect value for states[6].mesid.sat, expected 15, is "
       << last_msg_->states[6].mesid.sat;
-  EXPECT_EQ(last_msg_->states[7].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[7].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[7].cn0)),
+            0)
       << "incorrect value for states[7].cn0, expected 0, is "
       << last_msg_->states[7].cn0;
-  EXPECT_EQ(last_msg_->states[7].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[7].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[7].mesid.code)),
+      0)
       << "incorrect value for states[7].mesid.code, expected 0, is "
       << last_msg_->states[7].mesid.code;
-  EXPECT_EQ(last_msg_->states[7].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[7].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[7].mesid.sat)),
+      0)
       << "incorrect value for states[7].mesid.sat, expected 0, is "
       << last_msg_->states[7].mesid.sat;
-  EXPECT_EQ(last_msg_->states[8].cn0, 210)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[8].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[8].cn0)),
+            210)
       << "incorrect value for states[8].cn0, expected 210, is "
       << last_msg_->states[8].cn0;
-  EXPECT_EQ(last_msg_->states[8].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[8].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[8].mesid.code)),
+      0)
       << "incorrect value for states[8].mesid.code, expected 0, is "
       << last_msg_->states[8].mesid.code;
-  EXPECT_EQ(last_msg_->states[8].mesid.sat, 18)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[8].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[8].mesid.sat)),
+      18)
       << "incorrect value for states[8].mesid.sat, expected 18, is "
       << last_msg_->states[8].mesid.sat;
-  EXPECT_EQ(last_msg_->states[9].cn0, 167)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[9].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[9].cn0)),
+            167)
       << "incorrect value for states[9].cn0, expected 167, is "
       << last_msg_->states[9].cn0;
-  EXPECT_EQ(last_msg_->states[9].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[9].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[9].mesid.code)),
+      0)
       << "incorrect value for states[9].mesid.code, expected 0, is "
       << last_msg_->states[9].mesid.code;
-  EXPECT_EQ(last_msg_->states[9].mesid.sat, 16)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[9].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[9].mesid.sat)),
+      16)
       << "incorrect value for states[9].mesid.sat, expected 16, is "
       << last_msg_->states[9].mesid.sat;
-  EXPECT_EQ(last_msg_->states[10].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[10].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[10].cn0)),
+            0)
       << "incorrect value for states[10].cn0, expected 0, is "
       << last_msg_->states[10].cn0;
-  EXPECT_EQ(last_msg_->states[10].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[10].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[10].mesid.code)),
+      0)
       << "incorrect value for states[10].mesid.code, expected 0, is "
       << last_msg_->states[10].mesid.code;
-  EXPECT_EQ(last_msg_->states[10].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[10].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[10].mesid.sat)),
+      0)
       << "incorrect value for states[10].mesid.sat, expected 0, is "
       << last_msg_->states[10].mesid.sat;
-  EXPECT_EQ(last_msg_->states[11].cn0, 213)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[11].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[11].cn0)),
+            213)
       << "incorrect value for states[11].cn0, expected 213, is "
       << last_msg_->states[11].cn0;
-  EXPECT_EQ(last_msg_->states[11].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[11].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[11].mesid.code)),
+      0)
       << "incorrect value for states[11].mesid.code, expected 0, is "
       << last_msg_->states[11].mesid.code;
-  EXPECT_EQ(last_msg_->states[11].mesid.sat, 23)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[11].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[11].mesid.sat)),
+      23)
       << "incorrect value for states[11].mesid.sat, expected 23, is "
       << last_msg_->states[11].mesid.sat;
-  EXPECT_EQ(last_msg_->states[12].cn0, 223)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[12].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[12].cn0)),
+            223)
       << "incorrect value for states[12].cn0, expected 223, is "
       << last_msg_->states[12].cn0;
-  EXPECT_EQ(last_msg_->states[12].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[12].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[12].mesid.code)),
+      0)
       << "incorrect value for states[12].mesid.code, expected 0, is "
       << last_msg_->states[12].mesid.code;
-  EXPECT_EQ(last_msg_->states[12].mesid.sat, 10)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[12].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[12].mesid.sat)),
+      10)
       << "incorrect value for states[12].mesid.sat, expected 10, is "
       << last_msg_->states[12].mesid.sat;
-  EXPECT_EQ(last_msg_->states[13].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[13].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[13].cn0)),
+            0)
       << "incorrect value for states[13].cn0, expected 0, is "
       << last_msg_->states[13].cn0;
-  EXPECT_EQ(last_msg_->states[13].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[13].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[13].mesid.code)),
+      0)
       << "incorrect value for states[13].mesid.code, expected 0, is "
       << last_msg_->states[13].mesid.code;
-  EXPECT_EQ(last_msg_->states[13].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[13].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[13].mesid.sat)),
+      0)
       << "incorrect value for states[13].mesid.sat, expected 0, is "
       << last_msg_->states[13].mesid.sat;
-  EXPECT_EQ(last_msg_->states[14].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[14].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[14].cn0)),
+            0)
       << "incorrect value for states[14].cn0, expected 0, is "
       << last_msg_->states[14].cn0;
-  EXPECT_EQ(last_msg_->states[14].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[14].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[14].mesid.code)),
+      0)
       << "incorrect value for states[14].mesid.code, expected 0, is "
       << last_msg_->states[14].mesid.code;
-  EXPECT_EQ(last_msg_->states[14].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[14].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[14].mesid.sat)),
+      0)
       << "incorrect value for states[14].mesid.sat, expected 0, is "
       << last_msg_->states[14].mesid.sat;
-  EXPECT_EQ(last_msg_->states[15].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[15].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[15].cn0)),
+            0)
       << "incorrect value for states[15].cn0, expected 0, is "
       << last_msg_->states[15].cn0;
-  EXPECT_EQ(last_msg_->states[15].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[15].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[15].mesid.code)),
+      0)
       << "incorrect value for states[15].mesid.code, expected 0, is "
       << last_msg_->states[15].mesid.code;
-  EXPECT_EQ(last_msg_->states[15].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[15].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[15].mesid.sat)),
+      0)
       << "incorrect value for states[15].mesid.sat, expected 0, is "
       << last_msg_->states[15].mesid.sat;
-  EXPECT_EQ(last_msg_->states[16].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[16].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[16].cn0)),
+            0)
       << "incorrect value for states[16].cn0, expected 0, is "
       << last_msg_->states[16].cn0;
-  EXPECT_EQ(last_msg_->states[16].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[16].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[16].mesid.code)),
+      0)
       << "incorrect value for states[16].mesid.code, expected 0, is "
       << last_msg_->states[16].mesid.code;
-  EXPECT_EQ(last_msg_->states[16].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[16].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[16].mesid.sat)),
+      0)
       << "incorrect value for states[16].mesid.sat, expected 0, is "
       << last_msg_->states[16].mesid.sat;
-  EXPECT_EQ(last_msg_->states[17].cn0, 202)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[17].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[17].cn0)),
+            202)
       << "incorrect value for states[17].cn0, expected 202, is "
       << last_msg_->states[17].cn0;
-  EXPECT_EQ(last_msg_->states[17].mesid.code, 2)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[17].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[17].mesid.code)),
+      2)
       << "incorrect value for states[17].mesid.code, expected 2, is "
       << last_msg_->states[17].mesid.code;
-  EXPECT_EQ(last_msg_->states[17].mesid.sat, 131)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[17].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[17].mesid.sat)),
+      131)
       << "incorrect value for states[17].mesid.sat, expected 131, is "
       << last_msg_->states[17].mesid.sat;
-  EXPECT_EQ(last_msg_->states[18].cn0, 192)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[18].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[18].cn0)),
+            192)
       << "incorrect value for states[18].cn0, expected 192, is "
       << last_msg_->states[18].cn0;
-  EXPECT_EQ(last_msg_->states[18].mesid.code, 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[18].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[18].mesid.code)),
+      1)
       << "incorrect value for states[18].mesid.code, expected 1, is "
       << last_msg_->states[18].mesid.code;
-  EXPECT_EQ(last_msg_->states[18].mesid.sat, 27)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[18].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[18].mesid.sat)),
+      27)
       << "incorrect value for states[18].mesid.sat, expected 27, is "
       << last_msg_->states[18].mesid.sat;
-  EXPECT_EQ(last_msg_->states[19].cn0, 165)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[19].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[19].cn0)),
+            165)
       << "incorrect value for states[19].cn0, expected 165, is "
       << last_msg_->states[19].cn0;
-  EXPECT_EQ(last_msg_->states[19].mesid.code, 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[19].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[19].mesid.code)),
+      1)
       << "incorrect value for states[19].mesid.code, expected 1, is "
       << last_msg_->states[19].mesid.code;
-  EXPECT_EQ(last_msg_->states[19].mesid.sat, 15)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[19].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[19].mesid.sat)),
+      15)
       << "incorrect value for states[19].mesid.sat, expected 15, is "
       << last_msg_->states[19].mesid.sat;
-  EXPECT_EQ(last_msg_->states[20].cn0, 146)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[20].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[20].cn0)),
+            146)
       << "incorrect value for states[20].cn0, expected 146, is "
       << last_msg_->states[20].cn0;
-  EXPECT_EQ(last_msg_->states[20].mesid.code, 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[20].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[20].mesid.code)),
+      1)
       << "incorrect value for states[20].mesid.code, expected 1, is "
       << last_msg_->states[20].mesid.code;
-  EXPECT_EQ(last_msg_->states[20].mesid.sat, 29)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[20].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[20].mesid.sat)),
+      29)
       << "incorrect value for states[20].mesid.sat, expected 29, is "
       << last_msg_->states[20].mesid.sat;
-  EXPECT_EQ(last_msg_->states[21].cn0, 170)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[21].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[21].cn0)),
+            170)
       << "incorrect value for states[21].cn0, expected 170, is "
       << last_msg_->states[21].cn0;
-  EXPECT_EQ(last_msg_->states[21].mesid.code, 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[21].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[21].mesid.code)),
+      1)
       << "incorrect value for states[21].mesid.code, expected 1, is "
       << last_msg_->states[21].mesid.code;
-  EXPECT_EQ(last_msg_->states[21].mesid.sat, 32)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[21].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[21].mesid.sat)),
+      32)
       << "incorrect value for states[21].mesid.sat, expected 32, is "
       << last_msg_->states[21].mesid.sat;
-  EXPECT_EQ(last_msg_->states[22].cn0, 201)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[22].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[22].cn0)),
+            201)
       << "incorrect value for states[22].cn0, expected 201, is "
       << last_msg_->states[22].cn0;
-  EXPECT_EQ(last_msg_->states[22].mesid.code, 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[22].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[22].mesid.code)),
+      1)
       << "incorrect value for states[22].mesid.code, expected 1, is "
       << last_msg_->states[22].mesid.code;
-  EXPECT_EQ(last_msg_->states[22].mesid.sat, 18)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[22].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[22].mesid.sat)),
+      18)
       << "incorrect value for states[22].mesid.sat, expected 18, is "
       << last_msg_->states[22].mesid.sat;
-  EXPECT_EQ(last_msg_->states[23].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[23].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[23].cn0)),
+            0)
       << "incorrect value for states[23].cn0, expected 0, is "
       << last_msg_->states[23].cn0;
-  EXPECT_EQ(last_msg_->states[23].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[23].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[23].mesid.code)),
+      0)
       << "incorrect value for states[23].mesid.code, expected 0, is "
       << last_msg_->states[23].mesid.code;
-  EXPECT_EQ(last_msg_->states[23].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[23].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[23].mesid.sat)),
+      0)
       << "incorrect value for states[23].mesid.sat, expected 0, is "
       << last_msg_->states[23].mesid.sat;
-  EXPECT_EQ(last_msg_->states[24].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[24].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[24].cn0)),
+            0)
       << "incorrect value for states[24].cn0, expected 0, is "
       << last_msg_->states[24].cn0;
-  EXPECT_EQ(last_msg_->states[24].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[24].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[24].mesid.code)),
+      0)
       << "incorrect value for states[24].mesid.code, expected 0, is "
       << last_msg_->states[24].mesid.code;
-  EXPECT_EQ(last_msg_->states[24].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[24].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[24].mesid.sat)),
+      0)
       << "incorrect value for states[24].mesid.sat, expected 0, is "
       << last_msg_->states[24].mesid.sat;
-  EXPECT_EQ(last_msg_->states[25].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[25].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[25].cn0)),
+            0)
       << "incorrect value for states[25].cn0, expected 0, is "
       << last_msg_->states[25].cn0;
-  EXPECT_EQ(last_msg_->states[25].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[25].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[25].mesid.code)),
+      0)
       << "incorrect value for states[25].mesid.code, expected 0, is "
       << last_msg_->states[25].mesid.code;
-  EXPECT_EQ(last_msg_->states[25].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[25].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[25].mesid.sat)),
+      0)
       << "incorrect value for states[25].mesid.sat, expected 0, is "
       << last_msg_->states[25].mesid.sat;
-  EXPECT_EQ(last_msg_->states[26].cn0, 212)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[26].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[26].cn0)),
+            212)
       << "incorrect value for states[26].cn0, expected 212, is "
       << last_msg_->states[26].cn0;
-  EXPECT_EQ(last_msg_->states[26].mesid.code, 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[26].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[26].mesid.code)),
+      1)
       << "incorrect value for states[26].mesid.code, expected 1, is "
       << last_msg_->states[26].mesid.code;
-  EXPECT_EQ(last_msg_->states[26].mesid.sat, 23)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[26].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[26].mesid.sat)),
+      23)
       << "incorrect value for states[26].mesid.sat, expected 23, is "
       << last_msg_->states[26].mesid.sat;
-  EXPECT_EQ(last_msg_->states[27].cn0, 205)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[27].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[27].cn0)),
+            205)
       << "incorrect value for states[27].cn0, expected 205, is "
       << last_msg_->states[27].cn0;
-  EXPECT_EQ(last_msg_->states[27].mesid.code, 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[27].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[27].mesid.code)),
+      1)
       << "incorrect value for states[27].mesid.code, expected 1, is "
       << last_msg_->states[27].mesid.code;
-  EXPECT_EQ(last_msg_->states[27].mesid.sat, 10)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[27].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[27].mesid.sat)),
+      10)
       << "incorrect value for states[27].mesid.sat, expected 10, is "
       << last_msg_->states[27].mesid.sat;
-  EXPECT_EQ(last_msg_->states[28].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[28].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[28].cn0)),
+            0)
       << "incorrect value for states[28].cn0, expected 0, is "
       << last_msg_->states[28].cn0;
-  EXPECT_EQ(last_msg_->states[28].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[28].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[28].mesid.code)),
+      0)
       << "incorrect value for states[28].mesid.code, expected 0, is "
       << last_msg_->states[28].mesid.code;
-  EXPECT_EQ(last_msg_->states[28].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[28].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[28].mesid.sat)),
+      0)
       << "incorrect value for states[28].mesid.sat, expected 0, is "
       << last_msg_->states[28].mesid.sat;
-  EXPECT_EQ(last_msg_->states[29].cn0, 230)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[29].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[29].cn0)),
+            230)
       << "incorrect value for states[29].cn0, expected 230, is "
       << last_msg_->states[29].cn0;
-  EXPECT_EQ(last_msg_->states[29].mesid.code, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[29].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[29].mesid.code)),
+      3)
       << "incorrect value for states[29].mesid.code, expected 3, is "
       << last_msg_->states[29].mesid.code;
-  EXPECT_EQ(last_msg_->states[29].mesid.sat, 96)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[29].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[29].mesid.sat)),
+      96)
       << "incorrect value for states[29].mesid.sat, expected 96, is "
       << last_msg_->states[29].mesid.sat;
-  EXPECT_EQ(last_msg_->states[30].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[30].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[30].cn0)),
+            0)
       << "incorrect value for states[30].cn0, expected 0, is "
       << last_msg_->states[30].cn0;
-  EXPECT_EQ(last_msg_->states[30].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[30].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[30].mesid.code)),
+      0)
       << "incorrect value for states[30].mesid.code, expected 0, is "
       << last_msg_->states[30].mesid.code;
-  EXPECT_EQ(last_msg_->states[30].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[30].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[30].mesid.sat)),
+      0)
       << "incorrect value for states[30].mesid.sat, expected 0, is "
       << last_msg_->states[30].mesid.sat;
-  EXPECT_EQ(last_msg_->states[31].cn0, 214)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[31].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[31].cn0)),
+            214)
       << "incorrect value for states[31].cn0, expected 214, is "
       << last_msg_->states[31].cn0;
-  EXPECT_EQ(last_msg_->states[31].mesid.code, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[31].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[31].mesid.code)),
+      3)
       << "incorrect value for states[31].mesid.code, expected 3, is "
       << last_msg_->states[31].mesid.code;
-  EXPECT_EQ(last_msg_->states[31].mesid.sat, 101)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[31].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[31].mesid.sat)),
+      101)
       << "incorrect value for states[31].mesid.sat, expected 101, is "
       << last_msg_->states[31].mesid.sat;
-  EXPECT_EQ(last_msg_->states[32].cn0, 212)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[32].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[32].cn0)),
+            212)
       << "incorrect value for states[32].cn0, expected 212, is "
       << last_msg_->states[32].cn0;
-  EXPECT_EQ(last_msg_->states[32].mesid.code, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[32].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[32].mesid.code)),
+      3)
       << "incorrect value for states[32].mesid.code, expected 3, is "
       << last_msg_->states[32].mesid.code;
-  EXPECT_EQ(last_msg_->states[32].mesid.sat, 103)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[32].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[32].mesid.sat)),
+      103)
       << "incorrect value for states[32].mesid.sat, expected 103, is "
       << last_msg_->states[32].mesid.sat;
-  EXPECT_EQ(last_msg_->states[33].cn0, 209)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[33].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[33].cn0)),
+            209)
       << "incorrect value for states[33].cn0, expected 209, is "
       << last_msg_->states[33].cn0;
-  EXPECT_EQ(last_msg_->states[33].mesid.code, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[33].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[33].mesid.code)),
+      3)
       << "incorrect value for states[33].mesid.code, expected 3, is "
       << last_msg_->states[33].mesid.code;
-  EXPECT_EQ(last_msg_->states[33].mesid.sat, 104)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[33].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[33].mesid.sat)),
+      104)
       << "incorrect value for states[33].mesid.sat, expected 104, is "
       << last_msg_->states[33].mesid.sat;
-  EXPECT_EQ(last_msg_->states[34].cn0, 157)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[34].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[34].cn0)),
+            157)
       << "incorrect value for states[34].cn0, expected 157, is "
       << last_msg_->states[34].cn0;
-  EXPECT_EQ(last_msg_->states[34].mesid.code, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[34].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[34].mesid.code)),
+      3)
       << "incorrect value for states[34].mesid.code, expected 3, is "
       << last_msg_->states[34].mesid.code;
-  EXPECT_EQ(last_msg_->states[34].mesid.sat, 106)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[34].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[34].mesid.sat)),
+      106)
       << "incorrect value for states[34].mesid.sat, expected 106, is "
       << last_msg_->states[34].mesid.sat;
-  EXPECT_EQ(last_msg_->states[35].cn0, 230)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[35].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[35].cn0)),
+            230)
       << "incorrect value for states[35].cn0, expected 230, is "
       << last_msg_->states[35].cn0;
-  EXPECT_EQ(last_msg_->states[35].mesid.code, 3)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[35].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[35].mesid.code)),
+      3)
       << "incorrect value for states[35].mesid.code, expected 3, is "
       << last_msg_->states[35].mesid.code;
-  EXPECT_EQ(last_msg_->states[35].mesid.sat, 102)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[35].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[35].mesid.sat)),
+      102)
       << "incorrect value for states[35].mesid.sat, expected 102, is "
       << last_msg_->states[35].mesid.sat;
-  EXPECT_EQ(last_msg_->states[36].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[36].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[36].cn0)),
+            0)
       << "incorrect value for states[36].cn0, expected 0, is "
       << last_msg_->states[36].cn0;
-  EXPECT_EQ(last_msg_->states[36].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[36].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[36].mesid.code)),
+      0)
       << "incorrect value for states[36].mesid.code, expected 0, is "
       << last_msg_->states[36].mesid.code;
-  EXPECT_EQ(last_msg_->states[36].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[36].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[36].mesid.sat)),
+      0)
       << "incorrect value for states[36].mesid.sat, expected 0, is "
       << last_msg_->states[36].mesid.sat;
-  EXPECT_EQ(last_msg_->states[37].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[37].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[37].cn0)),
+            0)
       << "incorrect value for states[37].cn0, expected 0, is "
       << last_msg_->states[37].cn0;
-  EXPECT_EQ(last_msg_->states[37].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[37].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[37].mesid.code)),
+      0)
       << "incorrect value for states[37].mesid.code, expected 0, is "
       << last_msg_->states[37].mesid.code;
-  EXPECT_EQ(last_msg_->states[37].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[37].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[37].mesid.sat)),
+      0)
       << "incorrect value for states[37].mesid.sat, expected 0, is "
       << last_msg_->states[37].mesid.sat;
-  EXPECT_EQ(last_msg_->states[38].cn0, 189)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[38].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[38].cn0)),
+            189)
       << "incorrect value for states[38].cn0, expected 189, is "
       << last_msg_->states[38].cn0;
-  EXPECT_EQ(last_msg_->states[38].mesid.code, 4)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[38].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[38].mesid.code)),
+      4)
       << "incorrect value for states[38].mesid.code, expected 4, is "
       << last_msg_->states[38].mesid.code;
-  EXPECT_EQ(last_msg_->states[38].mesid.sat, 101)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[38].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[38].mesid.sat)),
+      101)
       << "incorrect value for states[38].mesid.sat, expected 101, is "
       << last_msg_->states[38].mesid.sat;
-  EXPECT_EQ(last_msg_->states[39].cn0, 207)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[39].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[39].cn0)),
+            207)
       << "incorrect value for states[39].cn0, expected 207, is "
       << last_msg_->states[39].cn0;
-  EXPECT_EQ(last_msg_->states[39].mesid.code, 4)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[39].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[39].mesid.code)),
+      4)
       << "incorrect value for states[39].mesid.code, expected 4, is "
       << last_msg_->states[39].mesid.code;
-  EXPECT_EQ(last_msg_->states[39].mesid.sat, 96)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[39].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[39].mesid.sat)),
+      96)
       << "incorrect value for states[39].mesid.sat, expected 96, is "
       << last_msg_->states[39].mesid.sat;
-  EXPECT_EQ(last_msg_->states[40].cn0, 164)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[40].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[40].cn0)),
+            164)
       << "incorrect value for states[40].cn0, expected 164, is "
       << last_msg_->states[40].cn0;
-  EXPECT_EQ(last_msg_->states[40].mesid.code, 4)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[40].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[40].mesid.code)),
+      4)
       << "incorrect value for states[40].mesid.code, expected 4, is "
       << last_msg_->states[40].mesid.code;
-  EXPECT_EQ(last_msg_->states[40].mesid.sat, 106)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[40].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[40].mesid.sat)),
+      106)
       << "incorrect value for states[40].mesid.sat, expected 106, is "
       << last_msg_->states[40].mesid.sat;
-  EXPECT_EQ(last_msg_->states[41].cn0, 193)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[41].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[41].cn0)),
+            193)
       << "incorrect value for states[41].cn0, expected 193, is "
       << last_msg_->states[41].cn0;
-  EXPECT_EQ(last_msg_->states[41].mesid.code, 4)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[41].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[41].mesid.code)),
+      4)
       << "incorrect value for states[41].mesid.code, expected 4, is "
       << last_msg_->states[41].mesid.code;
-  EXPECT_EQ(last_msg_->states[41].mesid.sat, 104)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[41].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[41].mesid.sat)),
+      104)
       << "incorrect value for states[41].mesid.sat, expected 104, is "
       << last_msg_->states[41].mesid.sat;
-  EXPECT_EQ(last_msg_->states[42].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[42].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[42].cn0)),
+            0)
       << "incorrect value for states[42].cn0, expected 0, is "
       << last_msg_->states[42].cn0;
-  EXPECT_EQ(last_msg_->states[42].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[42].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[42].mesid.code)),
+      0)
       << "incorrect value for states[42].mesid.code, expected 0, is "
       << last_msg_->states[42].mesid.code;
-  EXPECT_EQ(last_msg_->states[42].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[42].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[42].mesid.sat)),
+      0)
       << "incorrect value for states[42].mesid.sat, expected 0, is "
       << last_msg_->states[42].mesid.sat;
-  EXPECT_EQ(last_msg_->states[43].cn0, 208)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[43].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[43].cn0)),
+            208)
       << "incorrect value for states[43].cn0, expected 208, is "
       << last_msg_->states[43].cn0;
-  EXPECT_EQ(last_msg_->states[43].mesid.code, 4)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[43].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[43].mesid.code)),
+      4)
       << "incorrect value for states[43].mesid.code, expected 4, is "
       << last_msg_->states[43].mesid.code;
-  EXPECT_EQ(last_msg_->states[43].mesid.sat, 102)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[43].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[43].mesid.sat)),
+      102)
       << "incorrect value for states[43].mesid.sat, expected 102, is "
       << last_msg_->states[43].mesid.sat;
-  EXPECT_EQ(last_msg_->states[44].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[44].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[44].cn0)),
+            0)
       << "incorrect value for states[44].cn0, expected 0, is "
       << last_msg_->states[44].cn0;
-  EXPECT_EQ(last_msg_->states[44].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[44].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[44].mesid.code)),
+      0)
       << "incorrect value for states[44].mesid.code, expected 0, is "
       << last_msg_->states[44].mesid.code;
-  EXPECT_EQ(last_msg_->states[44].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[44].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[44].mesid.sat)),
+      0)
       << "incorrect value for states[44].mesid.sat, expected 0, is "
       << last_msg_->states[44].mesid.sat;
-  EXPECT_EQ(last_msg_->states[45].cn0, 212)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[45].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[45].cn0)),
+            212)
       << "incorrect value for states[45].cn0, expected 212, is "
       << last_msg_->states[45].cn0;
-  EXPECT_EQ(last_msg_->states[45].mesid.code, 12)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[45].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[45].mesid.code)),
+      12)
       << "incorrect value for states[45].mesid.code, expected 12, is "
       << last_msg_->states[45].mesid.code;
-  EXPECT_EQ(last_msg_->states[45].mesid.sat, 27)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[45].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[45].mesid.sat)),
+      27)
       << "incorrect value for states[45].mesid.sat, expected 27, is "
       << last_msg_->states[45].mesid.sat;
-  EXPECT_EQ(last_msg_->states[46].cn0, 161)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[46].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[46].cn0)),
+            161)
       << "incorrect value for states[46].cn0, expected 161, is "
       << last_msg_->states[46].cn0;
-  EXPECT_EQ(last_msg_->states[46].mesid.code, 12)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[46].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[46].mesid.code)),
+      12)
       << "incorrect value for states[46].mesid.code, expected 12, is "
       << last_msg_->states[46].mesid.code;
-  EXPECT_EQ(last_msg_->states[46].mesid.sat, 29)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[46].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[46].mesid.sat)),
+      29)
       << "incorrect value for states[46].mesid.sat, expected 29, is "
       << last_msg_->states[46].mesid.sat;
-  EXPECT_EQ(last_msg_->states[47].cn0, 216)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[47].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[47].cn0)),
+            216)
       << "incorrect value for states[47].cn0, expected 216, is "
       << last_msg_->states[47].cn0;
-  EXPECT_EQ(last_msg_->states[47].mesid.code, 12)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[47].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[47].mesid.code)),
+      12)
       << "incorrect value for states[47].mesid.code, expected 12, is "
       << last_msg_->states[47].mesid.code;
-  EXPECT_EQ(last_msg_->states[47].mesid.sat, 32)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[47].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[47].mesid.sat)),
+      32)
       << "incorrect value for states[47].mesid.sat, expected 32, is "
       << last_msg_->states[47].mesid.sat;
-  EXPECT_EQ(last_msg_->states[48].cn0, 216)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[48].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[48].cn0)),
+            216)
       << "incorrect value for states[48].cn0, expected 216, is "
       << last_msg_->states[48].cn0;
-  EXPECT_EQ(last_msg_->states[48].mesid.code, 12)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[48].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[48].mesid.code)),
+      12)
       << "incorrect value for states[48].mesid.code, expected 12, is "
       << last_msg_->states[48].mesid.code;
-  EXPECT_EQ(last_msg_->states[48].mesid.sat, 30)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[48].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[48].mesid.sat)),
+      30)
       << "incorrect value for states[48].mesid.sat, expected 30, is "
       << last_msg_->states[48].mesid.sat;
-  EXPECT_EQ(last_msg_->states[49].cn0, 178)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[49].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[49].cn0)),
+            178)
       << "incorrect value for states[49].cn0, expected 178, is "
       << last_msg_->states[49].cn0;
-  EXPECT_EQ(last_msg_->states[49].mesid.code, 12)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[49].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[49].mesid.code)),
+      12)
       << "incorrect value for states[49].mesid.code, expected 12, is "
       << last_msg_->states[49].mesid.code;
-  EXPECT_EQ(last_msg_->states[49].mesid.sat, 20)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[49].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[49].mesid.sat)),
+      20)
       << "incorrect value for states[49].mesid.sat, expected 20, is "
       << last_msg_->states[49].mesid.sat;
-  EXPECT_EQ(last_msg_->states[50].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[50].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[50].cn0)),
+            0)
       << "incorrect value for states[50].cn0, expected 0, is "
       << last_msg_->states[50].cn0;
-  EXPECT_EQ(last_msg_->states[50].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[50].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[50].mesid.code)),
+      0)
       << "incorrect value for states[50].mesid.code, expected 0, is "
       << last_msg_->states[50].mesid.code;
-  EXPECT_EQ(last_msg_->states[50].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[50].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[50].mesid.sat)),
+      0)
       << "incorrect value for states[50].mesid.sat, expected 0, is "
       << last_msg_->states[50].mesid.sat;
-  EXPECT_EQ(last_msg_->states[51].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[51].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[51].cn0)),
+            0)
       << "incorrect value for states[51].cn0, expected 0, is "
       << last_msg_->states[51].cn0;
-  EXPECT_EQ(last_msg_->states[51].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[51].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[51].mesid.code)),
+      0)
       << "incorrect value for states[51].mesid.code, expected 0, is "
       << last_msg_->states[51].mesid.code;
-  EXPECT_EQ(last_msg_->states[51].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[51].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[51].mesid.sat)),
+      0)
       << "incorrect value for states[51].mesid.sat, expected 0, is "
       << last_msg_->states[51].mesid.sat;
-  EXPECT_EQ(last_msg_->states[52].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[52].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[52].cn0)),
+            0)
       << "incorrect value for states[52].cn0, expected 0, is "
       << last_msg_->states[52].cn0;
-  EXPECT_EQ(last_msg_->states[52].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[52].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[52].mesid.code)),
+      0)
       << "incorrect value for states[52].mesid.code, expected 0, is "
       << last_msg_->states[52].mesid.code;
-  EXPECT_EQ(last_msg_->states[52].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[52].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[52].mesid.sat)),
+      0)
       << "incorrect value for states[52].mesid.sat, expected 0, is "
       << last_msg_->states[52].mesid.sat;
-  EXPECT_EQ(last_msg_->states[53].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[53].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[53].cn0)),
+            0)
       << "incorrect value for states[53].cn0, expected 0, is "
       << last_msg_->states[53].cn0;
-  EXPECT_EQ(last_msg_->states[53].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[53].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[53].mesid.code)),
+      0)
       << "incorrect value for states[53].mesid.code, expected 0, is "
       << last_msg_->states[53].mesid.code;
-  EXPECT_EQ(last_msg_->states[53].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[53].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[53].mesid.sat)),
+      0)
       << "incorrect value for states[53].mesid.sat, expected 0, is "
       << last_msg_->states[53].mesid.sat;
-  EXPECT_EQ(last_msg_->states[54].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[54].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[54].cn0)),
+            0)
       << "incorrect value for states[54].cn0, expected 0, is "
       << last_msg_->states[54].cn0;
-  EXPECT_EQ(last_msg_->states[54].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[54].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[54].mesid.code)),
+      0)
       << "incorrect value for states[54].mesid.code, expected 0, is "
       << last_msg_->states[54].mesid.code;
-  EXPECT_EQ(last_msg_->states[54].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[54].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[54].mesid.sat)),
+      0)
       << "incorrect value for states[54].mesid.sat, expected 0, is "
       << last_msg_->states[54].mesid.sat;
-  EXPECT_EQ(last_msg_->states[55].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[55].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[55].cn0)),
+            0)
       << "incorrect value for states[55].cn0, expected 0, is "
       << last_msg_->states[55].cn0;
-  EXPECT_EQ(last_msg_->states[55].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[55].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[55].mesid.code)),
+      0)
       << "incorrect value for states[55].mesid.code, expected 0, is "
       << last_msg_->states[55].mesid.code;
-  EXPECT_EQ(last_msg_->states[55].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[55].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[55].mesid.sat)),
+      0)
       << "incorrect value for states[55].mesid.sat, expected 0, is "
       << last_msg_->states[55].mesid.sat;
-  EXPECT_EQ(last_msg_->states[56].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[56].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[56].cn0)),
+            0)
       << "incorrect value for states[56].cn0, expected 0, is "
       << last_msg_->states[56].cn0;
-  EXPECT_EQ(last_msg_->states[56].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[56].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[56].mesid.code)),
+      0)
       << "incorrect value for states[56].mesid.code, expected 0, is "
       << last_msg_->states[56].mesid.code;
-  EXPECT_EQ(last_msg_->states[56].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[56].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[56].mesid.sat)),
+      0)
       << "incorrect value for states[56].mesid.sat, expected 0, is "
       << last_msg_->states[56].mesid.sat;
-  EXPECT_EQ(last_msg_->states[57].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[57].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[57].cn0)),
+            0)
       << "incorrect value for states[57].cn0, expected 0, is "
       << last_msg_->states[57].cn0;
-  EXPECT_EQ(last_msg_->states[57].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[57].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[57].mesid.code)),
+      0)
       << "incorrect value for states[57].mesid.code, expected 0, is "
       << last_msg_->states[57].mesid.code;
-  EXPECT_EQ(last_msg_->states[57].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[57].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[57].mesid.sat)),
+      0)
       << "incorrect value for states[57].mesid.sat, expected 0, is "
       << last_msg_->states[57].mesid.sat;
-  EXPECT_EQ(last_msg_->states[58].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[58].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[58].cn0)),
+            0)
       << "incorrect value for states[58].cn0, expected 0, is "
       << last_msg_->states[58].cn0;
-  EXPECT_EQ(last_msg_->states[58].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[58].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[58].mesid.code)),
+      0)
       << "incorrect value for states[58].mesid.code, expected 0, is "
       << last_msg_->states[58].mesid.code;
-  EXPECT_EQ(last_msg_->states[58].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[58].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[58].mesid.sat)),
+      0)
       << "incorrect value for states[58].mesid.sat, expected 0, is "
       << last_msg_->states[58].mesid.sat;
-  EXPECT_EQ(last_msg_->states[59].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[59].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[59].cn0)),
+            0)
       << "incorrect value for states[59].cn0, expected 0, is "
       << last_msg_->states[59].cn0;
-  EXPECT_EQ(last_msg_->states[59].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[59].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[59].mesid.code)),
+      0)
       << "incorrect value for states[59].mesid.code, expected 0, is "
       << last_msg_->states[59].mesid.code;
-  EXPECT_EQ(last_msg_->states[59].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[59].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[59].mesid.sat)),
+      0)
       << "incorrect value for states[59].mesid.sat, expected 0, is "
       << last_msg_->states[59].mesid.sat;
-  EXPECT_EQ(last_msg_->states[60].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[60].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[60].cn0)),
+            0)
       << "incorrect value for states[60].cn0, expected 0, is "
       << last_msg_->states[60].cn0;
-  EXPECT_EQ(last_msg_->states[60].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[60].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[60].mesid.code)),
+      0)
       << "incorrect value for states[60].mesid.code, expected 0, is "
       << last_msg_->states[60].mesid.code;
-  EXPECT_EQ(last_msg_->states[60].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[60].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[60].mesid.sat)),
+      0)
       << "incorrect value for states[60].mesid.sat, expected 0, is "
       << last_msg_->states[60].mesid.sat;
-  EXPECT_EQ(last_msg_->states[61].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[61].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[61].cn0)),
+            0)
       << "incorrect value for states[61].cn0, expected 0, is "
       << last_msg_->states[61].cn0;
-  EXPECT_EQ(last_msg_->states[61].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[61].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[61].mesid.code)),
+      0)
       << "incorrect value for states[61].mesid.code, expected 0, is "
       << last_msg_->states[61].mesid.code;
-  EXPECT_EQ(last_msg_->states[61].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[61].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[61].mesid.sat)),
+      0)
       << "incorrect value for states[61].mesid.sat, expected 0, is "
       << last_msg_->states[61].mesid.sat;
-  EXPECT_EQ(last_msg_->states[62].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[62].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[62].cn0)),
+            0)
       << "incorrect value for states[62].cn0, expected 0, is "
       << last_msg_->states[62].cn0;
-  EXPECT_EQ(last_msg_->states[62].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[62].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[62].mesid.code)),
+      0)
       << "incorrect value for states[62].mesid.code, expected 0, is "
       << last_msg_->states[62].mesid.code;
-  EXPECT_EQ(last_msg_->states[62].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[62].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[62].mesid.sat)),
+      0)
       << "incorrect value for states[62].mesid.sat, expected 0, is "
       << last_msg_->states[62].mesid.sat;
-  EXPECT_EQ(last_msg_->states[63].cn0, 203)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[63].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[63].cn0)),
+            203)
       << "incorrect value for states[63].cn0, expected 203, is "
       << last_msg_->states[63].cn0;
-  EXPECT_EQ(last_msg_->states[63].mesid.code, 14)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[63].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[63].mesid.code)),
+      14)
       << "incorrect value for states[63].mesid.code, expected 14, is "
       << last_msg_->states[63].mesid.code;
-  EXPECT_EQ(last_msg_->states[63].mesid.sat, 36)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[63].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[63].mesid.sat)),
+      36)
       << "incorrect value for states[63].mesid.sat, expected 36, is "
       << last_msg_->states[63].mesid.sat;
-  EXPECT_EQ(last_msg_->states[64].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[64].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[64].cn0)),
+            0)
       << "incorrect value for states[64].cn0, expected 0, is "
       << last_msg_->states[64].cn0;
-  EXPECT_EQ(last_msg_->states[64].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[64].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[64].mesid.code)),
+      0)
       << "incorrect value for states[64].mesid.code, expected 0, is "
       << last_msg_->states[64].mesid.code;
-  EXPECT_EQ(last_msg_->states[64].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[64].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[64].mesid.sat)),
+      0)
       << "incorrect value for states[64].mesid.sat, expected 0, is "
       << last_msg_->states[64].mesid.sat;
-  EXPECT_EQ(last_msg_->states[65].cn0, 158)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[65].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[65].cn0)),
+            158)
       << "incorrect value for states[65].cn0, expected 158, is "
       << last_msg_->states[65].cn0;
-  EXPECT_EQ(last_msg_->states[65].mesid.code, 14)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[65].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[65].mesid.code)),
+      14)
       << "incorrect value for states[65].mesid.code, expected 14, is "
       << last_msg_->states[65].mesid.code;
-  EXPECT_EQ(last_msg_->states[65].mesid.sat, 5)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[65].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[65].mesid.sat)),
+      5)
       << "incorrect value for states[65].mesid.sat, expected 5, is "
       << last_msg_->states[65].mesid.sat;
-  EXPECT_EQ(last_msg_->states[66].cn0, 194)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[66].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[66].cn0)),
+            194)
       << "incorrect value for states[66].cn0, expected 194, is "
       << last_msg_->states[66].cn0;
-  EXPECT_EQ(last_msg_->states[66].mesid.code, 14)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[66].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[66].mesid.code)),
+      14)
       << "incorrect value for states[66].mesid.code, expected 14, is "
       << last_msg_->states[66].mesid.code;
-  EXPECT_EQ(last_msg_->states[66].mesid.sat, 4)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[66].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[66].mesid.sat)),
+      4)
       << "incorrect value for states[66].mesid.sat, expected 4, is "
       << last_msg_->states[66].mesid.sat;
-  EXPECT_EQ(last_msg_->states[67].cn0, 192)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[67].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[67].cn0)),
+            192)
       << "incorrect value for states[67].cn0, expected 192, is "
       << last_msg_->states[67].cn0;
-  EXPECT_EQ(last_msg_->states[67].mesid.code, 14)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[67].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[67].mesid.code)),
+      14)
       << "incorrect value for states[67].mesid.code, expected 14, is "
       << last_msg_->states[67].mesid.code;
-  EXPECT_EQ(last_msg_->states[67].mesid.sat, 11)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[67].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[67].mesid.sat)),
+      11)
       << "incorrect value for states[67].mesid.sat, expected 11, is "
       << last_msg_->states[67].mesid.sat;
-  EXPECT_EQ(last_msg_->states[68].cn0, 207)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[68].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[68].cn0)),
+            207)
       << "incorrect value for states[68].cn0, expected 207, is "
       << last_msg_->states[68].cn0;
-  EXPECT_EQ(last_msg_->states[68].mesid.code, 14)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[68].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[68].mesid.code)),
+      14)
       << "incorrect value for states[68].mesid.code, expected 14, is "
       << last_msg_->states[68].mesid.code;
-  EXPECT_EQ(last_msg_->states[68].mesid.sat, 9)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[68].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[68].mesid.sat)),
+      9)
       << "incorrect value for states[68].mesid.sat, expected 9, is "
       << last_msg_->states[68].mesid.sat;
-  EXPECT_EQ(last_msg_->states[69].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[69].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[69].cn0)),
+            0)
       << "incorrect value for states[69].cn0, expected 0, is "
       << last_msg_->states[69].cn0;
-  EXPECT_EQ(last_msg_->states[69].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[69].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[69].mesid.code)),
+      0)
       << "incorrect value for states[69].mesid.code, expected 0, is "
       << last_msg_->states[69].mesid.code;
-  EXPECT_EQ(last_msg_->states[69].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[69].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[69].mesid.sat)),
+      0)
       << "incorrect value for states[69].mesid.sat, expected 0, is "
       << last_msg_->states[69].mesid.sat;
-  EXPECT_EQ(last_msg_->states[70].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[70].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[70].cn0)),
+            0)
       << "incorrect value for states[70].cn0, expected 0, is "
       << last_msg_->states[70].cn0;
-  EXPECT_EQ(last_msg_->states[70].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[70].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[70].mesid.code)),
+      0)
       << "incorrect value for states[70].mesid.code, expected 0, is "
       << last_msg_->states[70].mesid.code;
-  EXPECT_EQ(last_msg_->states[70].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[70].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[70].mesid.sat)),
+      0)
       << "incorrect value for states[70].mesid.sat, expected 0, is "
       << last_msg_->states[70].mesid.sat;
-  EXPECT_EQ(last_msg_->states[71].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[71].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[71].cn0)),
+            0)
       << "incorrect value for states[71].cn0, expected 0, is "
       << last_msg_->states[71].cn0;
-  EXPECT_EQ(last_msg_->states[71].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[71].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[71].mesid.code)),
+      0)
       << "incorrect value for states[71].mesid.code, expected 0, is "
       << last_msg_->states[71].mesid.code;
-  EXPECT_EQ(last_msg_->states[71].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[71].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[71].mesid.sat)),
+      0)
       << "incorrect value for states[71].mesid.sat, expected 0, is "
       << last_msg_->states[71].mesid.sat;
-  EXPECT_EQ(last_msg_->states[72].cn0, 218)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[72].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[72].cn0)),
+            218)
       << "incorrect value for states[72].cn0, expected 218, is "
       << last_msg_->states[72].cn0;
-  EXPECT_EQ(last_msg_->states[72].mesid.code, 20)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[72].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[72].mesid.code)),
+      20)
       << "incorrect value for states[72].mesid.code, expected 20, is "
       << last_msg_->states[72].mesid.code;
-  EXPECT_EQ(last_msg_->states[72].mesid.sat, 9)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[72].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[72].mesid.sat)),
+      9)
       << "incorrect value for states[72].mesid.sat, expected 9, is "
       << last_msg_->states[72].mesid.sat;
-  EXPECT_EQ(last_msg_->states[73].cn0, 176)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[73].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[73].cn0)),
+            176)
       << "incorrect value for states[73].cn0, expected 176, is "
       << last_msg_->states[73].cn0;
-  EXPECT_EQ(last_msg_->states[73].mesid.code, 20)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[73].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[73].mesid.code)),
+      20)
       << "incorrect value for states[73].mesid.code, expected 20, is "
       << last_msg_->states[73].mesid.code;
-  EXPECT_EQ(last_msg_->states[73].mesid.sat, 5)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[73].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[73].mesid.sat)),
+      5)
       << "incorrect value for states[73].mesid.sat, expected 5, is "
       << last_msg_->states[73].mesid.sat;
-  EXPECT_EQ(last_msg_->states[74].cn0, 217)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[74].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[74].cn0)),
+            217)
       << "incorrect value for states[74].cn0, expected 217, is "
       << last_msg_->states[74].cn0;
-  EXPECT_EQ(last_msg_->states[74].mesid.code, 20)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[74].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[74].mesid.code)),
+      20)
       << "incorrect value for states[74].mesid.code, expected 20, is "
       << last_msg_->states[74].mesid.code;
-  EXPECT_EQ(last_msg_->states[74].mesid.sat, 36)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[74].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[74].mesid.sat)),
+      36)
       << "incorrect value for states[74].mesid.sat, expected 36, is "
       << last_msg_->states[74].mesid.sat;
-  EXPECT_EQ(last_msg_->states[75].cn0, 200)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[75].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[75].cn0)),
+            200)
       << "incorrect value for states[75].cn0, expected 200, is "
       << last_msg_->states[75].cn0;
-  EXPECT_EQ(last_msg_->states[75].mesid.code, 20)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[75].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[75].mesid.code)),
+      20)
       << "incorrect value for states[75].mesid.code, expected 20, is "
       << last_msg_->states[75].mesid.code;
-  EXPECT_EQ(last_msg_->states[75].mesid.sat, 11)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[75].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[75].mesid.sat)),
+      11)
       << "incorrect value for states[75].mesid.sat, expected 11, is "
       << last_msg_->states[75].mesid.sat;
-  EXPECT_EQ(last_msg_->states[76].cn0, 205)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[76].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[76].cn0)),
+            205)
       << "incorrect value for states[76].cn0, expected 205, is "
       << last_msg_->states[76].cn0;
-  EXPECT_EQ(last_msg_->states[76].mesid.code, 20)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[76].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[76].mesid.code)),
+      20)
       << "incorrect value for states[76].mesid.code, expected 20, is "
       << last_msg_->states[76].mesid.code;
-  EXPECT_EQ(last_msg_->states[76].mesid.sat, 4)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[76].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[76].mesid.sat)),
+      4)
       << "incorrect value for states[76].mesid.sat, expected 4, is "
       << last_msg_->states[76].mesid.sat;
-  EXPECT_EQ(last_msg_->states[77].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[77].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[77].cn0)),
+            0)
       << "incorrect value for states[77].cn0, expected 0, is "
       << last_msg_->states[77].cn0;
-  EXPECT_EQ(last_msg_->states[77].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[77].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[77].mesid.code)),
+      0)
       << "incorrect value for states[77].mesid.code, expected 0, is "
       << last_msg_->states[77].mesid.code;
-  EXPECT_EQ(last_msg_->states[77].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[77].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[77].mesid.sat)),
+      0)
       << "incorrect value for states[77].mesid.sat, expected 0, is "
       << last_msg_->states[77].mesid.sat;
-  EXPECT_EQ(last_msg_->states[78].cn0, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[78].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[78].cn0)),
+            0)
       << "incorrect value for states[78].cn0, expected 0, is "
       << last_msg_->states[78].cn0;
-  EXPECT_EQ(last_msg_->states[78].mesid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[78].mesid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[78].mesid.code)),
+      0)
       << "incorrect value for states[78].mesid.code, expected 0, is "
       << last_msg_->states[78].mesid.code;
-  EXPECT_EQ(last_msg_->states[78].mesid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[78].mesid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[78].mesid.sat)),
+      0)
       << "incorrect value for states[78].mesid.sat, expected 0, is "
       << last_msg_->states[78].mesid.sat;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_tracking_MsgTrackingIq.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_tracking_MsgTrackingIq.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/tracking.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_tracking_MsgTrackingIq0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -131,29 +138,47 @@ TEST_F(Test_legacy_auto_check_sbp_tracking_MsgTrackingIq0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 20482);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->channel, 145)
+  EXPECT_EQ(get_as<decltype(last_msg_->channel)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->channel)),
+            145)
       << "incorrect value for channel, expected 145, is " << last_msg_->channel;
-  EXPECT_EQ(last_msg_->corrs[0].I, -9937)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrs[0].I)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->corrs[0].I)),
+            -9937)
       << "incorrect value for corrs[0].I, expected -9937, is "
       << last_msg_->corrs[0].I;
-  EXPECT_EQ(last_msg_->corrs[0].Q, 14319)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrs[0].Q)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->corrs[0].Q)),
+            14319)
       << "incorrect value for corrs[0].Q, expected 14319, is "
       << last_msg_->corrs[0].Q;
-  EXPECT_EQ(last_msg_->corrs[1].I, 9773)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrs[1].I)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->corrs[1].I)),
+            9773)
       << "incorrect value for corrs[1].I, expected 9773, is "
       << last_msg_->corrs[1].I;
-  EXPECT_EQ(last_msg_->corrs[1].Q, 22717)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrs[1].Q)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->corrs[1].Q)),
+            22717)
       << "incorrect value for corrs[1].Q, expected 22717, is "
       << last_msg_->corrs[1].Q;
-  EXPECT_EQ(last_msg_->corrs[2].I, 5023)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrs[2].I)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->corrs[2].I)),
+            5023)
       << "incorrect value for corrs[2].I, expected 5023, is "
       << last_msg_->corrs[2].I;
-  EXPECT_EQ(last_msg_->corrs[2].Q, 3280)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrs[2].Q)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->corrs[2].Q)),
+            3280)
       << "incorrect value for corrs[2].Q, expected 3280, is "
       << last_msg_->corrs[2].Q;
-  EXPECT_EQ(last_msg_->sid.code, 203)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.code)),
+            203)
       << "incorrect value for sid.code, expected 203, is "
       << last_msg_->sid.code;
-  EXPECT_EQ(last_msg_->sid.sat, 121)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.sat)),
+            121)
       << "incorrect value for sid.sat, expected 121, is " << last_msg_->sid.sat;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_tracking_MsgTrackingIqDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_tracking_MsgTrackingIqDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/tracking.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_tracking_MsgTrackingIqDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -135,33 +142,53 @@ TEST_F(Test_legacy_auto_check_sbp_tracking_MsgTrackingIqDepA0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 17336);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->channel, 139)
+  EXPECT_EQ(get_as<decltype(last_msg_->channel)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->channel)),
+            139)
       << "incorrect value for channel, expected 139, is " << last_msg_->channel;
-  EXPECT_EQ(last_msg_->corrs[0].I, 1621776995)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrs[0].I)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->corrs[0].I)),
+            1621776995)
       << "incorrect value for corrs[0].I, expected 1621776995, is "
       << last_msg_->corrs[0].I;
-  EXPECT_EQ(last_msg_->corrs[0].Q, -1591641785)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrs[0].Q)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->corrs[0].Q)),
+            -1591641785)
       << "incorrect value for corrs[0].Q, expected -1591641785, is "
       << last_msg_->corrs[0].Q;
-  EXPECT_EQ(last_msg_->corrs[1].I, 1705169716)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrs[1].I)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->corrs[1].I)),
+            1705169716)
       << "incorrect value for corrs[1].I, expected 1705169716, is "
       << last_msg_->corrs[1].I;
-  EXPECT_EQ(last_msg_->corrs[1].Q, 1675764777)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrs[1].Q)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->corrs[1].Q)),
+            1675764777)
       << "incorrect value for corrs[1].Q, expected 1675764777, is "
       << last_msg_->corrs[1].Q;
-  EXPECT_EQ(last_msg_->corrs[2].I, -267498681)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrs[2].I)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->corrs[2].I)),
+            -267498681)
       << "incorrect value for corrs[2].I, expected -267498681, is "
       << last_msg_->corrs[2].I;
-  EXPECT_EQ(last_msg_->corrs[2].Q, 1403998854)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrs[2].Q)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->corrs[2].Q)),
+            1403998854)
       << "incorrect value for corrs[2].Q, expected 1403998854, is "
       << last_msg_->corrs[2].Q;
-  EXPECT_EQ(last_msg_->sid.code, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.code)),
+            15)
       << "incorrect value for sid.code, expected 15, is "
       << last_msg_->sid.code;
-  EXPECT_EQ(last_msg_->sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.reserved)),
+            0)
       << "incorrect value for sid.reserved, expected 0, is "
       << last_msg_->sid.reserved;
-  EXPECT_EQ(last_msg_->sid.sat, 64028)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.sat)),
+            64028)
       << "incorrect value for sid.sat, expected 64028, is "
       << last_msg_->sid.sat;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_tracking_MsgTrackingIqDepB.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_tracking_MsgTrackingIqDepB.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/tracking.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_tracking_MsgTrackingIqDepB0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -134,29 +141,47 @@ TEST_F(Test_legacy_auto_check_sbp_tracking_MsgTrackingIqDepB0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 25895);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->channel, 45)
+  EXPECT_EQ(get_as<decltype(last_msg_->channel)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->channel)),
+            45)
       << "incorrect value for channel, expected 45, is " << last_msg_->channel;
-  EXPECT_EQ(last_msg_->corrs[0].I, 261994824)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrs[0].I)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->corrs[0].I)),
+            261994824)
       << "incorrect value for corrs[0].I, expected 261994824, is "
       << last_msg_->corrs[0].I;
-  EXPECT_EQ(last_msg_->corrs[0].Q, 409336251)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrs[0].Q)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->corrs[0].Q)),
+            409336251)
       << "incorrect value for corrs[0].Q, expected 409336251, is "
       << last_msg_->corrs[0].Q;
-  EXPECT_EQ(last_msg_->corrs[1].I, -525036921)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrs[1].I)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->corrs[1].I)),
+            -525036921)
       << "incorrect value for corrs[1].I, expected -525036921, is "
       << last_msg_->corrs[1].I;
-  EXPECT_EQ(last_msg_->corrs[1].Q, -795939973)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrs[1].Q)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->corrs[1].Q)),
+            -795939973)
       << "incorrect value for corrs[1].Q, expected -795939973, is "
       << last_msg_->corrs[1].Q;
-  EXPECT_EQ(last_msg_->corrs[2].I, 353988710)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrs[2].I)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->corrs[2].I)),
+            353988710)
       << "incorrect value for corrs[2].I, expected 353988710, is "
       << last_msg_->corrs[2].I;
-  EXPECT_EQ(last_msg_->corrs[2].Q, 1148477617)
+  EXPECT_EQ(get_as<decltype(last_msg_->corrs[2].Q)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->corrs[2].Q)),
+            1148477617)
       << "incorrect value for corrs[2].Q, expected 1148477617, is "
       << last_msg_->corrs[2].Q;
-  EXPECT_EQ(last_msg_->sid.code, 183)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.code)),
+            183)
       << "incorrect value for sid.code, expected 183, is "
       << last_msg_->sid.code;
-  EXPECT_EQ(last_msg_->sid.sat, 188)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.sat)),
+            188)
       << "incorrect value for sid.sat, expected 188, is " << last_msg_->sid.sat;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_tracking_MsgTrackingState.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_tracking_MsgTrackingState.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/tracking.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_tracking_MsgTrackingState0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -630,760 +637,1390 @@ TEST_F(Test_legacy_auto_check_sbp_tracking_MsgTrackingState0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 33079);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->states[0].cn0, 102)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[0].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[0].cn0)),
+            102)
       << "incorrect value for states[0].cn0, expected 102, is "
       << last_msg_->states[0].cn0;
-  EXPECT_EQ(last_msg_->states[0].fcn, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[0].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[0].fcn)),
+            3)
       << "incorrect value for states[0].fcn, expected 3, is "
       << last_msg_->states[0].fcn;
-  EXPECT_EQ(last_msg_->states[0].sid.code, 184)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[0].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[0].sid.code)),
+      184)
       << "incorrect value for states[0].sid.code, expected 184, is "
       << last_msg_->states[0].sid.code;
-  EXPECT_EQ(last_msg_->states[0].sid.sat, 117)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[0].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[0].sid.sat)),
+      117)
       << "incorrect value for states[0].sid.sat, expected 117, is "
       << last_msg_->states[0].sid.sat;
-  EXPECT_EQ(last_msg_->states[1].cn0, 141)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[1].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[1].cn0)),
+            141)
       << "incorrect value for states[1].cn0, expected 141, is "
       << last_msg_->states[1].cn0;
-  EXPECT_EQ(last_msg_->states[1].fcn, 140)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[1].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[1].fcn)),
+            140)
       << "incorrect value for states[1].fcn, expected 140, is "
       << last_msg_->states[1].fcn;
-  EXPECT_EQ(last_msg_->states[1].sid.code, 106)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[1].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[1].sid.code)),
+      106)
       << "incorrect value for states[1].sid.code, expected 106, is "
       << last_msg_->states[1].sid.code;
-  EXPECT_EQ(last_msg_->states[1].sid.sat, 38)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[1].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[1].sid.sat)),
+      38)
       << "incorrect value for states[1].sid.sat, expected 38, is "
       << last_msg_->states[1].sid.sat;
-  EXPECT_EQ(last_msg_->states[2].cn0, 195)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[2].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[2].cn0)),
+            195)
       << "incorrect value for states[2].cn0, expected 195, is "
       << last_msg_->states[2].cn0;
-  EXPECT_EQ(last_msg_->states[2].fcn, 90)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[2].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[2].fcn)),
+            90)
       << "incorrect value for states[2].fcn, expected 90, is "
       << last_msg_->states[2].fcn;
-  EXPECT_EQ(last_msg_->states[2].sid.code, 4)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[2].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[2].sid.code)),
+      4)
       << "incorrect value for states[2].sid.code, expected 4, is "
       << last_msg_->states[2].sid.code;
-  EXPECT_EQ(last_msg_->states[2].sid.sat, 25)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[2].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[2].sid.sat)),
+      25)
       << "incorrect value for states[2].sid.sat, expected 25, is "
       << last_msg_->states[2].sid.sat;
-  EXPECT_EQ(last_msg_->states[3].cn0, 82)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[3].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[3].cn0)),
+            82)
       << "incorrect value for states[3].cn0, expected 82, is "
       << last_msg_->states[3].cn0;
-  EXPECT_EQ(last_msg_->states[3].fcn, 75)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[3].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[3].fcn)),
+            75)
       << "incorrect value for states[3].fcn, expected 75, is "
       << last_msg_->states[3].fcn;
-  EXPECT_EQ(last_msg_->states[3].sid.code, 108)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[3].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[3].sid.code)),
+      108)
       << "incorrect value for states[3].sid.code, expected 108, is "
       << last_msg_->states[3].sid.code;
-  EXPECT_EQ(last_msg_->states[3].sid.sat, 246)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[3].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[3].sid.sat)),
+      246)
       << "incorrect value for states[3].sid.sat, expected 246, is "
       << last_msg_->states[3].sid.sat;
-  EXPECT_EQ(last_msg_->states[4].cn0, 163)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[4].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[4].cn0)),
+            163)
       << "incorrect value for states[4].cn0, expected 163, is "
       << last_msg_->states[4].cn0;
-  EXPECT_EQ(last_msg_->states[4].fcn, 45)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[4].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[4].fcn)),
+            45)
       << "incorrect value for states[4].fcn, expected 45, is "
       << last_msg_->states[4].fcn;
-  EXPECT_EQ(last_msg_->states[4].sid.code, 127)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[4].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[4].sid.code)),
+      127)
       << "incorrect value for states[4].sid.code, expected 127, is "
       << last_msg_->states[4].sid.code;
-  EXPECT_EQ(last_msg_->states[4].sid.sat, 137)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[4].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[4].sid.sat)),
+      137)
       << "incorrect value for states[4].sid.sat, expected 137, is "
       << last_msg_->states[4].sid.sat;
-  EXPECT_EQ(last_msg_->states[5].cn0, 93)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[5].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[5].cn0)),
+            93)
       << "incorrect value for states[5].cn0, expected 93, is "
       << last_msg_->states[5].cn0;
-  EXPECT_EQ(last_msg_->states[5].fcn, 187)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[5].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[5].fcn)),
+            187)
       << "incorrect value for states[5].fcn, expected 187, is "
       << last_msg_->states[5].fcn;
-  EXPECT_EQ(last_msg_->states[5].sid.code, 46)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[5].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[5].sid.code)),
+      46)
       << "incorrect value for states[5].sid.code, expected 46, is "
       << last_msg_->states[5].sid.code;
-  EXPECT_EQ(last_msg_->states[5].sid.sat, 32)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[5].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[5].sid.sat)),
+      32)
       << "incorrect value for states[5].sid.sat, expected 32, is "
       << last_msg_->states[5].sid.sat;
-  EXPECT_EQ(last_msg_->states[6].cn0, 147)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[6].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[6].cn0)),
+            147)
       << "incorrect value for states[6].cn0, expected 147, is "
       << last_msg_->states[6].cn0;
-  EXPECT_EQ(last_msg_->states[6].fcn, 201)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[6].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[6].fcn)),
+            201)
       << "incorrect value for states[6].fcn, expected 201, is "
       << last_msg_->states[6].fcn;
-  EXPECT_EQ(last_msg_->states[6].sid.code, 60)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[6].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[6].sid.code)),
+      60)
       << "incorrect value for states[6].sid.code, expected 60, is "
       << last_msg_->states[6].sid.code;
-  EXPECT_EQ(last_msg_->states[6].sid.sat, 153)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[6].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[6].sid.sat)),
+      153)
       << "incorrect value for states[6].sid.sat, expected 153, is "
       << last_msg_->states[6].sid.sat;
-  EXPECT_EQ(last_msg_->states[7].cn0, 208)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[7].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[7].cn0)),
+            208)
       << "incorrect value for states[7].cn0, expected 208, is "
       << last_msg_->states[7].cn0;
-  EXPECT_EQ(last_msg_->states[7].fcn, 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[7].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[7].fcn)),
+            5)
       << "incorrect value for states[7].fcn, expected 5, is "
       << last_msg_->states[7].fcn;
-  EXPECT_EQ(last_msg_->states[7].sid.code, 29)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[7].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[7].sid.code)),
+      29)
       << "incorrect value for states[7].sid.code, expected 29, is "
       << last_msg_->states[7].sid.code;
-  EXPECT_EQ(last_msg_->states[7].sid.sat, 23)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[7].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[7].sid.sat)),
+      23)
       << "incorrect value for states[7].sid.sat, expected 23, is "
       << last_msg_->states[7].sid.sat;
-  EXPECT_EQ(last_msg_->states[8].cn0, 69)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[8].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[8].cn0)),
+            69)
       << "incorrect value for states[8].cn0, expected 69, is "
       << last_msg_->states[8].cn0;
-  EXPECT_EQ(last_msg_->states[8].fcn, 219)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[8].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[8].fcn)),
+            219)
       << "incorrect value for states[8].fcn, expected 219, is "
       << last_msg_->states[8].fcn;
-  EXPECT_EQ(last_msg_->states[8].sid.code, 30)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[8].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[8].sid.code)),
+      30)
       << "incorrect value for states[8].sid.code, expected 30, is "
       << last_msg_->states[8].sid.code;
-  EXPECT_EQ(last_msg_->states[8].sid.sat, 181)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[8].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[8].sid.sat)),
+      181)
       << "incorrect value for states[8].sid.sat, expected 181, is "
       << last_msg_->states[8].sid.sat;
-  EXPECT_EQ(last_msg_->states[9].cn0, 121)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[9].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[9].cn0)),
+            121)
       << "incorrect value for states[9].cn0, expected 121, is "
       << last_msg_->states[9].cn0;
-  EXPECT_EQ(last_msg_->states[9].fcn, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[9].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[9].fcn)),
+            3)
       << "incorrect value for states[9].fcn, expected 3, is "
       << last_msg_->states[9].fcn;
-  EXPECT_EQ(last_msg_->states[9].sid.code, 136)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[9].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[9].sid.code)),
+      136)
       << "incorrect value for states[9].sid.code, expected 136, is "
       << last_msg_->states[9].sid.code;
-  EXPECT_EQ(last_msg_->states[9].sid.sat, 254)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[9].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[9].sid.sat)),
+      254)
       << "incorrect value for states[9].sid.sat, expected 254, is "
       << last_msg_->states[9].sid.sat;
-  EXPECT_EQ(last_msg_->states[10].cn0, 215)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[10].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[10].cn0)),
+            215)
       << "incorrect value for states[10].cn0, expected 215, is "
       << last_msg_->states[10].cn0;
-  EXPECT_EQ(last_msg_->states[10].fcn, 144)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[10].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[10].fcn)),
+            144)
       << "incorrect value for states[10].fcn, expected 144, is "
       << last_msg_->states[10].fcn;
-  EXPECT_EQ(last_msg_->states[10].sid.code, 98)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[10].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[10].sid.code)),
+      98)
       << "incorrect value for states[10].sid.code, expected 98, is "
       << last_msg_->states[10].sid.code;
-  EXPECT_EQ(last_msg_->states[10].sid.sat, 33)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[10].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[10].sid.sat)),
+      33)
       << "incorrect value for states[10].sid.sat, expected 33, is "
       << last_msg_->states[10].sid.sat;
-  EXPECT_EQ(last_msg_->states[11].cn0, 56)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[11].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[11].cn0)),
+            56)
       << "incorrect value for states[11].cn0, expected 56, is "
       << last_msg_->states[11].cn0;
-  EXPECT_EQ(last_msg_->states[11].fcn, 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[11].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[11].fcn)),
+            14)
       << "incorrect value for states[11].fcn, expected 14, is "
       << last_msg_->states[11].fcn;
-  EXPECT_EQ(last_msg_->states[11].sid.code, 182)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[11].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[11].sid.code)),
+      182)
       << "incorrect value for states[11].sid.code, expected 182, is "
       << last_msg_->states[11].sid.code;
-  EXPECT_EQ(last_msg_->states[11].sid.sat, 133)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[11].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[11].sid.sat)),
+      133)
       << "incorrect value for states[11].sid.sat, expected 133, is "
       << last_msg_->states[11].sid.sat;
-  EXPECT_EQ(last_msg_->states[12].cn0, 62)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[12].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[12].cn0)),
+            62)
       << "incorrect value for states[12].cn0, expected 62, is "
       << last_msg_->states[12].cn0;
-  EXPECT_EQ(last_msg_->states[12].fcn, 218)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[12].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[12].fcn)),
+            218)
       << "incorrect value for states[12].fcn, expected 218, is "
       << last_msg_->states[12].fcn;
-  EXPECT_EQ(last_msg_->states[12].sid.code, 77)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[12].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[12].sid.code)),
+      77)
       << "incorrect value for states[12].sid.code, expected 77, is "
       << last_msg_->states[12].sid.code;
-  EXPECT_EQ(last_msg_->states[12].sid.sat, 169)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[12].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[12].sid.sat)),
+      169)
       << "incorrect value for states[12].sid.sat, expected 169, is "
       << last_msg_->states[12].sid.sat;
-  EXPECT_EQ(last_msg_->states[13].cn0, 249)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[13].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[13].cn0)),
+            249)
       << "incorrect value for states[13].cn0, expected 249, is "
       << last_msg_->states[13].cn0;
-  EXPECT_EQ(last_msg_->states[13].fcn, 171)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[13].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[13].fcn)),
+            171)
       << "incorrect value for states[13].fcn, expected 171, is "
       << last_msg_->states[13].fcn;
-  EXPECT_EQ(last_msg_->states[13].sid.code, 84)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[13].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[13].sid.code)),
+      84)
       << "incorrect value for states[13].sid.code, expected 84, is "
       << last_msg_->states[13].sid.code;
-  EXPECT_EQ(last_msg_->states[13].sid.sat, 242)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[13].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[13].sid.sat)),
+      242)
       << "incorrect value for states[13].sid.sat, expected 242, is "
       << last_msg_->states[13].sid.sat;
-  EXPECT_EQ(last_msg_->states[14].cn0, 130)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[14].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[14].cn0)),
+            130)
       << "incorrect value for states[14].cn0, expected 130, is "
       << last_msg_->states[14].cn0;
-  EXPECT_EQ(last_msg_->states[14].fcn, 131)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[14].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[14].fcn)),
+            131)
       << "incorrect value for states[14].fcn, expected 131, is "
       << last_msg_->states[14].fcn;
-  EXPECT_EQ(last_msg_->states[14].sid.code, 137)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[14].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[14].sid.code)),
+      137)
       << "incorrect value for states[14].sid.code, expected 137, is "
       << last_msg_->states[14].sid.code;
-  EXPECT_EQ(last_msg_->states[14].sid.sat, 152)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[14].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[14].sid.sat)),
+      152)
       << "incorrect value for states[14].sid.sat, expected 152, is "
       << last_msg_->states[14].sid.sat;
-  EXPECT_EQ(last_msg_->states[15].cn0, 68)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[15].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[15].cn0)),
+            68)
       << "incorrect value for states[15].cn0, expected 68, is "
       << last_msg_->states[15].cn0;
-  EXPECT_EQ(last_msg_->states[15].fcn, 42)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[15].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[15].fcn)),
+            42)
       << "incorrect value for states[15].fcn, expected 42, is "
       << last_msg_->states[15].fcn;
-  EXPECT_EQ(last_msg_->states[15].sid.code, 21)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[15].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[15].sid.code)),
+      21)
       << "incorrect value for states[15].sid.code, expected 21, is "
       << last_msg_->states[15].sid.code;
-  EXPECT_EQ(last_msg_->states[15].sid.sat, 193)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[15].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[15].sid.sat)),
+      193)
       << "incorrect value for states[15].sid.sat, expected 193, is "
       << last_msg_->states[15].sid.sat;
-  EXPECT_EQ(last_msg_->states[16].cn0, 227)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[16].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[16].cn0)),
+            227)
       << "incorrect value for states[16].cn0, expected 227, is "
       << last_msg_->states[16].cn0;
-  EXPECT_EQ(last_msg_->states[16].fcn, 216)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[16].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[16].fcn)),
+            216)
       << "incorrect value for states[16].fcn, expected 216, is "
       << last_msg_->states[16].fcn;
-  EXPECT_EQ(last_msg_->states[16].sid.code, 227)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[16].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[16].sid.code)),
+      227)
       << "incorrect value for states[16].sid.code, expected 227, is "
       << last_msg_->states[16].sid.code;
-  EXPECT_EQ(last_msg_->states[16].sid.sat, 253)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[16].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[16].sid.sat)),
+      253)
       << "incorrect value for states[16].sid.sat, expected 253, is "
       << last_msg_->states[16].sid.sat;
-  EXPECT_EQ(last_msg_->states[17].cn0, 179)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[17].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[17].cn0)),
+            179)
       << "incorrect value for states[17].cn0, expected 179, is "
       << last_msg_->states[17].cn0;
-  EXPECT_EQ(last_msg_->states[17].fcn, 210)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[17].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[17].fcn)),
+            210)
       << "incorrect value for states[17].fcn, expected 210, is "
       << last_msg_->states[17].fcn;
-  EXPECT_EQ(last_msg_->states[17].sid.code, 26)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[17].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[17].sid.code)),
+      26)
       << "incorrect value for states[17].sid.code, expected 26, is "
       << last_msg_->states[17].sid.code;
-  EXPECT_EQ(last_msg_->states[17].sid.sat, 24)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[17].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[17].sid.sat)),
+      24)
       << "incorrect value for states[17].sid.sat, expected 24, is "
       << last_msg_->states[17].sid.sat;
-  EXPECT_EQ(last_msg_->states[18].cn0, 255)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[18].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[18].cn0)),
+            255)
       << "incorrect value for states[18].cn0, expected 255, is "
       << last_msg_->states[18].cn0;
-  EXPECT_EQ(last_msg_->states[18].fcn, 227)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[18].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[18].fcn)),
+            227)
       << "incorrect value for states[18].fcn, expected 227, is "
       << last_msg_->states[18].fcn;
-  EXPECT_EQ(last_msg_->states[18].sid.code, 15)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[18].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[18].sid.code)),
+      15)
       << "incorrect value for states[18].sid.code, expected 15, is "
       << last_msg_->states[18].sid.code;
-  EXPECT_EQ(last_msg_->states[18].sid.sat, 19)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[18].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[18].sid.sat)),
+      19)
       << "incorrect value for states[18].sid.sat, expected 19, is "
       << last_msg_->states[18].sid.sat;
-  EXPECT_EQ(last_msg_->states[19].cn0, 200)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[19].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[19].cn0)),
+            200)
       << "incorrect value for states[19].cn0, expected 200, is "
       << last_msg_->states[19].cn0;
-  EXPECT_EQ(last_msg_->states[19].fcn, 187)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[19].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[19].fcn)),
+            187)
       << "incorrect value for states[19].fcn, expected 187, is "
       << last_msg_->states[19].fcn;
-  EXPECT_EQ(last_msg_->states[19].sid.code, 75)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[19].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[19].sid.code)),
+      75)
       << "incorrect value for states[19].sid.code, expected 75, is "
       << last_msg_->states[19].sid.code;
-  EXPECT_EQ(last_msg_->states[19].sid.sat, 122)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[19].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[19].sid.sat)),
+      122)
       << "incorrect value for states[19].sid.sat, expected 122, is "
       << last_msg_->states[19].sid.sat;
-  EXPECT_EQ(last_msg_->states[20].cn0, 122)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[20].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[20].cn0)),
+            122)
       << "incorrect value for states[20].cn0, expected 122, is "
       << last_msg_->states[20].cn0;
-  EXPECT_EQ(last_msg_->states[20].fcn, 218)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[20].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[20].fcn)),
+            218)
       << "incorrect value for states[20].fcn, expected 218, is "
       << last_msg_->states[20].fcn;
-  EXPECT_EQ(last_msg_->states[20].sid.code, 48)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[20].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[20].sid.code)),
+      48)
       << "incorrect value for states[20].sid.code, expected 48, is "
       << last_msg_->states[20].sid.code;
-  EXPECT_EQ(last_msg_->states[20].sid.sat, 217)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[20].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[20].sid.sat)),
+      217)
       << "incorrect value for states[20].sid.sat, expected 217, is "
       << last_msg_->states[20].sid.sat;
-  EXPECT_EQ(last_msg_->states[21].cn0, 149)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[21].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[21].cn0)),
+            149)
       << "incorrect value for states[21].cn0, expected 149, is "
       << last_msg_->states[21].cn0;
-  EXPECT_EQ(last_msg_->states[21].fcn, 142)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[21].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[21].fcn)),
+            142)
       << "incorrect value for states[21].fcn, expected 142, is "
       << last_msg_->states[21].fcn;
-  EXPECT_EQ(last_msg_->states[21].sid.code, 238)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[21].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[21].sid.code)),
+      238)
       << "incorrect value for states[21].sid.code, expected 238, is "
       << last_msg_->states[21].sid.code;
-  EXPECT_EQ(last_msg_->states[21].sid.sat, 187)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[21].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[21].sid.sat)),
+      187)
       << "incorrect value for states[21].sid.sat, expected 187, is "
       << last_msg_->states[21].sid.sat;
-  EXPECT_EQ(last_msg_->states[22].cn0, 212)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[22].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[22].cn0)),
+            212)
       << "incorrect value for states[22].cn0, expected 212, is "
       << last_msg_->states[22].cn0;
-  EXPECT_EQ(last_msg_->states[22].fcn, 251)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[22].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[22].fcn)),
+            251)
       << "incorrect value for states[22].fcn, expected 251, is "
       << last_msg_->states[22].fcn;
-  EXPECT_EQ(last_msg_->states[22].sid.code, 55)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[22].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[22].sid.code)),
+      55)
       << "incorrect value for states[22].sid.code, expected 55, is "
       << last_msg_->states[22].sid.code;
-  EXPECT_EQ(last_msg_->states[22].sid.sat, 238)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[22].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[22].sid.sat)),
+      238)
       << "incorrect value for states[22].sid.sat, expected 238, is "
       << last_msg_->states[22].sid.sat;
-  EXPECT_EQ(last_msg_->states[23].cn0, 104)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[23].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[23].cn0)),
+            104)
       << "incorrect value for states[23].cn0, expected 104, is "
       << last_msg_->states[23].cn0;
-  EXPECT_EQ(last_msg_->states[23].fcn, 194)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[23].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[23].fcn)),
+            194)
       << "incorrect value for states[23].fcn, expected 194, is "
       << last_msg_->states[23].fcn;
-  EXPECT_EQ(last_msg_->states[23].sid.code, 160)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[23].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[23].sid.code)),
+      160)
       << "incorrect value for states[23].sid.code, expected 160, is "
       << last_msg_->states[23].sid.code;
-  EXPECT_EQ(last_msg_->states[23].sid.sat, 128)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[23].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[23].sid.sat)),
+      128)
       << "incorrect value for states[23].sid.sat, expected 128, is "
       << last_msg_->states[23].sid.sat;
-  EXPECT_EQ(last_msg_->states[24].cn0, 62)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[24].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[24].cn0)),
+            62)
       << "incorrect value for states[24].cn0, expected 62, is "
       << last_msg_->states[24].cn0;
-  EXPECT_EQ(last_msg_->states[24].fcn, 141)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[24].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[24].fcn)),
+            141)
       << "incorrect value for states[24].fcn, expected 141, is "
       << last_msg_->states[24].fcn;
-  EXPECT_EQ(last_msg_->states[24].sid.code, 255)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[24].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[24].sid.code)),
+      255)
       << "incorrect value for states[24].sid.code, expected 255, is "
       << last_msg_->states[24].sid.code;
-  EXPECT_EQ(last_msg_->states[24].sid.sat, 113)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[24].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[24].sid.sat)),
+      113)
       << "incorrect value for states[24].sid.sat, expected 113, is "
       << last_msg_->states[24].sid.sat;
-  EXPECT_EQ(last_msg_->states[25].cn0, 39)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[25].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[25].cn0)),
+            39)
       << "incorrect value for states[25].cn0, expected 39, is "
       << last_msg_->states[25].cn0;
-  EXPECT_EQ(last_msg_->states[25].fcn, 245)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[25].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[25].fcn)),
+            245)
       << "incorrect value for states[25].fcn, expected 245, is "
       << last_msg_->states[25].fcn;
-  EXPECT_EQ(last_msg_->states[25].sid.code, 69)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[25].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[25].sid.code)),
+      69)
       << "incorrect value for states[25].sid.code, expected 69, is "
       << last_msg_->states[25].sid.code;
-  EXPECT_EQ(last_msg_->states[25].sid.sat, 43)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[25].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[25].sid.sat)),
+      43)
       << "incorrect value for states[25].sid.sat, expected 43, is "
       << last_msg_->states[25].sid.sat;
-  EXPECT_EQ(last_msg_->states[26].cn0, 56)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[26].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[26].cn0)),
+            56)
       << "incorrect value for states[26].cn0, expected 56, is "
       << last_msg_->states[26].cn0;
-  EXPECT_EQ(last_msg_->states[26].fcn, 108)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[26].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[26].fcn)),
+            108)
       << "incorrect value for states[26].fcn, expected 108, is "
       << last_msg_->states[26].fcn;
-  EXPECT_EQ(last_msg_->states[26].sid.code, 230)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[26].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[26].sid.code)),
+      230)
       << "incorrect value for states[26].sid.code, expected 230, is "
       << last_msg_->states[26].sid.code;
-  EXPECT_EQ(last_msg_->states[26].sid.sat, 100)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[26].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[26].sid.sat)),
+      100)
       << "incorrect value for states[26].sid.sat, expected 100, is "
       << last_msg_->states[26].sid.sat;
-  EXPECT_EQ(last_msg_->states[27].cn0, 143)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[27].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[27].cn0)),
+            143)
       << "incorrect value for states[27].cn0, expected 143, is "
       << last_msg_->states[27].cn0;
-  EXPECT_EQ(last_msg_->states[27].fcn, 149)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[27].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[27].fcn)),
+            149)
       << "incorrect value for states[27].fcn, expected 149, is "
       << last_msg_->states[27].fcn;
-  EXPECT_EQ(last_msg_->states[27].sid.code, 68)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[27].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[27].sid.code)),
+      68)
       << "incorrect value for states[27].sid.code, expected 68, is "
       << last_msg_->states[27].sid.code;
-  EXPECT_EQ(last_msg_->states[27].sid.sat, 247)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[27].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[27].sid.sat)),
+      247)
       << "incorrect value for states[27].sid.sat, expected 247, is "
       << last_msg_->states[27].sid.sat;
-  EXPECT_EQ(last_msg_->states[28].cn0, 70)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[28].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[28].cn0)),
+            70)
       << "incorrect value for states[28].cn0, expected 70, is "
       << last_msg_->states[28].cn0;
-  EXPECT_EQ(last_msg_->states[28].fcn, 233)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[28].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[28].fcn)),
+            233)
       << "incorrect value for states[28].fcn, expected 233, is "
       << last_msg_->states[28].fcn;
-  EXPECT_EQ(last_msg_->states[28].sid.code, 101)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[28].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[28].sid.code)),
+      101)
       << "incorrect value for states[28].sid.code, expected 101, is "
       << last_msg_->states[28].sid.code;
-  EXPECT_EQ(last_msg_->states[28].sid.sat, 137)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[28].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[28].sid.sat)),
+      137)
       << "incorrect value for states[28].sid.sat, expected 137, is "
       << last_msg_->states[28].sid.sat;
-  EXPECT_EQ(last_msg_->states[29].cn0, 110)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[29].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[29].cn0)),
+            110)
       << "incorrect value for states[29].cn0, expected 110, is "
       << last_msg_->states[29].cn0;
-  EXPECT_EQ(last_msg_->states[29].fcn, 38)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[29].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[29].fcn)),
+            38)
       << "incorrect value for states[29].fcn, expected 38, is "
       << last_msg_->states[29].fcn;
-  EXPECT_EQ(last_msg_->states[29].sid.code, 165)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[29].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[29].sid.code)),
+      165)
       << "incorrect value for states[29].sid.code, expected 165, is "
       << last_msg_->states[29].sid.code;
-  EXPECT_EQ(last_msg_->states[29].sid.sat, 49)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[29].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[29].sid.sat)),
+      49)
       << "incorrect value for states[29].sid.sat, expected 49, is "
       << last_msg_->states[29].sid.sat;
-  EXPECT_EQ(last_msg_->states[30].cn0, 213)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[30].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[30].cn0)),
+            213)
       << "incorrect value for states[30].cn0, expected 213, is "
       << last_msg_->states[30].cn0;
-  EXPECT_EQ(last_msg_->states[30].fcn, 80)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[30].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[30].fcn)),
+            80)
       << "incorrect value for states[30].fcn, expected 80, is "
       << last_msg_->states[30].fcn;
-  EXPECT_EQ(last_msg_->states[30].sid.code, 230)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[30].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[30].sid.code)),
+      230)
       << "incorrect value for states[30].sid.code, expected 230, is "
       << last_msg_->states[30].sid.code;
-  EXPECT_EQ(last_msg_->states[30].sid.sat, 218)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[30].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[30].sid.sat)),
+      218)
       << "incorrect value for states[30].sid.sat, expected 218, is "
       << last_msg_->states[30].sid.sat;
-  EXPECT_EQ(last_msg_->states[31].cn0, 128)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[31].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[31].cn0)),
+            128)
       << "incorrect value for states[31].cn0, expected 128, is "
       << last_msg_->states[31].cn0;
-  EXPECT_EQ(last_msg_->states[31].fcn, 139)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[31].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[31].fcn)),
+            139)
       << "incorrect value for states[31].fcn, expected 139, is "
       << last_msg_->states[31].fcn;
-  EXPECT_EQ(last_msg_->states[31].sid.code, 179)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[31].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[31].sid.code)),
+      179)
       << "incorrect value for states[31].sid.code, expected 179, is "
       << last_msg_->states[31].sid.code;
-  EXPECT_EQ(last_msg_->states[31].sid.sat, 196)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[31].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[31].sid.sat)),
+      196)
       << "incorrect value for states[31].sid.sat, expected 196, is "
       << last_msg_->states[31].sid.sat;
-  EXPECT_EQ(last_msg_->states[32].cn0, 171)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[32].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[32].cn0)),
+            171)
       << "incorrect value for states[32].cn0, expected 171, is "
       << last_msg_->states[32].cn0;
-  EXPECT_EQ(last_msg_->states[32].fcn, 196)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[32].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[32].fcn)),
+            196)
       << "incorrect value for states[32].fcn, expected 196, is "
       << last_msg_->states[32].fcn;
-  EXPECT_EQ(last_msg_->states[32].sid.code, 178)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[32].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[32].sid.code)),
+      178)
       << "incorrect value for states[32].sid.code, expected 178, is "
       << last_msg_->states[32].sid.code;
-  EXPECT_EQ(last_msg_->states[32].sid.sat, 15)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[32].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[32].sid.sat)),
+      15)
       << "incorrect value for states[32].sid.sat, expected 15, is "
       << last_msg_->states[32].sid.sat;
-  EXPECT_EQ(last_msg_->states[33].cn0, 194)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[33].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[33].cn0)),
+            194)
       << "incorrect value for states[33].cn0, expected 194, is "
       << last_msg_->states[33].cn0;
-  EXPECT_EQ(last_msg_->states[33].fcn, 97)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[33].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[33].fcn)),
+            97)
       << "incorrect value for states[33].fcn, expected 97, is "
       << last_msg_->states[33].fcn;
-  EXPECT_EQ(last_msg_->states[33].sid.code, 212)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[33].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[33].sid.code)),
+      212)
       << "incorrect value for states[33].sid.code, expected 212, is "
       << last_msg_->states[33].sid.code;
-  EXPECT_EQ(last_msg_->states[33].sid.sat, 8)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[33].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[33].sid.sat)),
+      8)
       << "incorrect value for states[33].sid.sat, expected 8, is "
       << last_msg_->states[33].sid.sat;
-  EXPECT_EQ(last_msg_->states[34].cn0, 99)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[34].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[34].cn0)),
+            99)
       << "incorrect value for states[34].cn0, expected 99, is "
       << last_msg_->states[34].cn0;
-  EXPECT_EQ(last_msg_->states[34].fcn, 79)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[34].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[34].fcn)),
+            79)
       << "incorrect value for states[34].fcn, expected 79, is "
       << last_msg_->states[34].fcn;
-  EXPECT_EQ(last_msg_->states[34].sid.code, 233)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[34].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[34].sid.code)),
+      233)
       << "incorrect value for states[34].sid.code, expected 233, is "
       << last_msg_->states[34].sid.code;
-  EXPECT_EQ(last_msg_->states[34].sid.sat, 83)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[34].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[34].sid.sat)),
+      83)
       << "incorrect value for states[34].sid.sat, expected 83, is "
       << last_msg_->states[34].sid.sat;
-  EXPECT_EQ(last_msg_->states[35].cn0, 180)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[35].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[35].cn0)),
+            180)
       << "incorrect value for states[35].cn0, expected 180, is "
       << last_msg_->states[35].cn0;
-  EXPECT_EQ(last_msg_->states[35].fcn, 31)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[35].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[35].fcn)),
+            31)
       << "incorrect value for states[35].fcn, expected 31, is "
       << last_msg_->states[35].fcn;
-  EXPECT_EQ(last_msg_->states[35].sid.code, 90)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[35].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[35].sid.code)),
+      90)
       << "incorrect value for states[35].sid.code, expected 90, is "
       << last_msg_->states[35].sid.code;
-  EXPECT_EQ(last_msg_->states[35].sid.sat, 55)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[35].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[35].sid.sat)),
+      55)
       << "incorrect value for states[35].sid.sat, expected 55, is "
       << last_msg_->states[35].sid.sat;
-  EXPECT_EQ(last_msg_->states[36].cn0, 186)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[36].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[36].cn0)),
+            186)
       << "incorrect value for states[36].cn0, expected 186, is "
       << last_msg_->states[36].cn0;
-  EXPECT_EQ(last_msg_->states[36].fcn, 105)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[36].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[36].fcn)),
+            105)
       << "incorrect value for states[36].fcn, expected 105, is "
       << last_msg_->states[36].fcn;
-  EXPECT_EQ(last_msg_->states[36].sid.code, 25)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[36].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[36].sid.code)),
+      25)
       << "incorrect value for states[36].sid.code, expected 25, is "
       << last_msg_->states[36].sid.code;
-  EXPECT_EQ(last_msg_->states[36].sid.sat, 5)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[36].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[36].sid.sat)),
+      5)
       << "incorrect value for states[36].sid.sat, expected 5, is "
       << last_msg_->states[36].sid.sat;
-  EXPECT_EQ(last_msg_->states[37].cn0, 111)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[37].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[37].cn0)),
+            111)
       << "incorrect value for states[37].cn0, expected 111, is "
       << last_msg_->states[37].cn0;
-  EXPECT_EQ(last_msg_->states[37].fcn, 80)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[37].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[37].fcn)),
+            80)
       << "incorrect value for states[37].fcn, expected 80, is "
       << last_msg_->states[37].fcn;
-  EXPECT_EQ(last_msg_->states[37].sid.code, 224)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[37].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[37].sid.code)),
+      224)
       << "incorrect value for states[37].sid.code, expected 224, is "
       << last_msg_->states[37].sid.code;
-  EXPECT_EQ(last_msg_->states[37].sid.sat, 22)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[37].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[37].sid.sat)),
+      22)
       << "incorrect value for states[37].sid.sat, expected 22, is "
       << last_msg_->states[37].sid.sat;
-  EXPECT_EQ(last_msg_->states[38].cn0, 166)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[38].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[38].cn0)),
+            166)
       << "incorrect value for states[38].cn0, expected 166, is "
       << last_msg_->states[38].cn0;
-  EXPECT_EQ(last_msg_->states[38].fcn, 106)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[38].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[38].fcn)),
+            106)
       << "incorrect value for states[38].fcn, expected 106, is "
       << last_msg_->states[38].fcn;
-  EXPECT_EQ(last_msg_->states[38].sid.code, 48)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[38].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[38].sid.code)),
+      48)
       << "incorrect value for states[38].sid.code, expected 48, is "
       << last_msg_->states[38].sid.code;
-  EXPECT_EQ(last_msg_->states[38].sid.sat, 8)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[38].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[38].sid.sat)),
+      8)
       << "incorrect value for states[38].sid.sat, expected 8, is "
       << last_msg_->states[38].sid.sat;
-  EXPECT_EQ(last_msg_->states[39].cn0, 49)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[39].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[39].cn0)),
+            49)
       << "incorrect value for states[39].cn0, expected 49, is "
       << last_msg_->states[39].cn0;
-  EXPECT_EQ(last_msg_->states[39].fcn, 156)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[39].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[39].fcn)),
+            156)
       << "incorrect value for states[39].fcn, expected 156, is "
       << last_msg_->states[39].fcn;
-  EXPECT_EQ(last_msg_->states[39].sid.code, 48)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[39].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[39].sid.code)),
+      48)
       << "incorrect value for states[39].sid.code, expected 48, is "
       << last_msg_->states[39].sid.code;
-  EXPECT_EQ(last_msg_->states[39].sid.sat, 4)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[39].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[39].sid.sat)),
+      4)
       << "incorrect value for states[39].sid.sat, expected 4, is "
       << last_msg_->states[39].sid.sat;
-  EXPECT_EQ(last_msg_->states[40].cn0, 146)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[40].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[40].cn0)),
+            146)
       << "incorrect value for states[40].cn0, expected 146, is "
       << last_msg_->states[40].cn0;
-  EXPECT_EQ(last_msg_->states[40].fcn, 142)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[40].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[40].fcn)),
+            142)
       << "incorrect value for states[40].fcn, expected 142, is "
       << last_msg_->states[40].fcn;
-  EXPECT_EQ(last_msg_->states[40].sid.code, 19)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[40].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[40].sid.code)),
+      19)
       << "incorrect value for states[40].sid.code, expected 19, is "
       << last_msg_->states[40].sid.code;
-  EXPECT_EQ(last_msg_->states[40].sid.sat, 86)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[40].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[40].sid.sat)),
+      86)
       << "incorrect value for states[40].sid.sat, expected 86, is "
       << last_msg_->states[40].sid.sat;
-  EXPECT_EQ(last_msg_->states[41].cn0, 64)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[41].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[41].cn0)),
+            64)
       << "incorrect value for states[41].cn0, expected 64, is "
       << last_msg_->states[41].cn0;
-  EXPECT_EQ(last_msg_->states[41].fcn, 115)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[41].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[41].fcn)),
+            115)
       << "incorrect value for states[41].fcn, expected 115, is "
       << last_msg_->states[41].fcn;
-  EXPECT_EQ(last_msg_->states[41].sid.code, 124)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[41].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[41].sid.code)),
+      124)
       << "incorrect value for states[41].sid.code, expected 124, is "
       << last_msg_->states[41].sid.code;
-  EXPECT_EQ(last_msg_->states[41].sid.sat, 91)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[41].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[41].sid.sat)),
+      91)
       << "incorrect value for states[41].sid.sat, expected 91, is "
       << last_msg_->states[41].sid.sat;
-  EXPECT_EQ(last_msg_->states[42].cn0, 178)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[42].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[42].cn0)),
+            178)
       << "incorrect value for states[42].cn0, expected 178, is "
       << last_msg_->states[42].cn0;
-  EXPECT_EQ(last_msg_->states[42].fcn, 115)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[42].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[42].fcn)),
+            115)
       << "incorrect value for states[42].fcn, expected 115, is "
       << last_msg_->states[42].fcn;
-  EXPECT_EQ(last_msg_->states[42].sid.code, 230)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[42].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[42].sid.code)),
+      230)
       << "incorrect value for states[42].sid.code, expected 230, is "
       << last_msg_->states[42].sid.code;
-  EXPECT_EQ(last_msg_->states[42].sid.sat, 28)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[42].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[42].sid.sat)),
+      28)
       << "incorrect value for states[42].sid.sat, expected 28, is "
       << last_msg_->states[42].sid.sat;
-  EXPECT_EQ(last_msg_->states[43].cn0, 242)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[43].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[43].cn0)),
+            242)
       << "incorrect value for states[43].cn0, expected 242, is "
       << last_msg_->states[43].cn0;
-  EXPECT_EQ(last_msg_->states[43].fcn, 16)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[43].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[43].fcn)),
+            16)
       << "incorrect value for states[43].fcn, expected 16, is "
       << last_msg_->states[43].fcn;
-  EXPECT_EQ(last_msg_->states[43].sid.code, 131)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[43].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[43].sid.code)),
+      131)
       << "incorrect value for states[43].sid.code, expected 131, is "
       << last_msg_->states[43].sid.code;
-  EXPECT_EQ(last_msg_->states[43].sid.sat, 190)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[43].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[43].sid.sat)),
+      190)
       << "incorrect value for states[43].sid.sat, expected 190, is "
       << last_msg_->states[43].sid.sat;
-  EXPECT_EQ(last_msg_->states[44].cn0, 113)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[44].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[44].cn0)),
+            113)
       << "incorrect value for states[44].cn0, expected 113, is "
       << last_msg_->states[44].cn0;
-  EXPECT_EQ(last_msg_->states[44].fcn, 182)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[44].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[44].fcn)),
+            182)
       << "incorrect value for states[44].fcn, expected 182, is "
       << last_msg_->states[44].fcn;
-  EXPECT_EQ(last_msg_->states[44].sid.code, 59)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[44].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[44].sid.code)),
+      59)
       << "incorrect value for states[44].sid.code, expected 59, is "
       << last_msg_->states[44].sid.code;
-  EXPECT_EQ(last_msg_->states[44].sid.sat, 105)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[44].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[44].sid.sat)),
+      105)
       << "incorrect value for states[44].sid.sat, expected 105, is "
       << last_msg_->states[44].sid.sat;
-  EXPECT_EQ(last_msg_->states[45].cn0, 179)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[45].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[45].cn0)),
+            179)
       << "incorrect value for states[45].cn0, expected 179, is "
       << last_msg_->states[45].cn0;
-  EXPECT_EQ(last_msg_->states[45].fcn, 48)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[45].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[45].fcn)),
+            48)
       << "incorrect value for states[45].fcn, expected 48, is "
       << last_msg_->states[45].fcn;
-  EXPECT_EQ(last_msg_->states[45].sid.code, 180)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[45].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[45].sid.code)),
+      180)
       << "incorrect value for states[45].sid.code, expected 180, is "
       << last_msg_->states[45].sid.code;
-  EXPECT_EQ(last_msg_->states[45].sid.sat, 192)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[45].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[45].sid.sat)),
+      192)
       << "incorrect value for states[45].sid.sat, expected 192, is "
       << last_msg_->states[45].sid.sat;
-  EXPECT_EQ(last_msg_->states[46].cn0, 211)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[46].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[46].cn0)),
+            211)
       << "incorrect value for states[46].cn0, expected 211, is "
       << last_msg_->states[46].cn0;
-  EXPECT_EQ(last_msg_->states[46].fcn, 172)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[46].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[46].fcn)),
+            172)
       << "incorrect value for states[46].fcn, expected 172, is "
       << last_msg_->states[46].fcn;
-  EXPECT_EQ(last_msg_->states[46].sid.code, 31)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[46].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[46].sid.code)),
+      31)
       << "incorrect value for states[46].sid.code, expected 31, is "
       << last_msg_->states[46].sid.code;
-  EXPECT_EQ(last_msg_->states[46].sid.sat, 166)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[46].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[46].sid.sat)),
+      166)
       << "incorrect value for states[46].sid.sat, expected 166, is "
       << last_msg_->states[46].sid.sat;
-  EXPECT_EQ(last_msg_->states[47].cn0, 49)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[47].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[47].cn0)),
+            49)
       << "incorrect value for states[47].cn0, expected 49, is "
       << last_msg_->states[47].cn0;
-  EXPECT_EQ(last_msg_->states[47].fcn, 140)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[47].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[47].fcn)),
+            140)
       << "incorrect value for states[47].fcn, expected 140, is "
       << last_msg_->states[47].fcn;
-  EXPECT_EQ(last_msg_->states[47].sid.code, 228)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[47].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[47].sid.code)),
+      228)
       << "incorrect value for states[47].sid.code, expected 228, is "
       << last_msg_->states[47].sid.code;
-  EXPECT_EQ(last_msg_->states[47].sid.sat, 77)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[47].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[47].sid.sat)),
+      77)
       << "incorrect value for states[47].sid.sat, expected 77, is "
       << last_msg_->states[47].sid.sat;
-  EXPECT_EQ(last_msg_->states[48].cn0, 194)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[48].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[48].cn0)),
+            194)
       << "incorrect value for states[48].cn0, expected 194, is "
       << last_msg_->states[48].cn0;
-  EXPECT_EQ(last_msg_->states[48].fcn, 240)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[48].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[48].fcn)),
+            240)
       << "incorrect value for states[48].fcn, expected 240, is "
       << last_msg_->states[48].fcn;
-  EXPECT_EQ(last_msg_->states[48].sid.code, 77)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[48].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[48].sid.code)),
+      77)
       << "incorrect value for states[48].sid.code, expected 77, is "
       << last_msg_->states[48].sid.code;
-  EXPECT_EQ(last_msg_->states[48].sid.sat, 128)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[48].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[48].sid.sat)),
+      128)
       << "incorrect value for states[48].sid.sat, expected 128, is "
       << last_msg_->states[48].sid.sat;
-  EXPECT_EQ(last_msg_->states[49].cn0, 58)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[49].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[49].cn0)),
+            58)
       << "incorrect value for states[49].cn0, expected 58, is "
       << last_msg_->states[49].cn0;
-  EXPECT_EQ(last_msg_->states[49].fcn, 41)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[49].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[49].fcn)),
+            41)
       << "incorrect value for states[49].fcn, expected 41, is "
       << last_msg_->states[49].fcn;
-  EXPECT_EQ(last_msg_->states[49].sid.code, 194)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[49].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[49].sid.code)),
+      194)
       << "incorrect value for states[49].sid.code, expected 194, is "
       << last_msg_->states[49].sid.code;
-  EXPECT_EQ(last_msg_->states[49].sid.sat, 134)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[49].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[49].sid.sat)),
+      134)
       << "incorrect value for states[49].sid.sat, expected 134, is "
       << last_msg_->states[49].sid.sat;
-  EXPECT_EQ(last_msg_->states[50].cn0, 55)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[50].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[50].cn0)),
+            55)
       << "incorrect value for states[50].cn0, expected 55, is "
       << last_msg_->states[50].cn0;
-  EXPECT_EQ(last_msg_->states[50].fcn, 129)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[50].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[50].fcn)),
+            129)
       << "incorrect value for states[50].fcn, expected 129, is "
       << last_msg_->states[50].fcn;
-  EXPECT_EQ(last_msg_->states[50].sid.code, 53)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[50].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[50].sid.code)),
+      53)
       << "incorrect value for states[50].sid.code, expected 53, is "
       << last_msg_->states[50].sid.code;
-  EXPECT_EQ(last_msg_->states[50].sid.sat, 18)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[50].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[50].sid.sat)),
+      18)
       << "incorrect value for states[50].sid.sat, expected 18, is "
       << last_msg_->states[50].sid.sat;
-  EXPECT_EQ(last_msg_->states[51].cn0, 92)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[51].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[51].cn0)),
+            92)
       << "incorrect value for states[51].cn0, expected 92, is "
       << last_msg_->states[51].cn0;
-  EXPECT_EQ(last_msg_->states[51].fcn, 134)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[51].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[51].fcn)),
+            134)
       << "incorrect value for states[51].fcn, expected 134, is "
       << last_msg_->states[51].fcn;
-  EXPECT_EQ(last_msg_->states[51].sid.code, 72)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[51].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[51].sid.code)),
+      72)
       << "incorrect value for states[51].sid.code, expected 72, is "
       << last_msg_->states[51].sid.code;
-  EXPECT_EQ(last_msg_->states[51].sid.sat, 91)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[51].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[51].sid.sat)),
+      91)
       << "incorrect value for states[51].sid.sat, expected 91, is "
       << last_msg_->states[51].sid.sat;
-  EXPECT_EQ(last_msg_->states[52].cn0, 56)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[52].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[52].cn0)),
+            56)
       << "incorrect value for states[52].cn0, expected 56, is "
       << last_msg_->states[52].cn0;
-  EXPECT_EQ(last_msg_->states[52].fcn, 157)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[52].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[52].fcn)),
+            157)
       << "incorrect value for states[52].fcn, expected 157, is "
       << last_msg_->states[52].fcn;
-  EXPECT_EQ(last_msg_->states[52].sid.code, 224)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[52].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[52].sid.code)),
+      224)
       << "incorrect value for states[52].sid.code, expected 224, is "
       << last_msg_->states[52].sid.code;
-  EXPECT_EQ(last_msg_->states[52].sid.sat, 33)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[52].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[52].sid.sat)),
+      33)
       << "incorrect value for states[52].sid.sat, expected 33, is "
       << last_msg_->states[52].sid.sat;
-  EXPECT_EQ(last_msg_->states[53].cn0, 174)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[53].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[53].cn0)),
+            174)
       << "incorrect value for states[53].cn0, expected 174, is "
       << last_msg_->states[53].cn0;
-  EXPECT_EQ(last_msg_->states[53].fcn, 224)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[53].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[53].fcn)),
+            224)
       << "incorrect value for states[53].fcn, expected 224, is "
       << last_msg_->states[53].fcn;
-  EXPECT_EQ(last_msg_->states[53].sid.code, 54)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[53].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[53].sid.code)),
+      54)
       << "incorrect value for states[53].sid.code, expected 54, is "
       << last_msg_->states[53].sid.code;
-  EXPECT_EQ(last_msg_->states[53].sid.sat, 186)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[53].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[53].sid.sat)),
+      186)
       << "incorrect value for states[53].sid.sat, expected 186, is "
       << last_msg_->states[53].sid.sat;
-  EXPECT_EQ(last_msg_->states[54].cn0, 190)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[54].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[54].cn0)),
+            190)
       << "incorrect value for states[54].cn0, expected 190, is "
       << last_msg_->states[54].cn0;
-  EXPECT_EQ(last_msg_->states[54].fcn, 148)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[54].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[54].fcn)),
+            148)
       << "incorrect value for states[54].fcn, expected 148, is "
       << last_msg_->states[54].fcn;
-  EXPECT_EQ(last_msg_->states[54].sid.code, 84)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[54].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[54].sid.code)),
+      84)
       << "incorrect value for states[54].sid.code, expected 84, is "
       << last_msg_->states[54].sid.code;
-  EXPECT_EQ(last_msg_->states[54].sid.sat, 82)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[54].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[54].sid.sat)),
+      82)
       << "incorrect value for states[54].sid.sat, expected 82, is "
       << last_msg_->states[54].sid.sat;
-  EXPECT_EQ(last_msg_->states[55].cn0, 67)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[55].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[55].cn0)),
+            67)
       << "incorrect value for states[55].cn0, expected 67, is "
       << last_msg_->states[55].cn0;
-  EXPECT_EQ(last_msg_->states[55].fcn, 62)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[55].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[55].fcn)),
+            62)
       << "incorrect value for states[55].fcn, expected 62, is "
       << last_msg_->states[55].fcn;
-  EXPECT_EQ(last_msg_->states[55].sid.code, 54)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[55].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[55].sid.code)),
+      54)
       << "incorrect value for states[55].sid.code, expected 54, is "
       << last_msg_->states[55].sid.code;
-  EXPECT_EQ(last_msg_->states[55].sid.sat, 236)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[55].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[55].sid.sat)),
+      236)
       << "incorrect value for states[55].sid.sat, expected 236, is "
       << last_msg_->states[55].sid.sat;
-  EXPECT_EQ(last_msg_->states[56].cn0, 254)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[56].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[56].cn0)),
+            254)
       << "incorrect value for states[56].cn0, expected 254, is "
       << last_msg_->states[56].cn0;
-  EXPECT_EQ(last_msg_->states[56].fcn, 57)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[56].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[56].fcn)),
+            57)
       << "incorrect value for states[56].fcn, expected 57, is "
       << last_msg_->states[56].fcn;
-  EXPECT_EQ(last_msg_->states[56].sid.code, 215)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[56].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[56].sid.code)),
+      215)
       << "incorrect value for states[56].sid.code, expected 215, is "
       << last_msg_->states[56].sid.code;
-  EXPECT_EQ(last_msg_->states[56].sid.sat, 52)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[56].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[56].sid.sat)),
+      52)
       << "incorrect value for states[56].sid.sat, expected 52, is "
       << last_msg_->states[56].sid.sat;
-  EXPECT_EQ(last_msg_->states[57].cn0, 174)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[57].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[57].cn0)),
+            174)
       << "incorrect value for states[57].cn0, expected 174, is "
       << last_msg_->states[57].cn0;
-  EXPECT_EQ(last_msg_->states[57].fcn, 36)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[57].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[57].fcn)),
+            36)
       << "incorrect value for states[57].fcn, expected 36, is "
       << last_msg_->states[57].fcn;
-  EXPECT_EQ(last_msg_->states[57].sid.code, 133)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[57].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[57].sid.code)),
+      133)
       << "incorrect value for states[57].sid.code, expected 133, is "
       << last_msg_->states[57].sid.code;
-  EXPECT_EQ(last_msg_->states[57].sid.sat, 16)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[57].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[57].sid.sat)),
+      16)
       << "incorrect value for states[57].sid.sat, expected 16, is "
       << last_msg_->states[57].sid.sat;
-  EXPECT_EQ(last_msg_->states[58].cn0, 17)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[58].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[58].cn0)),
+            17)
       << "incorrect value for states[58].cn0, expected 17, is "
       << last_msg_->states[58].cn0;
-  EXPECT_EQ(last_msg_->states[58].fcn, 145)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[58].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[58].fcn)),
+            145)
       << "incorrect value for states[58].fcn, expected 145, is "
       << last_msg_->states[58].fcn;
-  EXPECT_EQ(last_msg_->states[58].sid.code, 172)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[58].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[58].sid.code)),
+      172)
       << "incorrect value for states[58].sid.code, expected 172, is "
       << last_msg_->states[58].sid.code;
-  EXPECT_EQ(last_msg_->states[58].sid.sat, 219)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[58].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[58].sid.sat)),
+      219)
       << "incorrect value for states[58].sid.sat, expected 219, is "
       << last_msg_->states[58].sid.sat;
-  EXPECT_EQ(last_msg_->states[59].cn0, 97)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[59].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[59].cn0)),
+            97)
       << "incorrect value for states[59].cn0, expected 97, is "
       << last_msg_->states[59].cn0;
-  EXPECT_EQ(last_msg_->states[59].fcn, 111)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[59].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[59].fcn)),
+            111)
       << "incorrect value for states[59].fcn, expected 111, is "
       << last_msg_->states[59].fcn;
-  EXPECT_EQ(last_msg_->states[59].sid.code, 179)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[59].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[59].sid.code)),
+      179)
       << "incorrect value for states[59].sid.code, expected 179, is "
       << last_msg_->states[59].sid.code;
-  EXPECT_EQ(last_msg_->states[59].sid.sat, 192)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[59].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[59].sid.sat)),
+      192)
       << "incorrect value for states[59].sid.sat, expected 192, is "
       << last_msg_->states[59].sid.sat;
-  EXPECT_EQ(last_msg_->states[60].cn0, 134)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[60].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[60].cn0)),
+            134)
       << "incorrect value for states[60].cn0, expected 134, is "
       << last_msg_->states[60].cn0;
-  EXPECT_EQ(last_msg_->states[60].fcn, 208)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[60].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[60].fcn)),
+            208)
       << "incorrect value for states[60].fcn, expected 208, is "
       << last_msg_->states[60].fcn;
-  EXPECT_EQ(last_msg_->states[60].sid.code, 56)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[60].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[60].sid.code)),
+      56)
       << "incorrect value for states[60].sid.code, expected 56, is "
       << last_msg_->states[60].sid.code;
-  EXPECT_EQ(last_msg_->states[60].sid.sat, 207)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[60].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[60].sid.sat)),
+      207)
       << "incorrect value for states[60].sid.sat, expected 207, is "
       << last_msg_->states[60].sid.sat;
-  EXPECT_EQ(last_msg_->states[61].cn0, 226)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[61].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[61].cn0)),
+            226)
       << "incorrect value for states[61].cn0, expected 226, is "
       << last_msg_->states[61].cn0;
-  EXPECT_EQ(last_msg_->states[61].fcn, 43)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[61].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[61].fcn)),
+            43)
       << "incorrect value for states[61].fcn, expected 43, is "
       << last_msg_->states[61].fcn;
-  EXPECT_EQ(last_msg_->states[61].sid.code, 17)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[61].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[61].sid.code)),
+      17)
       << "incorrect value for states[61].sid.code, expected 17, is "
       << last_msg_->states[61].sid.code;
-  EXPECT_EQ(last_msg_->states[61].sid.sat, 180)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[61].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[61].sid.sat)),
+      180)
       << "incorrect value for states[61].sid.sat, expected 180, is "
       << last_msg_->states[61].sid.sat;
-  EXPECT_EQ(last_msg_->states[62].cn0, 113)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[62].cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[62].cn0)),
+            113)
       << "incorrect value for states[62].cn0, expected 113, is "
       << last_msg_->states[62].cn0;
-  EXPECT_EQ(last_msg_->states[62].fcn, 140)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[62].fcn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[62].fcn)),
+            140)
       << "incorrect value for states[62].fcn, expected 140, is "
       << last_msg_->states[62].fcn;
-  EXPECT_EQ(last_msg_->states[62].sid.code, 182)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[62].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[62].sid.code)),
+      182)
       << "incorrect value for states[62].sid.code, expected 182, is "
       << last_msg_->states[62].sid.code;
-  EXPECT_EQ(last_msg_->states[62].sid.sat, 255)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[62].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[62].sid.sat)),
+      255)
       << "incorrect value for states[62].sid.sat, expected 255, is "
       << last_msg_->states[62].sid.sat;
 }
@@ -1578,166 +2215,288 @@ TEST_F(Test_legacy_auto_check_sbp_tracking_MsgTrackingState1, Test) {
   EXPECT_LT((last_msg_->states[0].cn0 * 100 - 39.2478218079 * 100), 0.05)
       << "incorrect value for states[0].cn0, expected 39.2478218079, is "
       << last_msg_->states[0].cn0;
-  EXPECT_EQ(last_msg_->states[0].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[0].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[0].sid.code)),
+      0)
       << "incorrect value for states[0].sid.code, expected 0, is "
       << last_msg_->states[0].sid.code;
-  EXPECT_EQ(last_msg_->states[0].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[0].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[0].sid.reserved)),
+            0)
       << "incorrect value for states[0].sid.reserved, expected 0, is "
       << last_msg_->states[0].sid.reserved;
-  EXPECT_EQ(last_msg_->states[0].sid.sat, 202)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[0].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[0].sid.sat)),
+      202)
       << "incorrect value for states[0].sid.sat, expected 202, is "
       << last_msg_->states[0].sid.sat;
-  EXPECT_EQ(last_msg_->states[0].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[0].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[0].state)),
+            1)
       << "incorrect value for states[0].state, expected 1, is "
       << last_msg_->states[0].state;
   EXPECT_LT((last_msg_->states[1].cn0 * 100 - 36.0975608826 * 100), 0.05)
       << "incorrect value for states[1].cn0, expected 36.0975608826, is "
       << last_msg_->states[1].cn0;
-  EXPECT_EQ(last_msg_->states[1].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[1].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[1].sid.code)),
+      0)
       << "incorrect value for states[1].sid.code, expected 0, is "
       << last_msg_->states[1].sid.code;
-  EXPECT_EQ(last_msg_->states[1].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[1].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[1].sid.reserved)),
+            0)
       << "incorrect value for states[1].sid.reserved, expected 0, is "
       << last_msg_->states[1].sid.reserved;
-  EXPECT_EQ(last_msg_->states[1].sid.sat, 203)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[1].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[1].sid.sat)),
+      203)
       << "incorrect value for states[1].sid.sat, expected 203, is "
       << last_msg_->states[1].sid.sat;
-  EXPECT_EQ(last_msg_->states[1].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[1].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[1].state)),
+            1)
       << "incorrect value for states[1].state, expected 1, is "
       << last_msg_->states[1].state;
   EXPECT_LT((last_msg_->states[2].cn0 * 100 - 37.6267852783 * 100), 0.05)
       << "incorrect value for states[2].cn0, expected 37.6267852783, is "
       << last_msg_->states[2].cn0;
-  EXPECT_EQ(last_msg_->states[2].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[2].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[2].sid.code)),
+      0)
       << "incorrect value for states[2].sid.code, expected 0, is "
       << last_msg_->states[2].sid.code;
-  EXPECT_EQ(last_msg_->states[2].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[2].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[2].sid.reserved)),
+            0)
       << "incorrect value for states[2].sid.reserved, expected 0, is "
       << last_msg_->states[2].sid.reserved;
-  EXPECT_EQ(last_msg_->states[2].sid.sat, 208)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[2].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[2].sid.sat)),
+      208)
       << "incorrect value for states[2].sid.sat, expected 208, is "
       << last_msg_->states[2].sid.sat;
-  EXPECT_EQ(last_msg_->states[2].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[2].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[2].state)),
+            1)
       << "incorrect value for states[2].state, expected 1, is "
       << last_msg_->states[2].state;
   EXPECT_LT((last_msg_->states[3].cn0 * 100 - 39.0207290649 * 100), 0.05)
       << "incorrect value for states[3].cn0, expected 39.0207290649, is "
       << last_msg_->states[3].cn0;
-  EXPECT_EQ(last_msg_->states[3].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[3].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[3].sid.code)),
+      0)
       << "incorrect value for states[3].sid.code, expected 0, is "
       << last_msg_->states[3].sid.code;
-  EXPECT_EQ(last_msg_->states[3].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[3].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[3].sid.reserved)),
+            0)
       << "incorrect value for states[3].sid.reserved, expected 0, is "
       << last_msg_->states[3].sid.reserved;
-  EXPECT_EQ(last_msg_->states[3].sid.sat, 212)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[3].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[3].sid.sat)),
+      212)
       << "incorrect value for states[3].sid.sat, expected 212, is "
       << last_msg_->states[3].sid.sat;
-  EXPECT_EQ(last_msg_->states[3].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[3].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[3].state)),
+            1)
       << "incorrect value for states[3].state, expected 1, is "
       << last_msg_->states[3].state;
   EXPECT_LT((last_msg_->states[4].cn0 * 100 - 42.0329055786 * 100), 0.05)
       << "incorrect value for states[4].cn0, expected 42.0329055786, is "
       << last_msg_->states[4].cn0;
-  EXPECT_EQ(last_msg_->states[4].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[4].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[4].sid.code)),
+      0)
       << "incorrect value for states[4].sid.code, expected 0, is "
       << last_msg_->states[4].sid.code;
-  EXPECT_EQ(last_msg_->states[4].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[4].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[4].sid.reserved)),
+            0)
       << "incorrect value for states[4].sid.reserved, expected 0, is "
       << last_msg_->states[4].sid.reserved;
-  EXPECT_EQ(last_msg_->states[4].sid.sat, 217)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[4].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[4].sid.sat)),
+      217)
       << "incorrect value for states[4].sid.sat, expected 217, is "
       << last_msg_->states[4].sid.sat;
-  EXPECT_EQ(last_msg_->states[4].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[4].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[4].state)),
+            1)
       << "incorrect value for states[4].state, expected 1, is "
       << last_msg_->states[4].state;
   EXPECT_LT((last_msg_->states[5].cn0 * 100 - 37.4354667664 * 100), 0.05)
       << "incorrect value for states[5].cn0, expected 37.4354667664, is "
       << last_msg_->states[5].cn0;
-  EXPECT_EQ(last_msg_->states[5].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[5].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[5].sid.code)),
+      0)
       << "incorrect value for states[5].sid.code, expected 0, is "
       << last_msg_->states[5].sid.code;
-  EXPECT_EQ(last_msg_->states[5].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[5].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[5].sid.reserved)),
+            0)
       << "incorrect value for states[5].sid.reserved, expected 0, is "
       << last_msg_->states[5].sid.reserved;
-  EXPECT_EQ(last_msg_->states[5].sid.sat, 218)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[5].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[5].sid.sat)),
+      218)
       << "incorrect value for states[5].sid.sat, expected 218, is "
       << last_msg_->states[5].sid.sat;
-  EXPECT_EQ(last_msg_->states[5].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[5].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[5].state)),
+            1)
       << "incorrect value for states[5].state, expected 1, is "
       << last_msg_->states[5].state;
   EXPECT_LT((last_msg_->states[6].cn0 * 100 - 38.4229621887 * 100), 0.05)
       << "incorrect value for states[6].cn0, expected 38.4229621887, is "
       << last_msg_->states[6].cn0;
-  EXPECT_EQ(last_msg_->states[6].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[6].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[6].sid.code)),
+      0)
       << "incorrect value for states[6].sid.code, expected 0, is "
       << last_msg_->states[6].sid.code;
-  EXPECT_EQ(last_msg_->states[6].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[6].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[6].sid.reserved)),
+            0)
       << "incorrect value for states[6].sid.reserved, expected 0, is "
       << last_msg_->states[6].sid.reserved;
-  EXPECT_EQ(last_msg_->states[6].sid.sat, 220)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[6].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[6].sid.sat)),
+      220)
       << "incorrect value for states[6].sid.sat, expected 220, is "
       << last_msg_->states[6].sid.sat;
-  EXPECT_EQ(last_msg_->states[6].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[6].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[6].state)),
+            1)
       << "incorrect value for states[6].state, expected 1, is "
       << last_msg_->states[6].state;
   EXPECT_LT((last_msg_->states[7].cn0 * 100 - 38.9152030945 * 100), 0.05)
       << "incorrect value for states[7].cn0, expected 38.9152030945, is "
       << last_msg_->states[7].cn0;
-  EXPECT_EQ(last_msg_->states[7].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[7].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[7].sid.code)),
+      0)
       << "incorrect value for states[7].sid.code, expected 0, is "
       << last_msg_->states[7].sid.code;
-  EXPECT_EQ(last_msg_->states[7].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[7].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[7].sid.reserved)),
+            0)
       << "incorrect value for states[7].sid.reserved, expected 0, is "
       << last_msg_->states[7].sid.reserved;
-  EXPECT_EQ(last_msg_->states[7].sid.sat, 222)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[7].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[7].sid.sat)),
+      222)
       << "incorrect value for states[7].sid.sat, expected 222, is "
       << last_msg_->states[7].sid.sat;
-  EXPECT_EQ(last_msg_->states[7].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[7].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[7].state)),
+            1)
       << "incorrect value for states[7].state, expected 1, is "
       << last_msg_->states[7].state;
   EXPECT_LT((last_msg_->states[8].cn0 * 100 - 42.622592926 * 100), 0.05)
       << "incorrect value for states[8].cn0, expected 42.622592926, is "
       << last_msg_->states[8].cn0;
-  EXPECT_EQ(last_msg_->states[8].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[8].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[8].sid.code)),
+      0)
       << "incorrect value for states[8].sid.code, expected 0, is "
       << last_msg_->states[8].sid.code;
-  EXPECT_EQ(last_msg_->states[8].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[8].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[8].sid.reserved)),
+            0)
       << "incorrect value for states[8].sid.reserved, expected 0, is "
       << last_msg_->states[8].sid.reserved;
-  EXPECT_EQ(last_msg_->states[8].sid.sat, 225)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[8].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[8].sid.sat)),
+      225)
       << "incorrect value for states[8].sid.sat, expected 225, is "
       << last_msg_->states[8].sid.sat;
-  EXPECT_EQ(last_msg_->states[8].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[8].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[8].state)),
+            1)
       << "incorrect value for states[8].state, expected 1, is "
       << last_msg_->states[8].state;
   EXPECT_LT((last_msg_->states[9].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[9].cn0, expected -1.0, is "
       << last_msg_->states[9].cn0;
-  EXPECT_EQ(last_msg_->states[9].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[9].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[9].sid.code)),
+      0)
       << "incorrect value for states[9].sid.code, expected 0, is "
       << last_msg_->states[9].sid.code;
-  EXPECT_EQ(last_msg_->states[9].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[9].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[9].sid.reserved)),
+            0)
       << "incorrect value for states[9].sid.reserved, expected 0, is "
       << last_msg_->states[9].sid.reserved;
-  EXPECT_EQ(last_msg_->states[9].sid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[9].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[9].sid.sat)),
+      0)
       << "incorrect value for states[9].sid.sat, expected 0, is "
       << last_msg_->states[9].sid.sat;
-  EXPECT_EQ(last_msg_->states[9].state, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[9].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[9].state)),
+            0)
       << "incorrect value for states[9].state, expected 0, is "
       << last_msg_->states[9].state;
   EXPECT_LT((last_msg_->states[10].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[10].cn0, expected -1.0, is "
       << last_msg_->states[10].cn0;
-  EXPECT_EQ(last_msg_->states[10].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[10].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[10].sid.code)),
+      0)
       << "incorrect value for states[10].sid.code, expected 0, is "
       << last_msg_->states[10].sid.code;
-  EXPECT_EQ(last_msg_->states[10].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[10].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[10].sid.reserved)),
+            0)
       << "incorrect value for states[10].sid.reserved, expected 0, is "
       << last_msg_->states[10].sid.reserved;
-  EXPECT_EQ(last_msg_->states[10].sid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[10].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[10].sid.sat)),
+      0)
       << "incorrect value for states[10].sid.sat, expected 0, is "
       << last_msg_->states[10].sid.sat;
-  EXPECT_EQ(last_msg_->states[10].state, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[10].state)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[10].state)),
+      0)
       << "incorrect value for states[10].state, expected 0, is "
       << last_msg_->states[10].state;
 }
@@ -1932,166 +2691,288 @@ TEST_F(Test_legacy_auto_check_sbp_tracking_MsgTrackingState2, Test) {
   EXPECT_LT((last_msg_->states[0].cn0 * 100 - 38.9941177368 * 100), 0.05)
       << "incorrect value for states[0].cn0, expected 38.9941177368, is "
       << last_msg_->states[0].cn0;
-  EXPECT_EQ(last_msg_->states[0].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[0].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[0].sid.code)),
+      0)
       << "incorrect value for states[0].sid.code, expected 0, is "
       << last_msg_->states[0].sid.code;
-  EXPECT_EQ(last_msg_->states[0].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[0].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[0].sid.reserved)),
+            0)
       << "incorrect value for states[0].sid.reserved, expected 0, is "
       << last_msg_->states[0].sid.reserved;
-  EXPECT_EQ(last_msg_->states[0].sid.sat, 202)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[0].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[0].sid.sat)),
+      202)
       << "incorrect value for states[0].sid.sat, expected 202, is "
       << last_msg_->states[0].sid.sat;
-  EXPECT_EQ(last_msg_->states[0].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[0].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[0].state)),
+            1)
       << "incorrect value for states[0].state, expected 1, is "
       << last_msg_->states[0].state;
   EXPECT_LT((last_msg_->states[1].cn0 * 100 - 34.8898010254 * 100), 0.05)
       << "incorrect value for states[1].cn0, expected 34.8898010254, is "
       << last_msg_->states[1].cn0;
-  EXPECT_EQ(last_msg_->states[1].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[1].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[1].sid.code)),
+      0)
       << "incorrect value for states[1].sid.code, expected 0, is "
       << last_msg_->states[1].sid.code;
-  EXPECT_EQ(last_msg_->states[1].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[1].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[1].sid.reserved)),
+            0)
       << "incorrect value for states[1].sid.reserved, expected 0, is "
       << last_msg_->states[1].sid.reserved;
-  EXPECT_EQ(last_msg_->states[1].sid.sat, 203)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[1].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[1].sid.sat)),
+      203)
       << "incorrect value for states[1].sid.sat, expected 203, is "
       << last_msg_->states[1].sid.sat;
-  EXPECT_EQ(last_msg_->states[1].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[1].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[1].state)),
+            1)
       << "incorrect value for states[1].state, expected 1, is "
       << last_msg_->states[1].state;
   EXPECT_LT((last_msg_->states[2].cn0 * 100 - 37.4460372925 * 100), 0.05)
       << "incorrect value for states[2].cn0, expected 37.4460372925, is "
       << last_msg_->states[2].cn0;
-  EXPECT_EQ(last_msg_->states[2].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[2].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[2].sid.code)),
+      0)
       << "incorrect value for states[2].sid.code, expected 0, is "
       << last_msg_->states[2].sid.code;
-  EXPECT_EQ(last_msg_->states[2].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[2].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[2].sid.reserved)),
+            0)
       << "incorrect value for states[2].sid.reserved, expected 0, is "
       << last_msg_->states[2].sid.reserved;
-  EXPECT_EQ(last_msg_->states[2].sid.sat, 208)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[2].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[2].sid.sat)),
+      208)
       << "incorrect value for states[2].sid.sat, expected 208, is "
       << last_msg_->states[2].sid.sat;
-  EXPECT_EQ(last_msg_->states[2].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[2].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[2].state)),
+            1)
       << "incorrect value for states[2].state, expected 1, is "
       << last_msg_->states[2].state;
   EXPECT_LT((last_msg_->states[3].cn0 * 100 - 38.7284965515 * 100), 0.05)
       << "incorrect value for states[3].cn0, expected 38.7284965515, is "
       << last_msg_->states[3].cn0;
-  EXPECT_EQ(last_msg_->states[3].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[3].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[3].sid.code)),
+      0)
       << "incorrect value for states[3].sid.code, expected 0, is "
       << last_msg_->states[3].sid.code;
-  EXPECT_EQ(last_msg_->states[3].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[3].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[3].sid.reserved)),
+            0)
       << "incorrect value for states[3].sid.reserved, expected 0, is "
       << last_msg_->states[3].sid.reserved;
-  EXPECT_EQ(last_msg_->states[3].sid.sat, 212)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[3].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[3].sid.sat)),
+      212)
       << "incorrect value for states[3].sid.sat, expected 212, is "
       << last_msg_->states[3].sid.sat;
-  EXPECT_EQ(last_msg_->states[3].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[3].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[3].state)),
+            1)
       << "incorrect value for states[3].state, expected 1, is "
       << last_msg_->states[3].state;
   EXPECT_LT((last_msg_->states[4].cn0 * 100 - 41.9832191467 * 100), 0.05)
       << "incorrect value for states[4].cn0, expected 41.9832191467, is "
       << last_msg_->states[4].cn0;
-  EXPECT_EQ(last_msg_->states[4].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[4].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[4].sid.code)),
+      0)
       << "incorrect value for states[4].sid.code, expected 0, is "
       << last_msg_->states[4].sid.code;
-  EXPECT_EQ(last_msg_->states[4].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[4].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[4].sid.reserved)),
+            0)
       << "incorrect value for states[4].sid.reserved, expected 0, is "
       << last_msg_->states[4].sid.reserved;
-  EXPECT_EQ(last_msg_->states[4].sid.sat, 217)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[4].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[4].sid.sat)),
+      217)
       << "incorrect value for states[4].sid.sat, expected 217, is "
       << last_msg_->states[4].sid.sat;
-  EXPECT_EQ(last_msg_->states[4].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[4].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[4].state)),
+            1)
       << "incorrect value for states[4].state, expected 1, is "
       << last_msg_->states[4].state;
   EXPECT_LT((last_msg_->states[5].cn0 * 100 - 37.4644851685 * 100), 0.05)
       << "incorrect value for states[5].cn0, expected 37.4644851685, is "
       << last_msg_->states[5].cn0;
-  EXPECT_EQ(last_msg_->states[5].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[5].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[5].sid.code)),
+      0)
       << "incorrect value for states[5].sid.code, expected 0, is "
       << last_msg_->states[5].sid.code;
-  EXPECT_EQ(last_msg_->states[5].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[5].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[5].sid.reserved)),
+            0)
       << "incorrect value for states[5].sid.reserved, expected 0, is "
       << last_msg_->states[5].sid.reserved;
-  EXPECT_EQ(last_msg_->states[5].sid.sat, 218)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[5].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[5].sid.sat)),
+      218)
       << "incorrect value for states[5].sid.sat, expected 218, is "
       << last_msg_->states[5].sid.sat;
-  EXPECT_EQ(last_msg_->states[5].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[5].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[5].state)),
+            1)
       << "incorrect value for states[5].state, expected 1, is "
       << last_msg_->states[5].state;
   EXPECT_LT((last_msg_->states[6].cn0 * 100 - 38.4430007935 * 100), 0.05)
       << "incorrect value for states[6].cn0, expected 38.4430007935, is "
       << last_msg_->states[6].cn0;
-  EXPECT_EQ(last_msg_->states[6].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[6].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[6].sid.code)),
+      0)
       << "incorrect value for states[6].sid.code, expected 0, is "
       << last_msg_->states[6].sid.code;
-  EXPECT_EQ(last_msg_->states[6].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[6].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[6].sid.reserved)),
+            0)
       << "incorrect value for states[6].sid.reserved, expected 0, is "
       << last_msg_->states[6].sid.reserved;
-  EXPECT_EQ(last_msg_->states[6].sid.sat, 220)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[6].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[6].sid.sat)),
+      220)
       << "incorrect value for states[6].sid.sat, expected 220, is "
       << last_msg_->states[6].sid.sat;
-  EXPECT_EQ(last_msg_->states[6].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[6].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[6].state)),
+            1)
       << "incorrect value for states[6].state, expected 1, is "
       << last_msg_->states[6].state;
   EXPECT_LT((last_msg_->states[7].cn0 * 100 - 39.0342330933 * 100), 0.05)
       << "incorrect value for states[7].cn0, expected 39.0342330933, is "
       << last_msg_->states[7].cn0;
-  EXPECT_EQ(last_msg_->states[7].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[7].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[7].sid.code)),
+      0)
       << "incorrect value for states[7].sid.code, expected 0, is "
       << last_msg_->states[7].sid.code;
-  EXPECT_EQ(last_msg_->states[7].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[7].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[7].sid.reserved)),
+            0)
       << "incorrect value for states[7].sid.reserved, expected 0, is "
       << last_msg_->states[7].sid.reserved;
-  EXPECT_EQ(last_msg_->states[7].sid.sat, 222)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[7].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[7].sid.sat)),
+      222)
       << "incorrect value for states[7].sid.sat, expected 222, is "
       << last_msg_->states[7].sid.sat;
-  EXPECT_EQ(last_msg_->states[7].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[7].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[7].state)),
+            1)
       << "incorrect value for states[7].state, expected 1, is "
       << last_msg_->states[7].state;
   EXPECT_LT((last_msg_->states[8].cn0 * 100 - 42.8994483948 * 100), 0.05)
       << "incorrect value for states[8].cn0, expected 42.8994483948, is "
       << last_msg_->states[8].cn0;
-  EXPECT_EQ(last_msg_->states[8].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[8].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[8].sid.code)),
+      0)
       << "incorrect value for states[8].sid.code, expected 0, is "
       << last_msg_->states[8].sid.code;
-  EXPECT_EQ(last_msg_->states[8].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[8].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[8].sid.reserved)),
+            0)
       << "incorrect value for states[8].sid.reserved, expected 0, is "
       << last_msg_->states[8].sid.reserved;
-  EXPECT_EQ(last_msg_->states[8].sid.sat, 225)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[8].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[8].sid.sat)),
+      225)
       << "incorrect value for states[8].sid.sat, expected 225, is "
       << last_msg_->states[8].sid.sat;
-  EXPECT_EQ(last_msg_->states[8].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[8].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[8].state)),
+            1)
       << "incorrect value for states[8].state, expected 1, is "
       << last_msg_->states[8].state;
   EXPECT_LT((last_msg_->states[9].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[9].cn0, expected -1.0, is "
       << last_msg_->states[9].cn0;
-  EXPECT_EQ(last_msg_->states[9].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[9].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[9].sid.code)),
+      0)
       << "incorrect value for states[9].sid.code, expected 0, is "
       << last_msg_->states[9].sid.code;
-  EXPECT_EQ(last_msg_->states[9].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[9].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[9].sid.reserved)),
+            0)
       << "incorrect value for states[9].sid.reserved, expected 0, is "
       << last_msg_->states[9].sid.reserved;
-  EXPECT_EQ(last_msg_->states[9].sid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[9].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[9].sid.sat)),
+      0)
       << "incorrect value for states[9].sid.sat, expected 0, is "
       << last_msg_->states[9].sid.sat;
-  EXPECT_EQ(last_msg_->states[9].state, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[9].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[9].state)),
+            0)
       << "incorrect value for states[9].state, expected 0, is "
       << last_msg_->states[9].state;
   EXPECT_LT((last_msg_->states[10].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[10].cn0, expected -1.0, is "
       << last_msg_->states[10].cn0;
-  EXPECT_EQ(last_msg_->states[10].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[10].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[10].sid.code)),
+      0)
       << "incorrect value for states[10].sid.code, expected 0, is "
       << last_msg_->states[10].sid.code;
-  EXPECT_EQ(last_msg_->states[10].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[10].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[10].sid.reserved)),
+            0)
       << "incorrect value for states[10].sid.reserved, expected 0, is "
       << last_msg_->states[10].sid.reserved;
-  EXPECT_EQ(last_msg_->states[10].sid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[10].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[10].sid.sat)),
+      0)
       << "incorrect value for states[10].sid.sat, expected 0, is "
       << last_msg_->states[10].sid.sat;
-  EXPECT_EQ(last_msg_->states[10].state, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[10].state)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[10].state)),
+      0)
       << "incorrect value for states[10].state, expected 0, is "
       << last_msg_->states[10].state;
 }
@@ -2286,166 +3167,288 @@ TEST_F(Test_legacy_auto_check_sbp_tracking_MsgTrackingState3, Test) {
   EXPECT_LT((last_msg_->states[0].cn0 * 100 - 38.9545707703 * 100), 0.05)
       << "incorrect value for states[0].cn0, expected 38.9545707703, is "
       << last_msg_->states[0].cn0;
-  EXPECT_EQ(last_msg_->states[0].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[0].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[0].sid.code)),
+      0)
       << "incorrect value for states[0].sid.code, expected 0, is "
       << last_msg_->states[0].sid.code;
-  EXPECT_EQ(last_msg_->states[0].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[0].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[0].sid.reserved)),
+            0)
       << "incorrect value for states[0].sid.reserved, expected 0, is "
       << last_msg_->states[0].sid.reserved;
-  EXPECT_EQ(last_msg_->states[0].sid.sat, 202)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[0].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[0].sid.sat)),
+      202)
       << "incorrect value for states[0].sid.sat, expected 202, is "
       << last_msg_->states[0].sid.sat;
-  EXPECT_EQ(last_msg_->states[0].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[0].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[0].state)),
+            1)
       << "incorrect value for states[0].state, expected 1, is "
       << last_msg_->states[0].state;
   EXPECT_LT((last_msg_->states[1].cn0 * 100 - 35.8133163452 * 100), 0.05)
       << "incorrect value for states[1].cn0, expected 35.8133163452, is "
       << last_msg_->states[1].cn0;
-  EXPECT_EQ(last_msg_->states[1].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[1].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[1].sid.code)),
+      0)
       << "incorrect value for states[1].sid.code, expected 0, is "
       << last_msg_->states[1].sid.code;
-  EXPECT_EQ(last_msg_->states[1].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[1].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[1].sid.reserved)),
+            0)
       << "incorrect value for states[1].sid.reserved, expected 0, is "
       << last_msg_->states[1].sid.reserved;
-  EXPECT_EQ(last_msg_->states[1].sid.sat, 203)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[1].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[1].sid.sat)),
+      203)
       << "incorrect value for states[1].sid.sat, expected 203, is "
       << last_msg_->states[1].sid.sat;
-  EXPECT_EQ(last_msg_->states[1].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[1].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[1].state)),
+            1)
       << "incorrect value for states[1].state, expected 1, is "
       << last_msg_->states[1].state;
   EXPECT_LT((last_msg_->states[2].cn0 * 100 - 37.5539245605 * 100), 0.05)
       << "incorrect value for states[2].cn0, expected 37.5539245605, is "
       << last_msg_->states[2].cn0;
-  EXPECT_EQ(last_msg_->states[2].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[2].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[2].sid.code)),
+      0)
       << "incorrect value for states[2].sid.code, expected 0, is "
       << last_msg_->states[2].sid.code;
-  EXPECT_EQ(last_msg_->states[2].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[2].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[2].sid.reserved)),
+            0)
       << "incorrect value for states[2].sid.reserved, expected 0, is "
       << last_msg_->states[2].sid.reserved;
-  EXPECT_EQ(last_msg_->states[2].sid.sat, 208)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[2].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[2].sid.sat)),
+      208)
       << "incorrect value for states[2].sid.sat, expected 208, is "
       << last_msg_->states[2].sid.sat;
-  EXPECT_EQ(last_msg_->states[2].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[2].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[2].state)),
+            1)
       << "incorrect value for states[2].state, expected 1, is "
       << last_msg_->states[2].state;
   EXPECT_LT((last_msg_->states[3].cn0 * 100 - 38.8890190125 * 100), 0.05)
       << "incorrect value for states[3].cn0, expected 38.8890190125, is "
       << last_msg_->states[3].cn0;
-  EXPECT_EQ(last_msg_->states[3].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[3].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[3].sid.code)),
+      0)
       << "incorrect value for states[3].sid.code, expected 0, is "
       << last_msg_->states[3].sid.code;
-  EXPECT_EQ(last_msg_->states[3].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[3].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[3].sid.reserved)),
+            0)
       << "incorrect value for states[3].sid.reserved, expected 0, is "
       << last_msg_->states[3].sid.reserved;
-  EXPECT_EQ(last_msg_->states[3].sid.sat, 212)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[3].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[3].sid.sat)),
+      212)
       << "incorrect value for states[3].sid.sat, expected 212, is "
       << last_msg_->states[3].sid.sat;
-  EXPECT_EQ(last_msg_->states[3].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[3].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[3].state)),
+            1)
       << "incorrect value for states[3].state, expected 1, is "
       << last_msg_->states[3].state;
   EXPECT_LT((last_msg_->states[4].cn0 * 100 - 42.4013557434 * 100), 0.05)
       << "incorrect value for states[4].cn0, expected 42.4013557434, is "
       << last_msg_->states[4].cn0;
-  EXPECT_EQ(last_msg_->states[4].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[4].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[4].sid.code)),
+      0)
       << "incorrect value for states[4].sid.code, expected 0, is "
       << last_msg_->states[4].sid.code;
-  EXPECT_EQ(last_msg_->states[4].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[4].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[4].sid.reserved)),
+            0)
       << "incorrect value for states[4].sid.reserved, expected 0, is "
       << last_msg_->states[4].sid.reserved;
-  EXPECT_EQ(last_msg_->states[4].sid.sat, 217)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[4].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[4].sid.sat)),
+      217)
       << "incorrect value for states[4].sid.sat, expected 217, is "
       << last_msg_->states[4].sid.sat;
-  EXPECT_EQ(last_msg_->states[4].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[4].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[4].state)),
+            1)
       << "incorrect value for states[4].state, expected 1, is "
       << last_msg_->states[4].state;
   EXPECT_LT((last_msg_->states[5].cn0 * 100 - 37.6391601562 * 100), 0.05)
       << "incorrect value for states[5].cn0, expected 37.6391601562, is "
       << last_msg_->states[5].cn0;
-  EXPECT_EQ(last_msg_->states[5].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[5].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[5].sid.code)),
+      0)
       << "incorrect value for states[5].sid.code, expected 0, is "
       << last_msg_->states[5].sid.code;
-  EXPECT_EQ(last_msg_->states[5].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[5].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[5].sid.reserved)),
+            0)
       << "incorrect value for states[5].sid.reserved, expected 0, is "
       << last_msg_->states[5].sid.reserved;
-  EXPECT_EQ(last_msg_->states[5].sid.sat, 218)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[5].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[5].sid.sat)),
+      218)
       << "incorrect value for states[5].sid.sat, expected 218, is "
       << last_msg_->states[5].sid.sat;
-  EXPECT_EQ(last_msg_->states[5].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[5].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[5].state)),
+            1)
       << "incorrect value for states[5].state, expected 1, is "
       << last_msg_->states[5].state;
   EXPECT_LT((last_msg_->states[6].cn0 * 100 - 37.9199867249 * 100), 0.05)
       << "incorrect value for states[6].cn0, expected 37.9199867249, is "
       << last_msg_->states[6].cn0;
-  EXPECT_EQ(last_msg_->states[6].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[6].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[6].sid.code)),
+      0)
       << "incorrect value for states[6].sid.code, expected 0, is "
       << last_msg_->states[6].sid.code;
-  EXPECT_EQ(last_msg_->states[6].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[6].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[6].sid.reserved)),
+            0)
       << "incorrect value for states[6].sid.reserved, expected 0, is "
       << last_msg_->states[6].sid.reserved;
-  EXPECT_EQ(last_msg_->states[6].sid.sat, 220)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[6].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[6].sid.sat)),
+      220)
       << "incorrect value for states[6].sid.sat, expected 220, is "
       << last_msg_->states[6].sid.sat;
-  EXPECT_EQ(last_msg_->states[6].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[6].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[6].state)),
+            1)
       << "incorrect value for states[6].state, expected 1, is "
       << last_msg_->states[6].state;
   EXPECT_LT((last_msg_->states[7].cn0 * 100 - 39.2525444031 * 100), 0.05)
       << "incorrect value for states[7].cn0, expected 39.2525444031, is "
       << last_msg_->states[7].cn0;
-  EXPECT_EQ(last_msg_->states[7].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[7].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[7].sid.code)),
+      0)
       << "incorrect value for states[7].sid.code, expected 0, is "
       << last_msg_->states[7].sid.code;
-  EXPECT_EQ(last_msg_->states[7].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[7].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[7].sid.reserved)),
+            0)
       << "incorrect value for states[7].sid.reserved, expected 0, is "
       << last_msg_->states[7].sid.reserved;
-  EXPECT_EQ(last_msg_->states[7].sid.sat, 222)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[7].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[7].sid.sat)),
+      222)
       << "incorrect value for states[7].sid.sat, expected 222, is "
       << last_msg_->states[7].sid.sat;
-  EXPECT_EQ(last_msg_->states[7].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[7].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[7].state)),
+            1)
       << "incorrect value for states[7].state, expected 1, is "
       << last_msg_->states[7].state;
   EXPECT_LT((last_msg_->states[8].cn0 * 100 - 42.598274231 * 100), 0.05)
       << "incorrect value for states[8].cn0, expected 42.598274231, is "
       << last_msg_->states[8].cn0;
-  EXPECT_EQ(last_msg_->states[8].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[8].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[8].sid.code)),
+      0)
       << "incorrect value for states[8].sid.code, expected 0, is "
       << last_msg_->states[8].sid.code;
-  EXPECT_EQ(last_msg_->states[8].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[8].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[8].sid.reserved)),
+            0)
       << "incorrect value for states[8].sid.reserved, expected 0, is "
       << last_msg_->states[8].sid.reserved;
-  EXPECT_EQ(last_msg_->states[8].sid.sat, 225)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[8].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[8].sid.sat)),
+      225)
       << "incorrect value for states[8].sid.sat, expected 225, is "
       << last_msg_->states[8].sid.sat;
-  EXPECT_EQ(last_msg_->states[8].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[8].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[8].state)),
+            1)
       << "incorrect value for states[8].state, expected 1, is "
       << last_msg_->states[8].state;
   EXPECT_LT((last_msg_->states[9].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[9].cn0, expected -1.0, is "
       << last_msg_->states[9].cn0;
-  EXPECT_EQ(last_msg_->states[9].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[9].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[9].sid.code)),
+      0)
       << "incorrect value for states[9].sid.code, expected 0, is "
       << last_msg_->states[9].sid.code;
-  EXPECT_EQ(last_msg_->states[9].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[9].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[9].sid.reserved)),
+            0)
       << "incorrect value for states[9].sid.reserved, expected 0, is "
       << last_msg_->states[9].sid.reserved;
-  EXPECT_EQ(last_msg_->states[9].sid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[9].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[9].sid.sat)),
+      0)
       << "incorrect value for states[9].sid.sat, expected 0, is "
       << last_msg_->states[9].sid.sat;
-  EXPECT_EQ(last_msg_->states[9].state, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[9].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[9].state)),
+            0)
       << "incorrect value for states[9].state, expected 0, is "
       << last_msg_->states[9].state;
   EXPECT_LT((last_msg_->states[10].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[10].cn0, expected -1.0, is "
       << last_msg_->states[10].cn0;
-  EXPECT_EQ(last_msg_->states[10].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[10].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[10].sid.code)),
+      0)
       << "incorrect value for states[10].sid.code, expected 0, is "
       << last_msg_->states[10].sid.code;
-  EXPECT_EQ(last_msg_->states[10].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[10].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[10].sid.reserved)),
+            0)
       << "incorrect value for states[10].sid.reserved, expected 0, is "
       << last_msg_->states[10].sid.reserved;
-  EXPECT_EQ(last_msg_->states[10].sid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[10].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[10].sid.sat)),
+      0)
       << "incorrect value for states[10].sid.sat, expected 0, is "
       << last_msg_->states[10].sid.sat;
-  EXPECT_EQ(last_msg_->states[10].state, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[10].state)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[10].state)),
+      0)
       << "incorrect value for states[10].state, expected 0, is "
       << last_msg_->states[10].state;
 }
@@ -2640,166 +3643,288 @@ TEST_F(Test_legacy_auto_check_sbp_tracking_MsgTrackingState4, Test) {
   EXPECT_LT((last_msg_->states[0].cn0 * 100 - 39.3695983887 * 100), 0.05)
       << "incorrect value for states[0].cn0, expected 39.3695983887, is "
       << last_msg_->states[0].cn0;
-  EXPECT_EQ(last_msg_->states[0].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[0].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[0].sid.code)),
+      0)
       << "incorrect value for states[0].sid.code, expected 0, is "
       << last_msg_->states[0].sid.code;
-  EXPECT_EQ(last_msg_->states[0].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[0].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[0].sid.reserved)),
+            0)
       << "incorrect value for states[0].sid.reserved, expected 0, is "
       << last_msg_->states[0].sid.reserved;
-  EXPECT_EQ(last_msg_->states[0].sid.sat, 202)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[0].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[0].sid.sat)),
+      202)
       << "incorrect value for states[0].sid.sat, expected 202, is "
       << last_msg_->states[0].sid.sat;
-  EXPECT_EQ(last_msg_->states[0].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[0].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[0].state)),
+            1)
       << "incorrect value for states[0].state, expected 1, is "
       << last_msg_->states[0].state;
   EXPECT_LT((last_msg_->states[1].cn0 * 100 - 36.521736145 * 100), 0.05)
       << "incorrect value for states[1].cn0, expected 36.521736145, is "
       << last_msg_->states[1].cn0;
-  EXPECT_EQ(last_msg_->states[1].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[1].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[1].sid.code)),
+      0)
       << "incorrect value for states[1].sid.code, expected 0, is "
       << last_msg_->states[1].sid.code;
-  EXPECT_EQ(last_msg_->states[1].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[1].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[1].sid.reserved)),
+            0)
       << "incorrect value for states[1].sid.reserved, expected 0, is "
       << last_msg_->states[1].sid.reserved;
-  EXPECT_EQ(last_msg_->states[1].sid.sat, 203)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[1].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[1].sid.sat)),
+      203)
       << "incorrect value for states[1].sid.sat, expected 203, is "
       << last_msg_->states[1].sid.sat;
-  EXPECT_EQ(last_msg_->states[1].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[1].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[1].state)),
+            1)
       << "incorrect value for states[1].state, expected 1, is "
       << last_msg_->states[1].state;
   EXPECT_LT((last_msg_->states[2].cn0 * 100 - 38.1597633362 * 100), 0.05)
       << "incorrect value for states[2].cn0, expected 38.1597633362, is "
       << last_msg_->states[2].cn0;
-  EXPECT_EQ(last_msg_->states[2].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[2].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[2].sid.code)),
+      0)
       << "incorrect value for states[2].sid.code, expected 0, is "
       << last_msg_->states[2].sid.code;
-  EXPECT_EQ(last_msg_->states[2].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[2].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[2].sid.reserved)),
+            0)
       << "incorrect value for states[2].sid.reserved, expected 0, is "
       << last_msg_->states[2].sid.reserved;
-  EXPECT_EQ(last_msg_->states[2].sid.sat, 208)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[2].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[2].sid.sat)),
+      208)
       << "incorrect value for states[2].sid.sat, expected 208, is "
       << last_msg_->states[2].sid.sat;
-  EXPECT_EQ(last_msg_->states[2].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[2].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[2].state)),
+            1)
       << "incorrect value for states[2].state, expected 1, is "
       << last_msg_->states[2].state;
   EXPECT_LT((last_msg_->states[3].cn0 * 100 - 39.1998977661 * 100), 0.05)
       << "incorrect value for states[3].cn0, expected 39.1998977661, is "
       << last_msg_->states[3].cn0;
-  EXPECT_EQ(last_msg_->states[3].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[3].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[3].sid.code)),
+      0)
       << "incorrect value for states[3].sid.code, expected 0, is "
       << last_msg_->states[3].sid.code;
-  EXPECT_EQ(last_msg_->states[3].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[3].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[3].sid.reserved)),
+            0)
       << "incorrect value for states[3].sid.reserved, expected 0, is "
       << last_msg_->states[3].sid.reserved;
-  EXPECT_EQ(last_msg_->states[3].sid.sat, 212)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[3].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[3].sid.sat)),
+      212)
       << "incorrect value for states[3].sid.sat, expected 212, is "
       << last_msg_->states[3].sid.sat;
-  EXPECT_EQ(last_msg_->states[3].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[3].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[3].state)),
+            1)
       << "incorrect value for states[3].state, expected 1, is "
       << last_msg_->states[3].state;
   EXPECT_LT((last_msg_->states[4].cn0 * 100 - 41.5584564209 * 100), 0.05)
       << "incorrect value for states[4].cn0, expected 41.5584564209, is "
       << last_msg_->states[4].cn0;
-  EXPECT_EQ(last_msg_->states[4].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[4].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[4].sid.code)),
+      0)
       << "incorrect value for states[4].sid.code, expected 0, is "
       << last_msg_->states[4].sid.code;
-  EXPECT_EQ(last_msg_->states[4].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[4].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[4].sid.reserved)),
+            0)
       << "incorrect value for states[4].sid.reserved, expected 0, is "
       << last_msg_->states[4].sid.reserved;
-  EXPECT_EQ(last_msg_->states[4].sid.sat, 217)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[4].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[4].sid.sat)),
+      217)
       << "incorrect value for states[4].sid.sat, expected 217, is "
       << last_msg_->states[4].sid.sat;
-  EXPECT_EQ(last_msg_->states[4].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[4].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[4].state)),
+            1)
       << "incorrect value for states[4].state, expected 1, is "
       << last_msg_->states[4].state;
   EXPECT_LT((last_msg_->states[5].cn0 * 100 - 37.0269813538 * 100), 0.05)
       << "incorrect value for states[5].cn0, expected 37.0269813538, is "
       << last_msg_->states[5].cn0;
-  EXPECT_EQ(last_msg_->states[5].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[5].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[5].sid.code)),
+      0)
       << "incorrect value for states[5].sid.code, expected 0, is "
       << last_msg_->states[5].sid.code;
-  EXPECT_EQ(last_msg_->states[5].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[5].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[5].sid.reserved)),
+            0)
       << "incorrect value for states[5].sid.reserved, expected 0, is "
       << last_msg_->states[5].sid.reserved;
-  EXPECT_EQ(last_msg_->states[5].sid.sat, 218)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[5].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[5].sid.sat)),
+      218)
       << "incorrect value for states[5].sid.sat, expected 218, is "
       << last_msg_->states[5].sid.sat;
-  EXPECT_EQ(last_msg_->states[5].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[5].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[5].state)),
+            1)
       << "incorrect value for states[5].state, expected 1, is "
       << last_msg_->states[5].state;
   EXPECT_LT((last_msg_->states[6].cn0 * 100 - 38.1049690247 * 100), 0.05)
       << "incorrect value for states[6].cn0, expected 38.1049690247, is "
       << last_msg_->states[6].cn0;
-  EXPECT_EQ(last_msg_->states[6].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[6].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[6].sid.code)),
+      0)
       << "incorrect value for states[6].sid.code, expected 0, is "
       << last_msg_->states[6].sid.code;
-  EXPECT_EQ(last_msg_->states[6].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[6].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[6].sid.reserved)),
+            0)
       << "incorrect value for states[6].sid.reserved, expected 0, is "
       << last_msg_->states[6].sid.reserved;
-  EXPECT_EQ(last_msg_->states[6].sid.sat, 220)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[6].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[6].sid.sat)),
+      220)
       << "incorrect value for states[6].sid.sat, expected 220, is "
       << last_msg_->states[6].sid.sat;
-  EXPECT_EQ(last_msg_->states[6].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[6].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[6].state)),
+            1)
       << "incorrect value for states[6].state, expected 1, is "
       << last_msg_->states[6].state;
   EXPECT_LT((last_msg_->states[7].cn0 * 100 - 39.0458450317 * 100), 0.05)
       << "incorrect value for states[7].cn0, expected 39.0458450317, is "
       << last_msg_->states[7].cn0;
-  EXPECT_EQ(last_msg_->states[7].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[7].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[7].sid.code)),
+      0)
       << "incorrect value for states[7].sid.code, expected 0, is "
       << last_msg_->states[7].sid.code;
-  EXPECT_EQ(last_msg_->states[7].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[7].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[7].sid.reserved)),
+            0)
       << "incorrect value for states[7].sid.reserved, expected 0, is "
       << last_msg_->states[7].sid.reserved;
-  EXPECT_EQ(last_msg_->states[7].sid.sat, 222)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[7].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[7].sid.sat)),
+      222)
       << "incorrect value for states[7].sid.sat, expected 222, is "
       << last_msg_->states[7].sid.sat;
-  EXPECT_EQ(last_msg_->states[7].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[7].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[7].state)),
+            1)
       << "incorrect value for states[7].state, expected 1, is "
       << last_msg_->states[7].state;
   EXPECT_LT((last_msg_->states[8].cn0 * 100 - 42.3778343201 * 100), 0.05)
       << "incorrect value for states[8].cn0, expected 42.3778343201, is "
       << last_msg_->states[8].cn0;
-  EXPECT_EQ(last_msg_->states[8].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[8].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[8].sid.code)),
+      0)
       << "incorrect value for states[8].sid.code, expected 0, is "
       << last_msg_->states[8].sid.code;
-  EXPECT_EQ(last_msg_->states[8].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[8].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[8].sid.reserved)),
+            0)
       << "incorrect value for states[8].sid.reserved, expected 0, is "
       << last_msg_->states[8].sid.reserved;
-  EXPECT_EQ(last_msg_->states[8].sid.sat, 225)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[8].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[8].sid.sat)),
+      225)
       << "incorrect value for states[8].sid.sat, expected 225, is "
       << last_msg_->states[8].sid.sat;
-  EXPECT_EQ(last_msg_->states[8].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[8].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[8].state)),
+            1)
       << "incorrect value for states[8].state, expected 1, is "
       << last_msg_->states[8].state;
   EXPECT_LT((last_msg_->states[9].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[9].cn0, expected -1.0, is "
       << last_msg_->states[9].cn0;
-  EXPECT_EQ(last_msg_->states[9].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[9].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[9].sid.code)),
+      0)
       << "incorrect value for states[9].sid.code, expected 0, is "
       << last_msg_->states[9].sid.code;
-  EXPECT_EQ(last_msg_->states[9].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[9].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[9].sid.reserved)),
+            0)
       << "incorrect value for states[9].sid.reserved, expected 0, is "
       << last_msg_->states[9].sid.reserved;
-  EXPECT_EQ(last_msg_->states[9].sid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[9].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[9].sid.sat)),
+      0)
       << "incorrect value for states[9].sid.sat, expected 0, is "
       << last_msg_->states[9].sid.sat;
-  EXPECT_EQ(last_msg_->states[9].state, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[9].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[9].state)),
+            0)
       << "incorrect value for states[9].state, expected 0, is "
       << last_msg_->states[9].state;
   EXPECT_LT((last_msg_->states[10].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[10].cn0, expected -1.0, is "
       << last_msg_->states[10].cn0;
-  EXPECT_EQ(last_msg_->states[10].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[10].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[10].sid.code)),
+      0)
       << "incorrect value for states[10].sid.code, expected 0, is "
       << last_msg_->states[10].sid.code;
-  EXPECT_EQ(last_msg_->states[10].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[10].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[10].sid.reserved)),
+            0)
       << "incorrect value for states[10].sid.reserved, expected 0, is "
       << last_msg_->states[10].sid.reserved;
-  EXPECT_EQ(last_msg_->states[10].sid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[10].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[10].sid.sat)),
+      0)
       << "incorrect value for states[10].sid.sat, expected 0, is "
       << last_msg_->states[10].sid.sat;
-  EXPECT_EQ(last_msg_->states[10].state, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[10].state)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[10].state)),
+      0)
       << "incorrect value for states[10].state, expected 0, is "
       << last_msg_->states[10].state;
 }
@@ -2994,166 +4119,288 @@ TEST_F(Test_legacy_auto_check_sbp_tracking_MsgTrackingState5, Test) {
   EXPECT_LT((last_msg_->states[0].cn0 * 100 - 39.7035179138 * 100), 0.05)
       << "incorrect value for states[0].cn0, expected 39.7035179138, is "
       << last_msg_->states[0].cn0;
-  EXPECT_EQ(last_msg_->states[0].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[0].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[0].sid.code)),
+      0)
       << "incorrect value for states[0].sid.code, expected 0, is "
       << last_msg_->states[0].sid.code;
-  EXPECT_EQ(last_msg_->states[0].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[0].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[0].sid.reserved)),
+            0)
       << "incorrect value for states[0].sid.reserved, expected 0, is "
       << last_msg_->states[0].sid.reserved;
-  EXPECT_EQ(last_msg_->states[0].sid.sat, 202)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[0].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[0].sid.sat)),
+      202)
       << "incorrect value for states[0].sid.sat, expected 202, is "
       << last_msg_->states[0].sid.sat;
-  EXPECT_EQ(last_msg_->states[0].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[0].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[0].state)),
+            1)
       << "incorrect value for states[0].state, expected 1, is "
       << last_msg_->states[0].state;
   EXPECT_LT((last_msg_->states[1].cn0 * 100 - 36.5238838196 * 100), 0.05)
       << "incorrect value for states[1].cn0, expected 36.5238838196, is "
       << last_msg_->states[1].cn0;
-  EXPECT_EQ(last_msg_->states[1].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[1].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[1].sid.code)),
+      0)
       << "incorrect value for states[1].sid.code, expected 0, is "
       << last_msg_->states[1].sid.code;
-  EXPECT_EQ(last_msg_->states[1].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[1].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[1].sid.reserved)),
+            0)
       << "incorrect value for states[1].sid.reserved, expected 0, is "
       << last_msg_->states[1].sid.reserved;
-  EXPECT_EQ(last_msg_->states[1].sid.sat, 203)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[1].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[1].sid.sat)),
+      203)
       << "incorrect value for states[1].sid.sat, expected 203, is "
       << last_msg_->states[1].sid.sat;
-  EXPECT_EQ(last_msg_->states[1].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[1].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[1].state)),
+            1)
       << "incorrect value for states[1].state, expected 1, is "
       << last_msg_->states[1].state;
   EXPECT_LT((last_msg_->states[2].cn0 * 100 - 37.169708252 * 100), 0.05)
       << "incorrect value for states[2].cn0, expected 37.169708252, is "
       << last_msg_->states[2].cn0;
-  EXPECT_EQ(last_msg_->states[2].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[2].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[2].sid.code)),
+      0)
       << "incorrect value for states[2].sid.code, expected 0, is "
       << last_msg_->states[2].sid.code;
-  EXPECT_EQ(last_msg_->states[2].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[2].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[2].sid.reserved)),
+            0)
       << "incorrect value for states[2].sid.reserved, expected 0, is "
       << last_msg_->states[2].sid.reserved;
-  EXPECT_EQ(last_msg_->states[2].sid.sat, 208)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[2].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[2].sid.sat)),
+      208)
       << "incorrect value for states[2].sid.sat, expected 208, is "
       << last_msg_->states[2].sid.sat;
-  EXPECT_EQ(last_msg_->states[2].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[2].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[2].state)),
+            1)
       << "incorrect value for states[2].state, expected 1, is "
       << last_msg_->states[2].state;
   EXPECT_LT((last_msg_->states[3].cn0 * 100 - 38.8169288635 * 100), 0.05)
       << "incorrect value for states[3].cn0, expected 38.8169288635, is "
       << last_msg_->states[3].cn0;
-  EXPECT_EQ(last_msg_->states[3].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[3].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[3].sid.code)),
+      0)
       << "incorrect value for states[3].sid.code, expected 0, is "
       << last_msg_->states[3].sid.code;
-  EXPECT_EQ(last_msg_->states[3].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[3].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[3].sid.reserved)),
+            0)
       << "incorrect value for states[3].sid.reserved, expected 0, is "
       << last_msg_->states[3].sid.reserved;
-  EXPECT_EQ(last_msg_->states[3].sid.sat, 212)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[3].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[3].sid.sat)),
+      212)
       << "incorrect value for states[3].sid.sat, expected 212, is "
       << last_msg_->states[3].sid.sat;
-  EXPECT_EQ(last_msg_->states[3].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[3].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[3].state)),
+            1)
       << "incorrect value for states[3].state, expected 1, is "
       << last_msg_->states[3].state;
   EXPECT_LT((last_msg_->states[4].cn0 * 100 - 42.0507316589 * 100), 0.05)
       << "incorrect value for states[4].cn0, expected 42.0507316589, is "
       << last_msg_->states[4].cn0;
-  EXPECT_EQ(last_msg_->states[4].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[4].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[4].sid.code)),
+      0)
       << "incorrect value for states[4].sid.code, expected 0, is "
       << last_msg_->states[4].sid.code;
-  EXPECT_EQ(last_msg_->states[4].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[4].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[4].sid.reserved)),
+            0)
       << "incorrect value for states[4].sid.reserved, expected 0, is "
       << last_msg_->states[4].sid.reserved;
-  EXPECT_EQ(last_msg_->states[4].sid.sat, 217)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[4].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[4].sid.sat)),
+      217)
       << "incorrect value for states[4].sid.sat, expected 217, is "
       << last_msg_->states[4].sid.sat;
-  EXPECT_EQ(last_msg_->states[4].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[4].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[4].state)),
+            1)
       << "incorrect value for states[4].state, expected 1, is "
       << last_msg_->states[4].state;
   EXPECT_LT((last_msg_->states[5].cn0 * 100 - 37.8074989319 * 100), 0.05)
       << "incorrect value for states[5].cn0, expected 37.8074989319, is "
       << last_msg_->states[5].cn0;
-  EXPECT_EQ(last_msg_->states[5].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[5].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[5].sid.code)),
+      0)
       << "incorrect value for states[5].sid.code, expected 0, is "
       << last_msg_->states[5].sid.code;
-  EXPECT_EQ(last_msg_->states[5].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[5].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[5].sid.reserved)),
+            0)
       << "incorrect value for states[5].sid.reserved, expected 0, is "
       << last_msg_->states[5].sid.reserved;
-  EXPECT_EQ(last_msg_->states[5].sid.sat, 218)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[5].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[5].sid.sat)),
+      218)
       << "incorrect value for states[5].sid.sat, expected 218, is "
       << last_msg_->states[5].sid.sat;
-  EXPECT_EQ(last_msg_->states[5].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[5].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[5].state)),
+            1)
       << "incorrect value for states[5].state, expected 1, is "
       << last_msg_->states[5].state;
   EXPECT_LT((last_msg_->states[6].cn0 * 100 - 37.7163238525 * 100), 0.05)
       << "incorrect value for states[6].cn0, expected 37.7163238525, is "
       << last_msg_->states[6].cn0;
-  EXPECT_EQ(last_msg_->states[6].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[6].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[6].sid.code)),
+      0)
       << "incorrect value for states[6].sid.code, expected 0, is "
       << last_msg_->states[6].sid.code;
-  EXPECT_EQ(last_msg_->states[6].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[6].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[6].sid.reserved)),
+            0)
       << "incorrect value for states[6].sid.reserved, expected 0, is "
       << last_msg_->states[6].sid.reserved;
-  EXPECT_EQ(last_msg_->states[6].sid.sat, 220)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[6].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[6].sid.sat)),
+      220)
       << "incorrect value for states[6].sid.sat, expected 220, is "
       << last_msg_->states[6].sid.sat;
-  EXPECT_EQ(last_msg_->states[6].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[6].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[6].state)),
+            1)
       << "incorrect value for states[6].state, expected 1, is "
       << last_msg_->states[6].state;
   EXPECT_LT((last_msg_->states[7].cn0 * 100 - 38.52891922 * 100), 0.05)
       << "incorrect value for states[7].cn0, expected 38.52891922, is "
       << last_msg_->states[7].cn0;
-  EXPECT_EQ(last_msg_->states[7].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[7].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[7].sid.code)),
+      0)
       << "incorrect value for states[7].sid.code, expected 0, is "
       << last_msg_->states[7].sid.code;
-  EXPECT_EQ(last_msg_->states[7].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[7].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[7].sid.reserved)),
+            0)
       << "incorrect value for states[7].sid.reserved, expected 0, is "
       << last_msg_->states[7].sid.reserved;
-  EXPECT_EQ(last_msg_->states[7].sid.sat, 222)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[7].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[7].sid.sat)),
+      222)
       << "incorrect value for states[7].sid.sat, expected 222, is "
       << last_msg_->states[7].sid.sat;
-  EXPECT_EQ(last_msg_->states[7].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[7].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[7].state)),
+            1)
       << "incorrect value for states[7].state, expected 1, is "
       << last_msg_->states[7].state;
   EXPECT_LT((last_msg_->states[8].cn0 * 100 - 42.2710151672 * 100), 0.05)
       << "incorrect value for states[8].cn0, expected 42.2710151672, is "
       << last_msg_->states[8].cn0;
-  EXPECT_EQ(last_msg_->states[8].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[8].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[8].sid.code)),
+      0)
       << "incorrect value for states[8].sid.code, expected 0, is "
       << last_msg_->states[8].sid.code;
-  EXPECT_EQ(last_msg_->states[8].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[8].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[8].sid.reserved)),
+            0)
       << "incorrect value for states[8].sid.reserved, expected 0, is "
       << last_msg_->states[8].sid.reserved;
-  EXPECT_EQ(last_msg_->states[8].sid.sat, 225)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[8].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[8].sid.sat)),
+      225)
       << "incorrect value for states[8].sid.sat, expected 225, is "
       << last_msg_->states[8].sid.sat;
-  EXPECT_EQ(last_msg_->states[8].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[8].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[8].state)),
+            1)
       << "incorrect value for states[8].state, expected 1, is "
       << last_msg_->states[8].state;
   EXPECT_LT((last_msg_->states[9].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[9].cn0, expected -1.0, is "
       << last_msg_->states[9].cn0;
-  EXPECT_EQ(last_msg_->states[9].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[9].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[9].sid.code)),
+      0)
       << "incorrect value for states[9].sid.code, expected 0, is "
       << last_msg_->states[9].sid.code;
-  EXPECT_EQ(last_msg_->states[9].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[9].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[9].sid.reserved)),
+            0)
       << "incorrect value for states[9].sid.reserved, expected 0, is "
       << last_msg_->states[9].sid.reserved;
-  EXPECT_EQ(last_msg_->states[9].sid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[9].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[9].sid.sat)),
+      0)
       << "incorrect value for states[9].sid.sat, expected 0, is "
       << last_msg_->states[9].sid.sat;
-  EXPECT_EQ(last_msg_->states[9].state, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[9].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[9].state)),
+            0)
       << "incorrect value for states[9].state, expected 0, is "
       << last_msg_->states[9].state;
   EXPECT_LT((last_msg_->states[10].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[10].cn0, expected -1.0, is "
       << last_msg_->states[10].cn0;
-  EXPECT_EQ(last_msg_->states[10].sid.code, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[10].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[10].sid.code)),
+      0)
       << "incorrect value for states[10].sid.code, expected 0, is "
       << last_msg_->states[10].sid.code;
-  EXPECT_EQ(last_msg_->states[10].sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[10].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[10].sid.reserved)),
+            0)
       << "incorrect value for states[10].sid.reserved, expected 0, is "
       << last_msg_->states[10].sid.reserved;
-  EXPECT_EQ(last_msg_->states[10].sid.sat, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[10].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[10].sid.sat)),
+      0)
       << "incorrect value for states[10].sid.sat, expected 0, is "
       << last_msg_->states[10].sid.sat;
-  EXPECT_EQ(last_msg_->states[10].state, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[10].state)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[10].state)),
+      0)
       << "incorrect value for states[10].state, expected 0, is "
       << last_msg_->states[10].state;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_tracking_MsgTrackingStateDepB.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_tracking_MsgTrackingStateDepB.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/tracking.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_tracking_MsgTrackingStateDepB0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -383,421 +390,747 @@ TEST_F(Test_legacy_auto_check_sbp_tracking_MsgTrackingStateDepB0, Test) {
   EXPECT_LT((last_msg_->states[0].cn0 * 100 - 5856.20019531 * 100), 0.05)
       << "incorrect value for states[0].cn0, expected 5856.20019531, is "
       << last_msg_->states[0].cn0;
-  EXPECT_EQ(last_msg_->states[0].sid.code, 63)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[0].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[0].sid.code)),
+      63)
       << "incorrect value for states[0].sid.code, expected 63, is "
       << last_msg_->states[0].sid.code;
-  EXPECT_EQ(last_msg_->states[0].sid.reserved, 68)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[0].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[0].sid.reserved)),
+            68)
       << "incorrect value for states[0].sid.reserved, expected 68, is "
       << last_msg_->states[0].sid.reserved;
-  EXPECT_EQ(last_msg_->states[0].sid.sat, 58295)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[0].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[0].sid.sat)),
+      58295)
       << "incorrect value for states[0].sid.sat, expected 58295, is "
       << last_msg_->states[0].sid.sat;
-  EXPECT_EQ(last_msg_->states[0].state, 115)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[0].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[0].state)),
+            115)
       << "incorrect value for states[0].state, expected 115, is "
       << last_msg_->states[0].state;
   EXPECT_LT((last_msg_->states[1].cn0 * 100 - 2612.19995117 * 100), 0.05)
       << "incorrect value for states[1].cn0, expected 2612.19995117, is "
       << last_msg_->states[1].cn0;
-  EXPECT_EQ(last_msg_->states[1].sid.code, 43)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[1].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[1].sid.code)),
+      43)
       << "incorrect value for states[1].sid.code, expected 43, is "
       << last_msg_->states[1].sid.code;
-  EXPECT_EQ(last_msg_->states[1].sid.reserved, 222)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[1].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[1].sid.reserved)),
+            222)
       << "incorrect value for states[1].sid.reserved, expected 222, is "
       << last_msg_->states[1].sid.reserved;
-  EXPECT_EQ(last_msg_->states[1].sid.sat, 31151)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[1].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[1].sid.sat)),
+      31151)
       << "incorrect value for states[1].sid.sat, expected 31151, is "
       << last_msg_->states[1].sid.sat;
-  EXPECT_EQ(last_msg_->states[1].state, 255)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[1].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[1].state)),
+            255)
       << "incorrect value for states[1].state, expected 255, is "
       << last_msg_->states[1].state;
   EXPECT_LT((last_msg_->states[2].cn0 * 100 - 2925.19995117 * 100), 0.05)
       << "incorrect value for states[2].cn0, expected 2925.19995117, is "
       << last_msg_->states[2].cn0;
-  EXPECT_EQ(last_msg_->states[2].sid.code, 53)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[2].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[2].sid.code)),
+      53)
       << "incorrect value for states[2].sid.code, expected 53, is "
       << last_msg_->states[2].sid.code;
-  EXPECT_EQ(last_msg_->states[2].sid.reserved, 20)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[2].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[2].sid.reserved)),
+            20)
       << "incorrect value for states[2].sid.reserved, expected 20, is "
       << last_msg_->states[2].sid.reserved;
-  EXPECT_EQ(last_msg_->states[2].sid.sat, 1520)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[2].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[2].sid.sat)),
+      1520)
       << "incorrect value for states[2].sid.sat, expected 1520, is "
       << last_msg_->states[2].sid.sat;
-  EXPECT_EQ(last_msg_->states[2].state, 78)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[2].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[2].state)),
+            78)
       << "incorrect value for states[2].state, expected 78, is "
       << last_msg_->states[2].state;
   EXPECT_LT((last_msg_->states[3].cn0 * 100 - 3198.19995117 * 100), 0.05)
       << "incorrect value for states[3].cn0, expected 3198.19995117, is "
       << last_msg_->states[3].cn0;
-  EXPECT_EQ(last_msg_->states[3].sid.code, 66)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[3].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[3].sid.code)),
+      66)
       << "incorrect value for states[3].sid.code, expected 66, is "
       << last_msg_->states[3].sid.code;
-  EXPECT_EQ(last_msg_->states[3].sid.reserved, 155)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[3].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[3].sid.reserved)),
+            155)
       << "incorrect value for states[3].sid.reserved, expected 155, is "
       << last_msg_->states[3].sid.reserved;
-  EXPECT_EQ(last_msg_->states[3].sid.sat, 60802)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[3].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[3].sid.sat)),
+      60802)
       << "incorrect value for states[3].sid.sat, expected 60802, is "
       << last_msg_->states[3].sid.sat;
-  EXPECT_EQ(last_msg_->states[3].state, 153)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[3].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[3].state)),
+            153)
       << "incorrect value for states[3].state, expected 153, is "
       << last_msg_->states[3].state;
   EXPECT_LT((last_msg_->states[4].cn0 * 100 - 8623.20019531 * 100), 0.05)
       << "incorrect value for states[4].cn0, expected 8623.20019531, is "
       << last_msg_->states[4].cn0;
-  EXPECT_EQ(last_msg_->states[4].sid.code, 161)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[4].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[4].sid.code)),
+      161)
       << "incorrect value for states[4].sid.code, expected 161, is "
       << last_msg_->states[4].sid.code;
-  EXPECT_EQ(last_msg_->states[4].sid.reserved, 190)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[4].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[4].sid.reserved)),
+            190)
       << "incorrect value for states[4].sid.reserved, expected 190, is "
       << last_msg_->states[4].sid.reserved;
-  EXPECT_EQ(last_msg_->states[4].sid.sat, 35058)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[4].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[4].sid.sat)),
+      35058)
       << "incorrect value for states[4].sid.sat, expected 35058, is "
       << last_msg_->states[4].sid.sat;
-  EXPECT_EQ(last_msg_->states[4].state, 53)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[4].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[4].state)),
+            53)
       << "incorrect value for states[4].state, expected 53, is "
       << last_msg_->states[4].state;
   EXPECT_LT((last_msg_->states[5].cn0 * 100 - 5915.20019531 * 100), 0.05)
       << "incorrect value for states[5].cn0, expected 5915.20019531, is "
       << last_msg_->states[5].cn0;
-  EXPECT_EQ(last_msg_->states[5].sid.code, 142)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[5].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[5].sid.code)),
+      142)
       << "incorrect value for states[5].sid.code, expected 142, is "
       << last_msg_->states[5].sid.code;
-  EXPECT_EQ(last_msg_->states[5].sid.reserved, 149)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[5].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[5].sid.reserved)),
+            149)
       << "incorrect value for states[5].sid.reserved, expected 149, is "
       << last_msg_->states[5].sid.reserved;
-  EXPECT_EQ(last_msg_->states[5].sid.sat, 65405)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[5].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[5].sid.sat)),
+      65405)
       << "incorrect value for states[5].sid.sat, expected 65405, is "
       << last_msg_->states[5].sid.sat;
-  EXPECT_EQ(last_msg_->states[5].state, 153)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[5].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[5].state)),
+            153)
       << "incorrect value for states[5].state, expected 153, is "
       << last_msg_->states[5].state;
   EXPECT_LT((last_msg_->states[6].cn0 * 100 - 5412.20019531 * 100), 0.05)
       << "incorrect value for states[6].cn0, expected 5412.20019531, is "
       << last_msg_->states[6].cn0;
-  EXPECT_EQ(last_msg_->states[6].sid.code, 31)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[6].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[6].sid.code)),
+      31)
       << "incorrect value for states[6].sid.code, expected 31, is "
       << last_msg_->states[6].sid.code;
-  EXPECT_EQ(last_msg_->states[6].sid.reserved, 76)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[6].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[6].sid.reserved)),
+            76)
       << "incorrect value for states[6].sid.reserved, expected 76, is "
       << last_msg_->states[6].sid.reserved;
-  EXPECT_EQ(last_msg_->states[6].sid.sat, 24422)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[6].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[6].sid.sat)),
+      24422)
       << "incorrect value for states[6].sid.sat, expected 24422, is "
       << last_msg_->states[6].sid.sat;
-  EXPECT_EQ(last_msg_->states[6].state, 248)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[6].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[6].state)),
+            248)
       << "incorrect value for states[6].state, expected 248, is "
       << last_msg_->states[6].state;
   EXPECT_LT((last_msg_->states[7].cn0 * 100 - 6428.20019531 * 100), 0.05)
       << "incorrect value for states[7].cn0, expected 6428.20019531, is "
       << last_msg_->states[7].cn0;
-  EXPECT_EQ(last_msg_->states[7].sid.code, 27)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[7].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[7].sid.code)),
+      27)
       << "incorrect value for states[7].sid.code, expected 27, is "
       << last_msg_->states[7].sid.code;
-  EXPECT_EQ(last_msg_->states[7].sid.reserved, 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[7].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[7].sid.reserved)),
+            12)
       << "incorrect value for states[7].sid.reserved, expected 12, is "
       << last_msg_->states[7].sid.reserved;
-  EXPECT_EQ(last_msg_->states[7].sid.sat, 36211)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[7].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[7].sid.sat)),
+      36211)
       << "incorrect value for states[7].sid.sat, expected 36211, is "
       << last_msg_->states[7].sid.sat;
-  EXPECT_EQ(last_msg_->states[7].state, 131)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[7].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[7].state)),
+            131)
       << "incorrect value for states[7].state, expected 131, is "
       << last_msg_->states[7].state;
   EXPECT_LT((last_msg_->states[8].cn0 * 100 - 3104.19995117 * 100), 0.05)
       << "incorrect value for states[8].cn0, expected 3104.19995117, is "
       << last_msg_->states[8].cn0;
-  EXPECT_EQ(last_msg_->states[8].sid.code, 39)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[8].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[8].sid.code)),
+      39)
       << "incorrect value for states[8].sid.code, expected 39, is "
       << last_msg_->states[8].sid.code;
-  EXPECT_EQ(last_msg_->states[8].sid.reserved, 23)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[8].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[8].sid.reserved)),
+            23)
       << "incorrect value for states[8].sid.reserved, expected 23, is "
       << last_msg_->states[8].sid.reserved;
-  EXPECT_EQ(last_msg_->states[8].sid.sat, 37676)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[8].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[8].sid.sat)),
+      37676)
       << "incorrect value for states[8].sid.sat, expected 37676, is "
       << last_msg_->states[8].sid.sat;
-  EXPECT_EQ(last_msg_->states[8].state, 208)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[8].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[8].state)),
+            208)
       << "incorrect value for states[8].state, expected 208, is "
       << last_msg_->states[8].state;
   EXPECT_LT((last_msg_->states[9].cn0 * 100 - 3686.19995117 * 100), 0.05)
       << "incorrect value for states[9].cn0, expected 3686.19995117, is "
       << last_msg_->states[9].cn0;
-  EXPECT_EQ(last_msg_->states[9].sid.code, 49)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[9].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[9].sid.code)),
+      49)
       << "incorrect value for states[9].sid.code, expected 49, is "
       << last_msg_->states[9].sid.code;
-  EXPECT_EQ(last_msg_->states[9].sid.reserved, 203)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[9].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[9].sid.reserved)),
+            203)
       << "incorrect value for states[9].sid.reserved, expected 203, is "
       << last_msg_->states[9].sid.reserved;
-  EXPECT_EQ(last_msg_->states[9].sid.sat, 64415)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[9].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[9].sid.sat)),
+      64415)
       << "incorrect value for states[9].sid.sat, expected 64415, is "
       << last_msg_->states[9].sid.sat;
-  EXPECT_EQ(last_msg_->states[9].state, 237)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[9].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[9].state)),
+            237)
       << "incorrect value for states[9].state, expected 237, is "
       << last_msg_->states[9].state;
   EXPECT_LT((last_msg_->states[10].cn0 * 100 - 5967.20019531 * 100), 0.05)
       << "incorrect value for states[10].cn0, expected 5967.20019531, is "
       << last_msg_->states[10].cn0;
-  EXPECT_EQ(last_msg_->states[10].sid.code, 128)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[10].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[10].sid.code)),
+      128)
       << "incorrect value for states[10].sid.code, expected 128, is "
       << last_msg_->states[10].sid.code;
-  EXPECT_EQ(last_msg_->states[10].sid.reserved, 206)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[10].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[10].sid.reserved)),
+            206)
       << "incorrect value for states[10].sid.reserved, expected 206, is "
       << last_msg_->states[10].sid.reserved;
-  EXPECT_EQ(last_msg_->states[10].sid.sat, 22486)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[10].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[10].sid.sat)),
+      22486)
       << "incorrect value for states[10].sid.sat, expected 22486, is "
       << last_msg_->states[10].sid.sat;
-  EXPECT_EQ(last_msg_->states[10].state, 70)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[10].state)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[10].state)),
+      70)
       << "incorrect value for states[10].state, expected 70, is "
       << last_msg_->states[10].state;
   EXPECT_LT((last_msg_->states[11].cn0 * 100 - 5423.20019531 * 100), 0.05)
       << "incorrect value for states[11].cn0, expected 5423.20019531, is "
       << last_msg_->states[11].cn0;
-  EXPECT_EQ(last_msg_->states[11].sid.code, 218)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[11].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[11].sid.code)),
+      218)
       << "incorrect value for states[11].sid.code, expected 218, is "
       << last_msg_->states[11].sid.code;
-  EXPECT_EQ(last_msg_->states[11].sid.reserved, 19)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[11].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[11].sid.reserved)),
+            19)
       << "incorrect value for states[11].sid.reserved, expected 19, is "
       << last_msg_->states[11].sid.reserved;
-  EXPECT_EQ(last_msg_->states[11].sid.sat, 28622)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[11].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[11].sid.sat)),
+      28622)
       << "incorrect value for states[11].sid.sat, expected 28622, is "
       << last_msg_->states[11].sid.sat;
-  EXPECT_EQ(last_msg_->states[11].state, 14)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[11].state)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[11].state)),
+      14)
       << "incorrect value for states[11].state, expected 14, is "
       << last_msg_->states[11].state;
   EXPECT_LT((last_msg_->states[12].cn0 * 100 - 438.200012207 * 100), 0.05)
       << "incorrect value for states[12].cn0, expected 438.200012207, is "
       << last_msg_->states[12].cn0;
-  EXPECT_EQ(last_msg_->states[12].sid.code, 54)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[12].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[12].sid.code)),
+      54)
       << "incorrect value for states[12].sid.code, expected 54, is "
       << last_msg_->states[12].sid.code;
-  EXPECT_EQ(last_msg_->states[12].sid.reserved, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[12].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[12].sid.reserved)),
+            2)
       << "incorrect value for states[12].sid.reserved, expected 2, is "
       << last_msg_->states[12].sid.reserved;
-  EXPECT_EQ(last_msg_->states[12].sid.sat, 53602)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[12].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[12].sid.sat)),
+      53602)
       << "incorrect value for states[12].sid.sat, expected 53602, is "
       << last_msg_->states[12].sid.sat;
-  EXPECT_EQ(last_msg_->states[12].state, 216)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[12].state)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[12].state)),
+      216)
       << "incorrect value for states[12].state, expected 216, is "
       << last_msg_->states[12].state;
   EXPECT_LT((last_msg_->states[13].cn0 * 100 - 1862.19995117 * 100), 0.05)
       << "incorrect value for states[13].cn0, expected 1862.19995117, is "
       << last_msg_->states[13].cn0;
-  EXPECT_EQ(last_msg_->states[13].sid.code, 7)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[13].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[13].sid.code)),
+      7)
       << "incorrect value for states[13].sid.code, expected 7, is "
       << last_msg_->states[13].sid.code;
-  EXPECT_EQ(last_msg_->states[13].sid.reserved, 34)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[13].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[13].sid.reserved)),
+            34)
       << "incorrect value for states[13].sid.reserved, expected 34, is "
       << last_msg_->states[13].sid.reserved;
-  EXPECT_EQ(last_msg_->states[13].sid.sat, 25477)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[13].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[13].sid.sat)),
+      25477)
       << "incorrect value for states[13].sid.sat, expected 25477, is "
       << last_msg_->states[13].sid.sat;
-  EXPECT_EQ(last_msg_->states[13].state, 200)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[13].state)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[13].state)),
+      200)
       << "incorrect value for states[13].state, expected 200, is "
       << last_msg_->states[13].state;
   EXPECT_LT((last_msg_->states[14].cn0 * 100 - 5462.20019531 * 100), 0.05)
       << "incorrect value for states[14].cn0, expected 5462.20019531, is "
       << last_msg_->states[14].cn0;
-  EXPECT_EQ(last_msg_->states[14].sid.code, 135)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[14].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[14].sid.code)),
+      135)
       << "incorrect value for states[14].sid.code, expected 135, is "
       << last_msg_->states[14].sid.code;
-  EXPECT_EQ(last_msg_->states[14].sid.reserved, 46)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[14].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[14].sid.reserved)),
+            46)
       << "incorrect value for states[14].sid.reserved, expected 46, is "
       << last_msg_->states[14].sid.reserved;
-  EXPECT_EQ(last_msg_->states[14].sid.sat, 21803)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[14].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[14].sid.sat)),
+      21803)
       << "incorrect value for states[14].sid.sat, expected 21803, is "
       << last_msg_->states[14].sid.sat;
-  EXPECT_EQ(last_msg_->states[14].state, 155)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[14].state)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[14].state)),
+      155)
       << "incorrect value for states[14].state, expected 155, is "
       << last_msg_->states[14].state;
   EXPECT_LT((last_msg_->states[15].cn0 * 100 - 7454.20019531 * 100), 0.05)
       << "incorrect value for states[15].cn0, expected 7454.20019531, is "
       << last_msg_->states[15].cn0;
-  EXPECT_EQ(last_msg_->states[15].sid.code, 171)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[15].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[15].sid.code)),
+      171)
       << "incorrect value for states[15].sid.code, expected 171, is "
       << last_msg_->states[15].sid.code;
-  EXPECT_EQ(last_msg_->states[15].sid.reserved, 201)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[15].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[15].sid.reserved)),
+            201)
       << "incorrect value for states[15].sid.reserved, expected 201, is "
       << last_msg_->states[15].sid.reserved;
-  EXPECT_EQ(last_msg_->states[15].sid.sat, 21251)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[15].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[15].sid.sat)),
+      21251)
       << "incorrect value for states[15].sid.sat, expected 21251, is "
       << last_msg_->states[15].sid.sat;
-  EXPECT_EQ(last_msg_->states[15].state, 155)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[15].state)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[15].state)),
+      155)
       << "incorrect value for states[15].state, expected 155, is "
       << last_msg_->states[15].state;
   EXPECT_LT((last_msg_->states[16].cn0 * 100 - 7134.20019531 * 100), 0.05)
       << "incorrect value for states[16].cn0, expected 7134.20019531, is "
       << last_msg_->states[16].cn0;
-  EXPECT_EQ(last_msg_->states[16].sid.code, 16)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[16].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[16].sid.code)),
+      16)
       << "incorrect value for states[16].sid.code, expected 16, is "
       << last_msg_->states[16].sid.code;
-  EXPECT_EQ(last_msg_->states[16].sid.reserved, 19)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[16].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[16].sid.reserved)),
+            19)
       << "incorrect value for states[16].sid.reserved, expected 19, is "
       << last_msg_->states[16].sid.reserved;
-  EXPECT_EQ(last_msg_->states[16].sid.sat, 50475)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[16].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[16].sid.sat)),
+      50475)
       << "incorrect value for states[16].sid.sat, expected 50475, is "
       << last_msg_->states[16].sid.sat;
-  EXPECT_EQ(last_msg_->states[16].state, 121)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[16].state)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[16].state)),
+      121)
       << "incorrect value for states[16].state, expected 121, is "
       << last_msg_->states[16].state;
   EXPECT_LT((last_msg_->states[17].cn0 * 100 - 3111.19995117 * 100), 0.05)
       << "incorrect value for states[17].cn0, expected 3111.19995117, is "
       << last_msg_->states[17].cn0;
-  EXPECT_EQ(last_msg_->states[17].sid.code, 63)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[17].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[17].sid.code)),
+      63)
       << "incorrect value for states[17].sid.code, expected 63, is "
       << last_msg_->states[17].sid.code;
-  EXPECT_EQ(last_msg_->states[17].sid.reserved, 176)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[17].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[17].sid.reserved)),
+            176)
       << "incorrect value for states[17].sid.reserved, expected 176, is "
       << last_msg_->states[17].sid.reserved;
-  EXPECT_EQ(last_msg_->states[17].sid.sat, 13813)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[17].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[17].sid.sat)),
+      13813)
       << "incorrect value for states[17].sid.sat, expected 13813, is "
       << last_msg_->states[17].sid.sat;
-  EXPECT_EQ(last_msg_->states[17].state, 128)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[17].state)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[17].state)),
+      128)
       << "incorrect value for states[17].state, expected 128, is "
       << last_msg_->states[17].state;
   EXPECT_LT((last_msg_->states[18].cn0 * 100 - 4297.20019531 * 100), 0.05)
       << "incorrect value for states[18].cn0, expected 4297.20019531, is "
       << last_msg_->states[18].cn0;
-  EXPECT_EQ(last_msg_->states[18].sid.code, 153)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[18].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[18].sid.code)),
+      153)
       << "incorrect value for states[18].sid.code, expected 153, is "
       << last_msg_->states[18].sid.code;
-  EXPECT_EQ(last_msg_->states[18].sid.reserved, 51)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[18].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[18].sid.reserved)),
+            51)
       << "incorrect value for states[18].sid.reserved, expected 51, is "
       << last_msg_->states[18].sid.reserved;
-  EXPECT_EQ(last_msg_->states[18].sid.sat, 15636)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[18].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[18].sid.sat)),
+      15636)
       << "incorrect value for states[18].sid.sat, expected 15636, is "
       << last_msg_->states[18].sid.sat;
-  EXPECT_EQ(last_msg_->states[18].state, 36)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[18].state)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[18].state)),
+      36)
       << "incorrect value for states[18].state, expected 36, is "
       << last_msg_->states[18].state;
   EXPECT_LT((last_msg_->states[19].cn0 * 100 - 2649.19995117 * 100), 0.05)
       << "incorrect value for states[19].cn0, expected 2649.19995117, is "
       << last_msg_->states[19].cn0;
-  EXPECT_EQ(last_msg_->states[19].sid.code, 140)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[19].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[19].sid.code)),
+      140)
       << "incorrect value for states[19].sid.code, expected 140, is "
       << last_msg_->states[19].sid.code;
-  EXPECT_EQ(last_msg_->states[19].sid.reserved, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[19].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[19].sid.reserved)),
+            22)
       << "incorrect value for states[19].sid.reserved, expected 22, is "
       << last_msg_->states[19].sid.reserved;
-  EXPECT_EQ(last_msg_->states[19].sid.sat, 29778)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[19].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[19].sid.sat)),
+      29778)
       << "incorrect value for states[19].sid.sat, expected 29778, is "
       << last_msg_->states[19].sid.sat;
-  EXPECT_EQ(last_msg_->states[19].state, 46)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[19].state)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[19].state)),
+      46)
       << "incorrect value for states[19].state, expected 46, is "
       << last_msg_->states[19].state;
   EXPECT_LT((last_msg_->states[20].cn0 * 100 - 941.200012207 * 100), 0.05)
       << "incorrect value for states[20].cn0, expected 941.200012207, is "
       << last_msg_->states[20].cn0;
-  EXPECT_EQ(last_msg_->states[20].sid.code, 96)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[20].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[20].sid.code)),
+      96)
       << "incorrect value for states[20].sid.code, expected 96, is "
       << last_msg_->states[20].sid.code;
-  EXPECT_EQ(last_msg_->states[20].sid.reserved, 143)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[20].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[20].sid.reserved)),
+            143)
       << "incorrect value for states[20].sid.reserved, expected 143, is "
       << last_msg_->states[20].sid.reserved;
-  EXPECT_EQ(last_msg_->states[20].sid.sat, 37443)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[20].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[20].sid.sat)),
+      37443)
       << "incorrect value for states[20].sid.sat, expected 37443, is "
       << last_msg_->states[20].sid.sat;
-  EXPECT_EQ(last_msg_->states[20].state, 177)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[20].state)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[20].state)),
+      177)
       << "incorrect value for states[20].state, expected 177, is "
       << last_msg_->states[20].state;
   EXPECT_LT((last_msg_->states[21].cn0 * 100 - 1539.19995117 * 100), 0.05)
       << "incorrect value for states[21].cn0, expected 1539.19995117, is "
       << last_msg_->states[21].cn0;
-  EXPECT_EQ(last_msg_->states[21].sid.code, 201)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[21].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[21].sid.code)),
+      201)
       << "incorrect value for states[21].sid.code, expected 201, is "
       << last_msg_->states[21].sid.code;
-  EXPECT_EQ(last_msg_->states[21].sid.reserved, 251)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[21].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[21].sid.reserved)),
+            251)
       << "incorrect value for states[21].sid.reserved, expected 251, is "
       << last_msg_->states[21].sid.reserved;
-  EXPECT_EQ(last_msg_->states[21].sid.sat, 41011)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[21].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[21].sid.sat)),
+      41011)
       << "incorrect value for states[21].sid.sat, expected 41011, is "
       << last_msg_->states[21].sid.sat;
-  EXPECT_EQ(last_msg_->states[21].state, 220)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[21].state)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[21].state)),
+      220)
       << "incorrect value for states[21].state, expected 220, is "
       << last_msg_->states[21].state;
   EXPECT_LT((last_msg_->states[22].cn0 * 100 - 1443.19995117 * 100), 0.05)
       << "incorrect value for states[22].cn0, expected 1443.19995117, is "
       << last_msg_->states[22].cn0;
-  EXPECT_EQ(last_msg_->states[22].sid.code, 161)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[22].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[22].sid.code)),
+      161)
       << "incorrect value for states[22].sid.code, expected 161, is "
       << last_msg_->states[22].sid.code;
-  EXPECT_EQ(last_msg_->states[22].sid.reserved, 220)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[22].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[22].sid.reserved)),
+            220)
       << "incorrect value for states[22].sid.reserved, expected 220, is "
       << last_msg_->states[22].sid.reserved;
-  EXPECT_EQ(last_msg_->states[22].sid.sat, 706)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[22].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[22].sid.sat)),
+      706)
       << "incorrect value for states[22].sid.sat, expected 706, is "
       << last_msg_->states[22].sid.sat;
-  EXPECT_EQ(last_msg_->states[22].state, 168)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[22].state)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[22].state)),
+      168)
       << "incorrect value for states[22].state, expected 168, is "
       << last_msg_->states[22].state;
   EXPECT_LT((last_msg_->states[23].cn0 * 100 - 1074.19995117 * 100), 0.05)
       << "incorrect value for states[23].cn0, expected 1074.19995117, is "
       << last_msg_->states[23].cn0;
-  EXPECT_EQ(last_msg_->states[23].sid.code, 125)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[23].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[23].sid.code)),
+      125)
       << "incorrect value for states[23].sid.code, expected 125, is "
       << last_msg_->states[23].sid.code;
-  EXPECT_EQ(last_msg_->states[23].sid.reserved, 178)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[23].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[23].sid.reserved)),
+            178)
       << "incorrect value for states[23].sid.reserved, expected 178, is "
       << last_msg_->states[23].sid.reserved;
-  EXPECT_EQ(last_msg_->states[23].sid.sat, 2312)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[23].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[23].sid.sat)),
+      2312)
       << "incorrect value for states[23].sid.sat, expected 2312, is "
       << last_msg_->states[23].sid.sat;
-  EXPECT_EQ(last_msg_->states[23].state, 69)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[23].state)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[23].state)),
+      69)
       << "incorrect value for states[23].state, expected 69, is "
       << last_msg_->states[23].state;
   EXPECT_LT((last_msg_->states[24].cn0 * 100 - 2122.19995117 * 100), 0.05)
       << "incorrect value for states[24].cn0, expected 2122.19995117, is "
       << last_msg_->states[24].cn0;
-  EXPECT_EQ(last_msg_->states[24].sid.code, 186)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[24].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[24].sid.code)),
+      186)
       << "incorrect value for states[24].sid.code, expected 186, is "
       << last_msg_->states[24].sid.code;
-  EXPECT_EQ(last_msg_->states[24].sid.reserved, 171)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[24].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[24].sid.reserved)),
+            171)
       << "incorrect value for states[24].sid.reserved, expected 171, is "
       << last_msg_->states[24].sid.reserved;
-  EXPECT_EQ(last_msg_->states[24].sid.sat, 34580)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[24].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[24].sid.sat)),
+      34580)
       << "incorrect value for states[24].sid.sat, expected 34580, is "
       << last_msg_->states[24].sid.sat;
-  EXPECT_EQ(last_msg_->states[24].state, 185)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[24].state)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[24].state)),
+      185)
       << "incorrect value for states[24].state, expected 185, is "
       << last_msg_->states[24].state;
   EXPECT_LT((last_msg_->states[25].cn0 * 100 - 9076.20019531 * 100), 0.05)
       << "incorrect value for states[25].cn0, expected 9076.20019531, is "
       << last_msg_->states[25].cn0;
-  EXPECT_EQ(last_msg_->states[25].sid.code, 85)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[25].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[25].sid.code)),
+      85)
       << "incorrect value for states[25].sid.code, expected 85, is "
       << last_msg_->states[25].sid.code;
-  EXPECT_EQ(last_msg_->states[25].sid.reserved, 170)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[25].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[25].sid.reserved)),
+            170)
       << "incorrect value for states[25].sid.reserved, expected 170, is "
       << last_msg_->states[25].sid.reserved;
-  EXPECT_EQ(last_msg_->states[25].sid.sat, 39804)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[25].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[25].sid.sat)),
+      39804)
       << "incorrect value for states[25].sid.sat, expected 39804, is "
       << last_msg_->states[25].sid.sat;
-  EXPECT_EQ(last_msg_->states[25].state, 18)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[25].state)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[25].state)),
+      18)
       << "incorrect value for states[25].state, expected 18, is "
       << last_msg_->states[25].state;
   EXPECT_LT((last_msg_->states[26].cn0 * 100 - 4781.20019531 * 100), 0.05)
       << "incorrect value for states[26].cn0, expected 4781.20019531, is "
       << last_msg_->states[26].cn0;
-  EXPECT_EQ(last_msg_->states[26].sid.code, 255)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[26].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[26].sid.code)),
+      255)
       << "incorrect value for states[26].sid.code, expected 255, is "
       << last_msg_->states[26].sid.code;
-  EXPECT_EQ(last_msg_->states[26].sid.reserved, 186)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[26].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[26].sid.reserved)),
+            186)
       << "incorrect value for states[26].sid.reserved, expected 186, is "
       << last_msg_->states[26].sid.reserved;
-  EXPECT_EQ(last_msg_->states[26].sid.sat, 52980)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[26].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[26].sid.sat)),
+      52980)
       << "incorrect value for states[26].sid.sat, expected 52980, is "
       << last_msg_->states[26].sid.sat;
-  EXPECT_EQ(last_msg_->states[26].state, 57)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[26].state)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[26].state)),
+      57)
       << "incorrect value for states[26].state, expected 57, is "
       << last_msg_->states[26].state;
   EXPECT_LT((last_msg_->states[27].cn0 * 100 - 3076.19995117 * 100), 0.05)
       << "incorrect value for states[27].cn0, expected 3076.19995117, is "
       << last_msg_->states[27].cn0;
-  EXPECT_EQ(last_msg_->states[27].sid.code, 181)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[27].sid.code)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[27].sid.code)),
+      181)
       << "incorrect value for states[27].sid.code, expected 181, is "
       << last_msg_->states[27].sid.code;
-  EXPECT_EQ(last_msg_->states[27].sid.reserved, 175)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[27].sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(
+                    &last_msg_->states[27].sid.reserved)),
+            175)
       << "incorrect value for states[27].sid.reserved, expected 175, is "
       << last_msg_->states[27].sid.reserved;
-  EXPECT_EQ(last_msg_->states[27].sid.sat, 24007)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[27].sid.sat)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[27].sid.sat)),
+      24007)
       << "incorrect value for states[27].sid.sat, expected 24007, is "
       << last_msg_->states[27].sid.sat;
-  EXPECT_EQ(last_msg_->states[27].state, 165)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[27].state)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[27].state)),
+      165)
       << "incorrect value for states[27].state, expected 165, is "
       << last_msg_->states[27].state;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_tracking_MsgTrackingStateDetailedDep.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_tracking_MsgTrackingStateDetailedDep.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/tracking.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_tracking_MsgTrackingStateDetailedDep0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -139,69 +146,119 @@ TEST_F(Test_legacy_auto_check_sbp_tracking_MsgTrackingStateDetailedDep0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 26427);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->L.f, 169)
+  EXPECT_EQ(get_as<decltype(last_msg_->L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->L.f)),
+            169)
       << "incorrect value for L.f, expected 169, is " << last_msg_->L.f;
-  EXPECT_EQ(last_msg_->L.i, 1319)
+  EXPECT_EQ(get_as<decltype(last_msg_->L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->L.i)),
+            1319)
       << "incorrect value for L.i, expected 1319, is " << last_msg_->L.i;
-  EXPECT_EQ(last_msg_->P, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->P)),
+            0)
       << "incorrect value for P, expected 0, is " << last_msg_->P;
-  EXPECT_EQ(last_msg_->P_std, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->P_std)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->P_std)),
+            0)
       << "incorrect value for P_std, expected 0, is " << last_msg_->P_std;
-  EXPECT_EQ(last_msg_->acceleration, 108)
+  EXPECT_EQ(get_as<decltype(last_msg_->acceleration)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->acceleration)),
+            108)
       << "incorrect value for acceleration, expected 108, is "
       << last_msg_->acceleration;
-  EXPECT_EQ(last_msg_->clock_drift, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->clock_drift)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->clock_drift)),
+            0)
       << "incorrect value for clock_drift, expected 0, is "
       << last_msg_->clock_drift;
-  EXPECT_EQ(last_msg_->clock_offset, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->clock_offset)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->clock_offset)),
+            0)
       << "incorrect value for clock_offset, expected 0, is "
       << last_msg_->clock_offset;
-  EXPECT_EQ(last_msg_->cn0, 177)
+  EXPECT_EQ(get_as<decltype(last_msg_->cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cn0)),
+            177)
       << "incorrect value for cn0, expected 177, is " << last_msg_->cn0;
-  EXPECT_EQ(last_msg_->corr_spacing, 40)
+  EXPECT_EQ(get_as<decltype(last_msg_->corr_spacing)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->corr_spacing)),
+            40)
       << "incorrect value for corr_spacing, expected 40, is "
       << last_msg_->corr_spacing;
-  EXPECT_EQ(last_msg_->doppler, 15701)
+  EXPECT_EQ(get_as<decltype(last_msg_->doppler)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->doppler)),
+            15701)
       << "incorrect value for doppler, expected 15701, is "
       << last_msg_->doppler;
-  EXPECT_EQ(last_msg_->doppler_std, 39)
+  EXPECT_EQ(get_as<decltype(last_msg_->doppler_std)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->doppler_std)),
+            39)
       << "incorrect value for doppler_std, expected 39, is "
       << last_msg_->doppler_std;
-  EXPECT_EQ(last_msg_->lock, 14032)
+  EXPECT_EQ(get_as<decltype(last_msg_->lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->lock)),
+            14032)
       << "incorrect value for lock, expected 14032, is " << last_msg_->lock;
-  EXPECT_EQ(last_msg_->misc_flags, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->misc_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->misc_flags)),
+            9)
       << "incorrect value for misc_flags, expected 9, is "
       << last_msg_->misc_flags;
-  EXPECT_EQ(last_msg_->nav_flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->nav_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->nav_flags)),
+            0)
       << "incorrect value for nav_flags, expected 0, is "
       << last_msg_->nav_flags;
-  EXPECT_EQ(last_msg_->pset_flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->pset_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pset_flags)),
+            0)
       << "incorrect value for pset_flags, expected 0, is "
       << last_msg_->pset_flags;
-  EXPECT_EQ(last_msg_->recv_time, 7909447587)
+  EXPECT_EQ(get_as<decltype(last_msg_->recv_time)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->recv_time)),
+            7909447587)
       << "incorrect value for recv_time, expected 7909447587, is "
       << last_msg_->recv_time;
-  EXPECT_EQ(last_msg_->sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.code)),
+            0)
       << "incorrect value for sid.code, expected 0, is " << last_msg_->sid.code;
-  EXPECT_EQ(last_msg_->sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.reserved)),
+            0)
       << "incorrect value for sid.reserved, expected 0, is "
       << last_msg_->sid.reserved;
-  EXPECT_EQ(last_msg_->sid.sat, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.sat)),
+            15)
       << "incorrect value for sid.sat, expected 15, is " << last_msg_->sid.sat;
-  EXPECT_EQ(last_msg_->sync_flags, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->sync_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sync_flags)),
+            1)
       << "incorrect value for sync_flags, expected 1, is "
       << last_msg_->sync_flags;
-  EXPECT_EQ(last_msg_->tot.tow, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->tot.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tot.tow)),
+            0)
       << "incorrect value for tot.tow, expected 0, is " << last_msg_->tot.tow;
-  EXPECT_EQ(last_msg_->tot.wn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->tot.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tot.wn)),
+            0)
       << "incorrect value for tot.wn, expected 0, is " << last_msg_->tot.wn;
-  EXPECT_EQ(last_msg_->tow_flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow_flags)),
+            0)
       << "incorrect value for tow_flags, expected 0, is "
       << last_msg_->tow_flags;
-  EXPECT_EQ(last_msg_->track_flags, 11)
+  EXPECT_EQ(get_as<decltype(last_msg_->track_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->track_flags)),
+            11)
       << "incorrect value for track_flags, expected 11, is "
       << last_msg_->track_flags;
-  EXPECT_EQ(last_msg_->uptime, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->uptime)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->uptime)),
+            1)
       << "incorrect value for uptime, expected 1, is " << last_msg_->uptime;
 }
 class Test_legacy_auto_check_sbp_tracking_MsgTrackingStateDetailedDep1
@@ -314,69 +371,119 @@ TEST_F(Test_legacy_auto_check_sbp_tracking_MsgTrackingStateDetailedDep1, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 26427);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->L.f, 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->L.f)),
+            14)
       << "incorrect value for L.f, expected 14, is " << last_msg_->L.f;
-  EXPECT_EQ(last_msg_->L.i, 1810)
+  EXPECT_EQ(get_as<decltype(last_msg_->L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->L.i)),
+            1810)
       << "incorrect value for L.i, expected 1810, is " << last_msg_->L.i;
-  EXPECT_EQ(last_msg_->P, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->P)),
+            0)
       << "incorrect value for P, expected 0, is " << last_msg_->P;
-  EXPECT_EQ(last_msg_->P_std, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->P_std)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->P_std)),
+            0)
       << "incorrect value for P_std, expected 0, is " << last_msg_->P_std;
-  EXPECT_EQ(last_msg_->acceleration, -32)
+  EXPECT_EQ(get_as<decltype(last_msg_->acceleration)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->acceleration)),
+            -32)
       << "incorrect value for acceleration, expected -32, is "
       << last_msg_->acceleration;
-  EXPECT_EQ(last_msg_->clock_drift, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->clock_drift)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->clock_drift)),
+            0)
       << "incorrect value for clock_drift, expected 0, is "
       << last_msg_->clock_drift;
-  EXPECT_EQ(last_msg_->clock_offset, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->clock_offset)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->clock_offset)),
+            0)
       << "incorrect value for clock_offset, expected 0, is "
       << last_msg_->clock_offset;
-  EXPECT_EQ(last_msg_->cn0, 175)
+  EXPECT_EQ(get_as<decltype(last_msg_->cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cn0)),
+            175)
       << "incorrect value for cn0, expected 175, is " << last_msg_->cn0;
-  EXPECT_EQ(last_msg_->corr_spacing, 40)
+  EXPECT_EQ(get_as<decltype(last_msg_->corr_spacing)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->corr_spacing)),
+            40)
       << "incorrect value for corr_spacing, expected 40, is "
       << last_msg_->corr_spacing;
-  EXPECT_EQ(last_msg_->doppler, 15667)
+  EXPECT_EQ(get_as<decltype(last_msg_->doppler)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->doppler)),
+            15667)
       << "incorrect value for doppler, expected 15667, is "
       << last_msg_->doppler;
-  EXPECT_EQ(last_msg_->doppler_std, 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->doppler_std)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->doppler_std)),
+            30)
       << "incorrect value for doppler_std, expected 30, is "
       << last_msg_->doppler_std;
-  EXPECT_EQ(last_msg_->lock, 14032)
+  EXPECT_EQ(get_as<decltype(last_msg_->lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->lock)),
+            14032)
       << "incorrect value for lock, expected 14032, is " << last_msg_->lock;
-  EXPECT_EQ(last_msg_->misc_flags, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->misc_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->misc_flags)),
+            9)
       << "incorrect value for misc_flags, expected 9, is "
       << last_msg_->misc_flags;
-  EXPECT_EQ(last_msg_->nav_flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->nav_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->nav_flags)),
+            0)
       << "incorrect value for nav_flags, expected 0, is "
       << last_msg_->nav_flags;
-  EXPECT_EQ(last_msg_->pset_flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->pset_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pset_flags)),
+            0)
       << "incorrect value for pset_flags, expected 0, is "
       << last_msg_->pset_flags;
-  EXPECT_EQ(last_msg_->recv_time, 8409447265)
+  EXPECT_EQ(get_as<decltype(last_msg_->recv_time)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->recv_time)),
+            8409447265)
       << "incorrect value for recv_time, expected 8409447265, is "
       << last_msg_->recv_time;
-  EXPECT_EQ(last_msg_->sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.code)),
+            0)
       << "incorrect value for sid.code, expected 0, is " << last_msg_->sid.code;
-  EXPECT_EQ(last_msg_->sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.reserved)),
+            0)
       << "incorrect value for sid.reserved, expected 0, is "
       << last_msg_->sid.reserved;
-  EXPECT_EQ(last_msg_->sid.sat, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.sat)),
+            15)
       << "incorrect value for sid.sat, expected 15, is " << last_msg_->sid.sat;
-  EXPECT_EQ(last_msg_->sync_flags, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->sync_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sync_flags)),
+            1)
       << "incorrect value for sync_flags, expected 1, is "
       << last_msg_->sync_flags;
-  EXPECT_EQ(last_msg_->tot.tow, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->tot.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tot.tow)),
+            0)
       << "incorrect value for tot.tow, expected 0, is " << last_msg_->tot.tow;
-  EXPECT_EQ(last_msg_->tot.wn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->tot.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tot.wn)),
+            0)
       << "incorrect value for tot.wn, expected 0, is " << last_msg_->tot.wn;
-  EXPECT_EQ(last_msg_->tow_flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow_flags)),
+            0)
       << "incorrect value for tow_flags, expected 0, is "
       << last_msg_->tow_flags;
-  EXPECT_EQ(last_msg_->track_flags, 11)
+  EXPECT_EQ(get_as<decltype(last_msg_->track_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->track_flags)),
+            11)
       << "incorrect value for track_flags, expected 11, is "
       << last_msg_->track_flags;
-  EXPECT_EQ(last_msg_->uptime, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->uptime)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->uptime)),
+            1)
       << "incorrect value for uptime, expected 1, is " << last_msg_->uptime;
 }
 class Test_legacy_auto_check_sbp_tracking_MsgTrackingStateDetailedDep2
@@ -489,69 +596,119 @@ TEST_F(Test_legacy_auto_check_sbp_tracking_MsgTrackingStateDetailedDep2, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 26427);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->L.f, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->L.f)),
+            8)
       << "incorrect value for L.f, expected 8, is " << last_msg_->L.f;
-  EXPECT_EQ(last_msg_->L.i, 2298)
+  EXPECT_EQ(get_as<decltype(last_msg_->L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->L.i)),
+            2298)
       << "incorrect value for L.i, expected 2298, is " << last_msg_->L.i;
-  EXPECT_EQ(last_msg_->P, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->P)),
+            0)
       << "incorrect value for P, expected 0, is " << last_msg_->P;
-  EXPECT_EQ(last_msg_->P_std, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->P_std)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->P_std)),
+            0)
       << "incorrect value for P_std, expected 0, is " << last_msg_->P_std;
-  EXPECT_EQ(last_msg_->acceleration, 27)
+  EXPECT_EQ(get_as<decltype(last_msg_->acceleration)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->acceleration)),
+            27)
       << "incorrect value for acceleration, expected 27, is "
       << last_msg_->acceleration;
-  EXPECT_EQ(last_msg_->clock_drift, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->clock_drift)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->clock_drift)),
+            0)
       << "incorrect value for clock_drift, expected 0, is "
       << last_msg_->clock_drift;
-  EXPECT_EQ(last_msg_->clock_offset, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->clock_offset)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->clock_offset)),
+            0)
       << "incorrect value for clock_offset, expected 0, is "
       << last_msg_->clock_offset;
-  EXPECT_EQ(last_msg_->cn0, 179)
+  EXPECT_EQ(get_as<decltype(last_msg_->cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cn0)),
+            179)
       << "incorrect value for cn0, expected 179, is " << last_msg_->cn0;
-  EXPECT_EQ(last_msg_->corr_spacing, 40)
+  EXPECT_EQ(get_as<decltype(last_msg_->corr_spacing)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->corr_spacing)),
+            40)
       << "incorrect value for corr_spacing, expected 40, is "
       << last_msg_->corr_spacing;
-  EXPECT_EQ(last_msg_->doppler, 15683)
+  EXPECT_EQ(get_as<decltype(last_msg_->doppler)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->doppler)),
+            15683)
       << "incorrect value for doppler, expected 15683, is "
       << last_msg_->doppler;
-  EXPECT_EQ(last_msg_->doppler_std, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->doppler_std)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->doppler_std)),
+            22)
       << "incorrect value for doppler_std, expected 22, is "
       << last_msg_->doppler_std;
-  EXPECT_EQ(last_msg_->lock, 14032)
+  EXPECT_EQ(get_as<decltype(last_msg_->lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->lock)),
+            14032)
       << "incorrect value for lock, expected 14032, is " << last_msg_->lock;
-  EXPECT_EQ(last_msg_->misc_flags, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->misc_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->misc_flags)),
+            9)
       << "incorrect value for misc_flags, expected 9, is "
       << last_msg_->misc_flags;
-  EXPECT_EQ(last_msg_->nav_flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->nav_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->nav_flags)),
+            0)
       << "incorrect value for nav_flags, expected 0, is "
       << last_msg_->nav_flags;
-  EXPECT_EQ(last_msg_->pset_flags, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->pset_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pset_flags)),
+            2)
       << "incorrect value for pset_flags, expected 2, is "
       << last_msg_->pset_flags;
-  EXPECT_EQ(last_msg_->recv_time, 8907446923)
+  EXPECT_EQ(get_as<decltype(last_msg_->recv_time)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->recv_time)),
+            8907446923)
       << "incorrect value for recv_time, expected 8907446923, is "
       << last_msg_->recv_time;
-  EXPECT_EQ(last_msg_->sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.code)),
+            0)
       << "incorrect value for sid.code, expected 0, is " << last_msg_->sid.code;
-  EXPECT_EQ(last_msg_->sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.reserved)),
+            0)
       << "incorrect value for sid.reserved, expected 0, is "
       << last_msg_->sid.reserved;
-  EXPECT_EQ(last_msg_->sid.sat, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.sat)),
+            15)
       << "incorrect value for sid.sat, expected 15, is " << last_msg_->sid.sat;
-  EXPECT_EQ(last_msg_->sync_flags, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->sync_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sync_flags)),
+            1)
       << "incorrect value for sync_flags, expected 1, is "
       << last_msg_->sync_flags;
-  EXPECT_EQ(last_msg_->tot.tow, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->tot.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tot.tow)),
+            0)
       << "incorrect value for tot.tow, expected 0, is " << last_msg_->tot.tow;
-  EXPECT_EQ(last_msg_->tot.wn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->tot.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tot.wn)),
+            0)
       << "incorrect value for tot.wn, expected 0, is " << last_msg_->tot.wn;
-  EXPECT_EQ(last_msg_->tow_flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow_flags)),
+            0)
       << "incorrect value for tow_flags, expected 0, is "
       << last_msg_->tow_flags;
-  EXPECT_EQ(last_msg_->track_flags, 11)
+  EXPECT_EQ(get_as<decltype(last_msg_->track_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->track_flags)),
+            11)
       << "incorrect value for track_flags, expected 11, is "
       << last_msg_->track_flags;
-  EXPECT_EQ(last_msg_->uptime, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->uptime)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->uptime)),
+            2)
       << "incorrect value for uptime, expected 2, is " << last_msg_->uptime;
 }
 class Test_legacy_auto_check_sbp_tracking_MsgTrackingStateDetailedDep3
@@ -664,69 +821,119 @@ TEST_F(Test_legacy_auto_check_sbp_tracking_MsgTrackingStateDetailedDep3, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 26427);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->L.f, 125)
+  EXPECT_EQ(get_as<decltype(last_msg_->L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->L.f)),
+            125)
       << "incorrect value for L.f, expected 125, is " << last_msg_->L.f;
-  EXPECT_EQ(last_msg_->L.i, 2786)
+  EXPECT_EQ(get_as<decltype(last_msg_->L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->L.i)),
+            2786)
       << "incorrect value for L.i, expected 2786, is " << last_msg_->L.i;
-  EXPECT_EQ(last_msg_->P, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->P)),
+            0)
       << "incorrect value for P, expected 0, is " << last_msg_->P;
-  EXPECT_EQ(last_msg_->P_std, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->P_std)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->P_std)),
+            0)
       << "incorrect value for P_std, expected 0, is " << last_msg_->P_std;
-  EXPECT_EQ(last_msg_->acceleration, -36)
+  EXPECT_EQ(get_as<decltype(last_msg_->acceleration)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->acceleration)),
+            -36)
       << "incorrect value for acceleration, expected -36, is "
       << last_msg_->acceleration;
-  EXPECT_EQ(last_msg_->clock_drift, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->clock_drift)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->clock_drift)),
+            0)
       << "incorrect value for clock_drift, expected 0, is "
       << last_msg_->clock_drift;
-  EXPECT_EQ(last_msg_->clock_offset, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->clock_offset)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->clock_offset)),
+            0)
       << "incorrect value for clock_offset, expected 0, is "
       << last_msg_->clock_offset;
-  EXPECT_EQ(last_msg_->cn0, 181)
+  EXPECT_EQ(get_as<decltype(last_msg_->cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cn0)),
+            181)
       << "incorrect value for cn0, expected 181, is " << last_msg_->cn0;
-  EXPECT_EQ(last_msg_->corr_spacing, 40)
+  EXPECT_EQ(get_as<decltype(last_msg_->corr_spacing)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->corr_spacing)),
+            40)
       << "incorrect value for corr_spacing, expected 40, is "
       << last_msg_->corr_spacing;
-  EXPECT_EQ(last_msg_->doppler, 15645)
+  EXPECT_EQ(get_as<decltype(last_msg_->doppler)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->doppler)),
+            15645)
       << "incorrect value for doppler, expected 15645, is "
       << last_msg_->doppler;
-  EXPECT_EQ(last_msg_->doppler_std, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->doppler_std)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->doppler_std)),
+            10)
       << "incorrect value for doppler_std, expected 10, is "
       << last_msg_->doppler_std;
-  EXPECT_EQ(last_msg_->lock, 14032)
+  EXPECT_EQ(get_as<decltype(last_msg_->lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->lock)),
+            14032)
       << "incorrect value for lock, expected 14032, is " << last_msg_->lock;
-  EXPECT_EQ(last_msg_->misc_flags, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->misc_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->misc_flags)),
+            9)
       << "incorrect value for misc_flags, expected 9, is "
       << last_msg_->misc_flags;
-  EXPECT_EQ(last_msg_->nav_flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->nav_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->nav_flags)),
+            0)
       << "incorrect value for nav_flags, expected 0, is "
       << last_msg_->nav_flags;
-  EXPECT_EQ(last_msg_->pset_flags, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->pset_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pset_flags)),
+            3)
       << "incorrect value for pset_flags, expected 3, is "
       << last_msg_->pset_flags;
-  EXPECT_EQ(last_msg_->recv_time, 9406446591)
+  EXPECT_EQ(get_as<decltype(last_msg_->recv_time)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->recv_time)),
+            9406446591)
       << "incorrect value for recv_time, expected 9406446591, is "
       << last_msg_->recv_time;
-  EXPECT_EQ(last_msg_->sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.code)),
+            0)
       << "incorrect value for sid.code, expected 0, is " << last_msg_->sid.code;
-  EXPECT_EQ(last_msg_->sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.reserved)),
+            0)
       << "incorrect value for sid.reserved, expected 0, is "
       << last_msg_->sid.reserved;
-  EXPECT_EQ(last_msg_->sid.sat, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.sat)),
+            15)
       << "incorrect value for sid.sat, expected 15, is " << last_msg_->sid.sat;
-  EXPECT_EQ(last_msg_->sync_flags, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->sync_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sync_flags)),
+            1)
       << "incorrect value for sync_flags, expected 1, is "
       << last_msg_->sync_flags;
-  EXPECT_EQ(last_msg_->tot.tow, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->tot.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tot.tow)),
+            0)
       << "incorrect value for tot.tow, expected 0, is " << last_msg_->tot.tow;
-  EXPECT_EQ(last_msg_->tot.wn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->tot.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tot.wn)),
+            0)
       << "incorrect value for tot.wn, expected 0, is " << last_msg_->tot.wn;
-  EXPECT_EQ(last_msg_->tow_flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow_flags)),
+            0)
       << "incorrect value for tow_flags, expected 0, is "
       << last_msg_->tow_flags;
-  EXPECT_EQ(last_msg_->track_flags, 11)
+  EXPECT_EQ(get_as<decltype(last_msg_->track_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->track_flags)),
+            11)
       << "incorrect value for track_flags, expected 11, is "
       << last_msg_->track_flags;
-  EXPECT_EQ(last_msg_->uptime, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->uptime)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->uptime)),
+            2)
       << "incorrect value for uptime, expected 2, is " << last_msg_->uptime;
 }
 class Test_legacy_auto_check_sbp_tracking_MsgTrackingStateDetailedDep4
@@ -839,68 +1046,118 @@ TEST_F(Test_legacy_auto_check_sbp_tracking_MsgTrackingStateDetailedDep4, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 26427);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->L.f, 64)
+  EXPECT_EQ(get_as<decltype(last_msg_->L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->L.f)),
+            64)
       << "incorrect value for L.f, expected 64, is " << last_msg_->L.f;
-  EXPECT_EQ(last_msg_->L.i, 3275)
+  EXPECT_EQ(get_as<decltype(last_msg_->L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->L.i)),
+            3275)
       << "incorrect value for L.i, expected 3275, is " << last_msg_->L.i;
-  EXPECT_EQ(last_msg_->P, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->P)),
+            0)
       << "incorrect value for P, expected 0, is " << last_msg_->P;
-  EXPECT_EQ(last_msg_->P_std, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->P_std)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->P_std)),
+            0)
       << "incorrect value for P_std, expected 0, is " << last_msg_->P_std;
-  EXPECT_EQ(last_msg_->acceleration, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->acceleration)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->acceleration)),
+            2)
       << "incorrect value for acceleration, expected 2, is "
       << last_msg_->acceleration;
-  EXPECT_EQ(last_msg_->clock_drift, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->clock_drift)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->clock_drift)),
+            0)
       << "incorrect value for clock_drift, expected 0, is "
       << last_msg_->clock_drift;
-  EXPECT_EQ(last_msg_->clock_offset, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->clock_offset)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->clock_offset)),
+            0)
       << "incorrect value for clock_offset, expected 0, is "
       << last_msg_->clock_offset;
-  EXPECT_EQ(last_msg_->cn0, 184)
+  EXPECT_EQ(get_as<decltype(last_msg_->cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cn0)),
+            184)
       << "incorrect value for cn0, expected 184, is " << last_msg_->cn0;
-  EXPECT_EQ(last_msg_->corr_spacing, 40)
+  EXPECT_EQ(get_as<decltype(last_msg_->corr_spacing)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->corr_spacing)),
+            40)
       << "incorrect value for corr_spacing, expected 40, is "
       << last_msg_->corr_spacing;
-  EXPECT_EQ(last_msg_->doppler, 15640)
+  EXPECT_EQ(get_as<decltype(last_msg_->doppler)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->doppler)),
+            15640)
       << "incorrect value for doppler, expected 15640, is "
       << last_msg_->doppler;
-  EXPECT_EQ(last_msg_->doppler_std, 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->doppler_std)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->doppler_std)),
+            4)
       << "incorrect value for doppler_std, expected 4, is "
       << last_msg_->doppler_std;
-  EXPECT_EQ(last_msg_->lock, 14032)
+  EXPECT_EQ(get_as<decltype(last_msg_->lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->lock)),
+            14032)
       << "incorrect value for lock, expected 14032, is " << last_msg_->lock;
-  EXPECT_EQ(last_msg_->misc_flags, 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->misc_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->misc_flags)),
+            9)
       << "incorrect value for misc_flags, expected 9, is "
       << last_msg_->misc_flags;
-  EXPECT_EQ(last_msg_->nav_flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->nav_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->nav_flags)),
+            0)
       << "incorrect value for nav_flags, expected 0, is "
       << last_msg_->nav_flags;
-  EXPECT_EQ(last_msg_->pset_flags, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->pset_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pset_flags)),
+            3)
       << "incorrect value for pset_flags, expected 3, is "
       << last_msg_->pset_flags;
-  EXPECT_EQ(last_msg_->recv_time, 9906446269)
+  EXPECT_EQ(get_as<decltype(last_msg_->recv_time)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->recv_time)),
+            9906446269)
       << "incorrect value for recv_time, expected 9906446269, is "
       << last_msg_->recv_time;
-  EXPECT_EQ(last_msg_->sid.code, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.code)),
+            0)
       << "incorrect value for sid.code, expected 0, is " << last_msg_->sid.code;
-  EXPECT_EQ(last_msg_->sid.reserved, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.reserved)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.reserved)),
+            0)
       << "incorrect value for sid.reserved, expected 0, is "
       << last_msg_->sid.reserved;
-  EXPECT_EQ(last_msg_->sid.sat, 15)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.sat)),
+            15)
       << "incorrect value for sid.sat, expected 15, is " << last_msg_->sid.sat;
-  EXPECT_EQ(last_msg_->sync_flags, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->sync_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sync_flags)),
+            1)
       << "incorrect value for sync_flags, expected 1, is "
       << last_msg_->sync_flags;
-  EXPECT_EQ(last_msg_->tot.tow, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->tot.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tot.tow)),
+            0)
       << "incorrect value for tot.tow, expected 0, is " << last_msg_->tot.tow;
-  EXPECT_EQ(last_msg_->tot.wn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->tot.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tot.wn)),
+            0)
       << "incorrect value for tot.wn, expected 0, is " << last_msg_->tot.wn;
-  EXPECT_EQ(last_msg_->tow_flags, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow_flags)),
+            0)
       << "incorrect value for tow_flags, expected 0, is "
       << last_msg_->tow_flags;
-  EXPECT_EQ(last_msg_->track_flags, 11)
+  EXPECT_EQ(get_as<decltype(last_msg_->track_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->track_flags)),
+            11)
       << "incorrect value for track_flags, expected 11, is "
       << last_msg_->track_flags;
-  EXPECT_EQ(last_msg_->uptime, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->uptime)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->uptime)),
+            3)
       << "incorrect value for uptime, expected 3, is " << last_msg_->uptime;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_tracking_MsgTrackingStateDetailedDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_tracking_MsgTrackingStateDetailedDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/tracking.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_tracking_MsgTrackingStateDetailedDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -141,71 +148,121 @@ TEST_F(Test_legacy_auto_check_sbp_tracking_MsgTrackingStateDetailedDepA0,
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 28315);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->L.f, 204)
+  EXPECT_EQ(get_as<decltype(last_msg_->L.f)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->L.f)),
+            204)
       << "incorrect value for L.f, expected 204, is " << last_msg_->L.f;
-  EXPECT_EQ(last_msg_->L.i, -1601767965)
+  EXPECT_EQ(get_as<decltype(last_msg_->L.i)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->L.i)),
+            -1601767965)
       << "incorrect value for L.i, expected -1601767965, is " << last_msg_->L.i;
-  EXPECT_EQ(last_msg_->P, 1044286343)
+  EXPECT_EQ(get_as<decltype(last_msg_->P)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->P)),
+            1044286343)
       << "incorrect value for P, expected 1044286343, is " << last_msg_->P;
-  EXPECT_EQ(last_msg_->P_std, 21427)
+  EXPECT_EQ(get_as<decltype(last_msg_->P_std)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->P_std)),
+            21427)
       << "incorrect value for P_std, expected 21427, is " << last_msg_->P_std;
-  EXPECT_EQ(last_msg_->acceleration, -114)
+  EXPECT_EQ(get_as<decltype(last_msg_->acceleration)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->acceleration)),
+            -114)
       << "incorrect value for acceleration, expected -114, is "
       << last_msg_->acceleration;
-  EXPECT_EQ(last_msg_->clock_drift, 23311)
+  EXPECT_EQ(get_as<decltype(last_msg_->clock_drift)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->clock_drift)),
+            23311)
       << "incorrect value for clock_drift, expected 23311, is "
       << last_msg_->clock_drift;
-  EXPECT_EQ(last_msg_->clock_offset, 6012)
+  EXPECT_EQ(get_as<decltype(last_msg_->clock_offset)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->clock_offset)),
+            6012)
       << "incorrect value for clock_offset, expected 6012, is "
       << last_msg_->clock_offset;
-  EXPECT_EQ(last_msg_->cn0, 78)
+  EXPECT_EQ(get_as<decltype(last_msg_->cn0)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->cn0)),
+            78)
       << "incorrect value for cn0, expected 78, is " << last_msg_->cn0;
-  EXPECT_EQ(last_msg_->corr_spacing, 30201)
+  EXPECT_EQ(get_as<decltype(last_msg_->corr_spacing)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->corr_spacing)),
+            30201)
       << "incorrect value for corr_spacing, expected 30201, is "
       << last_msg_->corr_spacing;
-  EXPECT_EQ(last_msg_->doppler, 1459556257)
+  EXPECT_EQ(get_as<decltype(last_msg_->doppler)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->doppler)),
+            1459556257)
       << "incorrect value for doppler, expected 1459556257, is "
       << last_msg_->doppler;
-  EXPECT_EQ(last_msg_->doppler_std, 63677)
+  EXPECT_EQ(get_as<decltype(last_msg_->doppler_std)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->doppler_std)),
+            63677)
       << "incorrect value for doppler_std, expected 63677, is "
       << last_msg_->doppler_std;
-  EXPECT_EQ(last_msg_->lock, 65375)
+  EXPECT_EQ(get_as<decltype(last_msg_->lock)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->lock)),
+            65375)
       << "incorrect value for lock, expected 65375, is " << last_msg_->lock;
-  EXPECT_EQ(last_msg_->misc_flags, 62)
+  EXPECT_EQ(get_as<decltype(last_msg_->misc_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->misc_flags)),
+            62)
       << "incorrect value for misc_flags, expected 62, is "
       << last_msg_->misc_flags;
-  EXPECT_EQ(last_msg_->nav_flags, 25)
+  EXPECT_EQ(get_as<decltype(last_msg_->nav_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->nav_flags)),
+            25)
       << "incorrect value for nav_flags, expected 25, is "
       << last_msg_->nav_flags;
-  EXPECT_EQ(last_msg_->pset_flags, 83)
+  EXPECT_EQ(get_as<decltype(last_msg_->pset_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->pset_flags)),
+            83)
       << "incorrect value for pset_flags, expected 83, is "
       << last_msg_->pset_flags;
-  EXPECT_EQ(last_msg_->recv_time, 941247176494)
+  EXPECT_EQ(get_as<decltype(last_msg_->recv_time)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->recv_time)),
+            941247176494)
       << "incorrect value for recv_time, expected 941247176494, is "
       << last_msg_->recv_time;
-  EXPECT_EQ(last_msg_->sid.code, 59)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.code)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.code)),
+            59)
       << "incorrect value for sid.code, expected 59, is "
       << last_msg_->sid.code;
-  EXPECT_EQ(last_msg_->sid.sat, 38)
+  EXPECT_EQ(get_as<decltype(last_msg_->sid.sat)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sid.sat)),
+            38)
       << "incorrect value for sid.sat, expected 38, is " << last_msg_->sid.sat;
-  EXPECT_EQ(last_msg_->sync_flags, 90)
+  EXPECT_EQ(get_as<decltype(last_msg_->sync_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->sync_flags)),
+            90)
       << "incorrect value for sync_flags, expected 90, is "
       << last_msg_->sync_flags;
-  EXPECT_EQ(last_msg_->tot.ns_residual, -811597120)
+  EXPECT_EQ(get_as<decltype(last_msg_->tot.ns_residual)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tot.ns_residual)),
+            -811597120)
       << "incorrect value for tot.ns_residual, expected -811597120, is "
       << last_msg_->tot.ns_residual;
-  EXPECT_EQ(last_msg_->tot.tow, 1581737093)
+  EXPECT_EQ(get_as<decltype(last_msg_->tot.tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tot.tow)),
+            1581737093)
       << "incorrect value for tot.tow, expected 1581737093, is "
       << last_msg_->tot.tow;
-  EXPECT_EQ(last_msg_->tot.wn, 65492)
+  EXPECT_EQ(get_as<decltype(last_msg_->tot.wn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tot.wn)),
+            65492)
       << "incorrect value for tot.wn, expected 65492, is " << last_msg_->tot.wn;
-  EXPECT_EQ(last_msg_->tow_flags, 219)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow_flags)),
+            219)
       << "incorrect value for tow_flags, expected 219, is "
       << last_msg_->tow_flags;
-  EXPECT_EQ(last_msg_->track_flags, 67)
+  EXPECT_EQ(get_as<decltype(last_msg_->track_flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->track_flags)),
+            67)
       << "incorrect value for track_flags, expected 67, is "
       << last_msg_->track_flags;
-  EXPECT_EQ(last_msg_->uptime, 3263741727)
+  EXPECT_EQ(get_as<decltype(last_msg_->uptime)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->uptime)),
+            3263741727)
       << "incorrect value for uptime, expected 3263741727, is "
       << last_msg_->uptime;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_tracking_MsgtrackingStateDepA.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_tracking_MsgtrackingStateDepA.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/tracking.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_tracking_MsgtrackingStateDepA0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -195,100 +202,145 @@ TEST_F(Test_legacy_auto_check_sbp_tracking_MsgtrackingStateDepA0, Test) {
   EXPECT_LT((last_msg_->states[0].cn0 * 100 - 11.2309074402 * 100), 0.05)
       << "incorrect value for states[0].cn0, expected 11.2309074402, is "
       << last_msg_->states[0].cn0;
-  EXPECT_EQ(last_msg_->states[0].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[0].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[0].prn)),
+            0)
       << "incorrect value for states[0].prn, expected 0, is "
       << last_msg_->states[0].prn;
-  EXPECT_EQ(last_msg_->states[0].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[0].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[0].state)),
+            1)
       << "incorrect value for states[0].state, expected 1, is "
       << last_msg_->states[0].state;
   EXPECT_LT((last_msg_->states[1].cn0 * 100 - 10.43866539 * 100), 0.05)
       << "incorrect value for states[1].cn0, expected 10.43866539, is "
       << last_msg_->states[1].cn0;
-  EXPECT_EQ(last_msg_->states[1].prn, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[1].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[1].prn)),
+            2)
       << "incorrect value for states[1].prn, expected 2, is "
       << last_msg_->states[1].prn;
-  EXPECT_EQ(last_msg_->states[1].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[1].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[1].state)),
+            1)
       << "incorrect value for states[1].state, expected 1, is "
       << last_msg_->states[1].state;
   EXPECT_LT((last_msg_->states[2].cn0 * 100 - 9.73214244843 * 100), 0.05)
       << "incorrect value for states[2].cn0, expected 9.73214244843, is "
       << last_msg_->states[2].cn0;
-  EXPECT_EQ(last_msg_->states[2].prn, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[2].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[2].prn)),
+            3)
       << "incorrect value for states[2].prn, expected 3, is "
       << last_msg_->states[2].prn;
-  EXPECT_EQ(last_msg_->states[2].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[2].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[2].state)),
+            1)
       << "incorrect value for states[2].state, expected 1, is "
       << last_msg_->states[2].state;
   EXPECT_LT((last_msg_->states[3].cn0 * 100 - 14.34192276 * 100), 0.05)
       << "incorrect value for states[3].cn0, expected 14.34192276, is "
       << last_msg_->states[3].cn0;
-  EXPECT_EQ(last_msg_->states[3].prn, 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[3].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[3].prn)),
+            7)
       << "incorrect value for states[3].prn, expected 7, is "
       << last_msg_->states[3].prn;
-  EXPECT_EQ(last_msg_->states[3].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[3].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[3].state)),
+            1)
       << "incorrect value for states[3].state, expected 1, is "
       << last_msg_->states[3].state;
   EXPECT_LT((last_msg_->states[4].cn0 * 100 - 7.85490179062 * 100), 0.05)
       << "incorrect value for states[4].cn0, expected 7.85490179062, is "
       << last_msg_->states[4].cn0;
-  EXPECT_EQ(last_msg_->states[4].prn, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[4].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[4].prn)),
+            10)
       << "incorrect value for states[4].prn, expected 10, is "
       << last_msg_->states[4].prn;
-  EXPECT_EQ(last_msg_->states[4].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[4].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[4].state)),
+            1)
       << "incorrect value for states[4].state, expected 1, is "
       << last_msg_->states[4].state;
   EXPECT_LT((last_msg_->states[5].cn0 * 100 - 5.09828662872 * 100), 0.05)
       << "incorrect value for states[5].cn0, expected 5.09828662872, is "
       << last_msg_->states[5].cn0;
-  EXPECT_EQ(last_msg_->states[5].prn, 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[5].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[5].prn)),
+            13)
       << "incorrect value for states[5].prn, expected 13, is "
       << last_msg_->states[5].prn;
-  EXPECT_EQ(last_msg_->states[5].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[5].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[5].state)),
+            1)
       << "incorrect value for states[5].state, expected 1, is "
       << last_msg_->states[5].state;
   EXPECT_LT((last_msg_->states[6].cn0 * 100 - 6.74127292633 * 100), 0.05)
       << "incorrect value for states[6].cn0, expected 6.74127292633, is "
       << last_msg_->states[6].cn0;
-  EXPECT_EQ(last_msg_->states[6].prn, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[6].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[6].prn)),
+            22)
       << "incorrect value for states[6].prn, expected 22, is "
       << last_msg_->states[6].prn;
-  EXPECT_EQ(last_msg_->states[6].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[6].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[6].state)),
+            1)
       << "incorrect value for states[6].state, expected 1, is "
       << last_msg_->states[6].state;
   EXPECT_LT((last_msg_->states[7].cn0 * 100 - 12.7005491257 * 100), 0.05)
       << "incorrect value for states[7].cn0, expected 12.7005491257, is "
       << last_msg_->states[7].cn0;
-  EXPECT_EQ(last_msg_->states[7].prn, 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[7].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[7].prn)),
+            30)
       << "incorrect value for states[7].prn, expected 30, is "
       << last_msg_->states[7].prn;
-  EXPECT_EQ(last_msg_->states[7].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[7].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[7].state)),
+            1)
       << "incorrect value for states[7].state, expected 1, is "
       << last_msg_->states[7].state;
   EXPECT_LT((last_msg_->states[8].cn0 * 100 - 15.893081665 * 100), 0.05)
       << "incorrect value for states[8].cn0, expected 15.893081665, is "
       << last_msg_->states[8].cn0;
-  EXPECT_EQ(last_msg_->states[8].prn, 31)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[8].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[8].prn)),
+            31)
       << "incorrect value for states[8].prn, expected 31, is "
       << last_msg_->states[8].prn;
-  EXPECT_EQ(last_msg_->states[8].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[8].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[8].state)),
+            1)
       << "incorrect value for states[8].state, expected 1, is "
       << last_msg_->states[8].state;
   EXPECT_LT((last_msg_->states[9].cn0 * 100 - 4.24273872375 * 100), 0.05)
       << "incorrect value for states[9].cn0, expected 4.24273872375, is "
       << last_msg_->states[9].cn0;
-  EXPECT_EQ(last_msg_->states[9].prn, 25)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[9].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[9].prn)),
+            25)
       << "incorrect value for states[9].prn, expected 25, is "
       << last_msg_->states[9].prn;
-  EXPECT_EQ(last_msg_->states[9].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[9].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[9].state)),
+            1)
       << "incorrect value for states[9].state, expected 1, is "
       << last_msg_->states[9].state;
   EXPECT_LT((last_msg_->states[10].cn0 * 100 - 6.97599983215 * 100), 0.05)
       << "incorrect value for states[10].cn0, expected 6.97599983215, is "
       << last_msg_->states[10].cn0;
-  EXPECT_EQ(last_msg_->states[10].prn, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[10].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[10].prn)),
+            6)
       << "incorrect value for states[10].prn, expected 6, is "
       << last_msg_->states[10].prn;
-  EXPECT_EQ(last_msg_->states[10].state, 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[10].state)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[10].state)),
+      1)
       << "incorrect value for states[10].state, expected 1, is "
       << last_msg_->states[10].state;
 }
@@ -458,100 +510,145 @@ TEST_F(Test_legacy_auto_check_sbp_tracking_MsgtrackingStateDepA1, Test) {
   EXPECT_LT((last_msg_->states[0].cn0 * 100 - 11.0141220093 * 100), 0.05)
       << "incorrect value for states[0].cn0, expected 11.0141220093, is "
       << last_msg_->states[0].cn0;
-  EXPECT_EQ(last_msg_->states[0].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[0].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[0].prn)),
+            0)
       << "incorrect value for states[0].prn, expected 0, is "
       << last_msg_->states[0].prn;
-  EXPECT_EQ(last_msg_->states[0].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[0].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[0].state)),
+            1)
       << "incorrect value for states[0].state, expected 1, is "
       << last_msg_->states[0].state;
   EXPECT_LT((last_msg_->states[1].cn0 * 100 - 10.8851480484 * 100), 0.05)
       << "incorrect value for states[1].cn0, expected 10.8851480484, is "
       << last_msg_->states[1].cn0;
-  EXPECT_EQ(last_msg_->states[1].prn, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[1].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[1].prn)),
+            2)
       << "incorrect value for states[1].prn, expected 2, is "
       << last_msg_->states[1].prn;
-  EXPECT_EQ(last_msg_->states[1].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[1].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[1].state)),
+            1)
       << "incorrect value for states[1].state, expected 1, is "
       << last_msg_->states[1].state;
   EXPECT_LT((last_msg_->states[2].cn0 * 100 - 10.1313514709 * 100), 0.05)
       << "incorrect value for states[2].cn0, expected 10.1313514709, is "
       << last_msg_->states[2].cn0;
-  EXPECT_EQ(last_msg_->states[2].prn, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[2].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[2].prn)),
+            3)
       << "incorrect value for states[2].prn, expected 3, is "
       << last_msg_->states[2].prn;
-  EXPECT_EQ(last_msg_->states[2].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[2].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[2].state)),
+            1)
       << "incorrect value for states[2].state, expected 1, is "
       << last_msg_->states[2].state;
   EXPECT_LT((last_msg_->states[3].cn0 * 100 - 14.8290262222 * 100), 0.05)
       << "incorrect value for states[3].cn0, expected 14.8290262222, is "
       << last_msg_->states[3].cn0;
-  EXPECT_EQ(last_msg_->states[3].prn, 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[3].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[3].prn)),
+            7)
       << "incorrect value for states[3].prn, expected 7, is "
       << last_msg_->states[3].prn;
-  EXPECT_EQ(last_msg_->states[3].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[3].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[3].state)),
+            1)
       << "incorrect value for states[3].state, expected 1, is "
       << last_msg_->states[3].state;
   EXPECT_LT((last_msg_->states[4].cn0 * 100 - 7.79104471207 * 100), 0.05)
       << "incorrect value for states[4].cn0, expected 7.79104471207, is "
       << last_msg_->states[4].cn0;
-  EXPECT_EQ(last_msg_->states[4].prn, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[4].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[4].prn)),
+            10)
       << "incorrect value for states[4].prn, expected 10, is "
       << last_msg_->states[4].prn;
-  EXPECT_EQ(last_msg_->states[4].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[4].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[4].state)),
+            1)
       << "incorrect value for states[4].state, expected 1, is "
       << last_msg_->states[4].state;
   EXPECT_LT((last_msg_->states[5].cn0 * 100 - 4.86816120148 * 100), 0.05)
       << "incorrect value for states[5].cn0, expected 4.86816120148, is "
       << last_msg_->states[5].cn0;
-  EXPECT_EQ(last_msg_->states[5].prn, 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[5].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[5].prn)),
+            13)
       << "incorrect value for states[5].prn, expected 13, is "
       << last_msg_->states[5].prn;
-  EXPECT_EQ(last_msg_->states[5].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[5].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[5].state)),
+            1)
       << "incorrect value for states[5].state, expected 1, is "
       << last_msg_->states[5].state;
   EXPECT_LT((last_msg_->states[6].cn0 * 100 - 6.72109556198 * 100), 0.05)
       << "incorrect value for states[6].cn0, expected 6.72109556198, is "
       << last_msg_->states[6].cn0;
-  EXPECT_EQ(last_msg_->states[6].prn, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[6].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[6].prn)),
+            22)
       << "incorrect value for states[6].prn, expected 22, is "
       << last_msg_->states[6].prn;
-  EXPECT_EQ(last_msg_->states[6].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[6].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[6].state)),
+            1)
       << "incorrect value for states[6].state, expected 1, is "
       << last_msg_->states[6].state;
   EXPECT_LT((last_msg_->states[7].cn0 * 100 - 12.9713230133 * 100), 0.05)
       << "incorrect value for states[7].cn0, expected 12.9713230133, is "
       << last_msg_->states[7].cn0;
-  EXPECT_EQ(last_msg_->states[7].prn, 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[7].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[7].prn)),
+            30)
       << "incorrect value for states[7].prn, expected 30, is "
       << last_msg_->states[7].prn;
-  EXPECT_EQ(last_msg_->states[7].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[7].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[7].state)),
+            1)
       << "incorrect value for states[7].state, expected 1, is "
       << last_msg_->states[7].state;
   EXPECT_LT((last_msg_->states[8].cn0 * 100 - 15.4814052582 * 100), 0.05)
       << "incorrect value for states[8].cn0, expected 15.4814052582, is "
       << last_msg_->states[8].cn0;
-  EXPECT_EQ(last_msg_->states[8].prn, 31)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[8].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[8].prn)),
+            31)
       << "incorrect value for states[8].prn, expected 31, is "
       << last_msg_->states[8].prn;
-  EXPECT_EQ(last_msg_->states[8].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[8].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[8].state)),
+            1)
       << "incorrect value for states[8].state, expected 1, is "
       << last_msg_->states[8].state;
   EXPECT_LT((last_msg_->states[9].cn0 * 100 - 3.88343548775 * 100), 0.05)
       << "incorrect value for states[9].cn0, expected 3.88343548775, is "
       << last_msg_->states[9].cn0;
-  EXPECT_EQ(last_msg_->states[9].prn, 25)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[9].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[9].prn)),
+            25)
       << "incorrect value for states[9].prn, expected 25, is "
       << last_msg_->states[9].prn;
-  EXPECT_EQ(last_msg_->states[9].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[9].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[9].state)),
+            1)
       << "incorrect value for states[9].state, expected 1, is "
       << last_msg_->states[9].state;
   EXPECT_LT((last_msg_->states[10].cn0 * 100 - 4.06148862839 * 100), 0.05)
       << "incorrect value for states[10].cn0, expected 4.06148862839, is "
       << last_msg_->states[10].cn0;
-  EXPECT_EQ(last_msg_->states[10].prn, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[10].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[10].prn)),
+            6)
       << "incorrect value for states[10].prn, expected 6, is "
       << last_msg_->states[10].prn;
-  EXPECT_EQ(last_msg_->states[10].state, 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[10].state)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[10].state)),
+      1)
       << "incorrect value for states[10].state, expected 1, is "
       << last_msg_->states[10].state;
 }
@@ -721,100 +818,145 @@ TEST_F(Test_legacy_auto_check_sbp_tracking_MsgtrackingStateDepA2, Test) {
   EXPECT_LT((last_msg_->states[0].cn0 * 100 - 11.7686891556 * 100), 0.05)
       << "incorrect value for states[0].cn0, expected 11.7686891556, is "
       << last_msg_->states[0].cn0;
-  EXPECT_EQ(last_msg_->states[0].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[0].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[0].prn)),
+            0)
       << "incorrect value for states[0].prn, expected 0, is "
       << last_msg_->states[0].prn;
-  EXPECT_EQ(last_msg_->states[0].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[0].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[0].state)),
+            1)
       << "incorrect value for states[0].state, expected 1, is "
       << last_msg_->states[0].state;
   EXPECT_LT((last_msg_->states[1].cn0 * 100 - 10.9090013504 * 100), 0.05)
       << "incorrect value for states[1].cn0, expected 10.9090013504, is "
       << last_msg_->states[1].cn0;
-  EXPECT_EQ(last_msg_->states[1].prn, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[1].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[1].prn)),
+            2)
       << "incorrect value for states[1].prn, expected 2, is "
       << last_msg_->states[1].prn;
-  EXPECT_EQ(last_msg_->states[1].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[1].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[1].state)),
+            1)
       << "incorrect value for states[1].state, expected 1, is "
       << last_msg_->states[1].state;
   EXPECT_LT((last_msg_->states[2].cn0 * 100 - 9.88173103333 * 100), 0.05)
       << "incorrect value for states[2].cn0, expected 9.88173103333, is "
       << last_msg_->states[2].cn0;
-  EXPECT_EQ(last_msg_->states[2].prn, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[2].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[2].prn)),
+            3)
       << "incorrect value for states[2].prn, expected 3, is "
       << last_msg_->states[2].prn;
-  EXPECT_EQ(last_msg_->states[2].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[2].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[2].state)),
+            1)
       << "incorrect value for states[2].state, expected 1, is "
       << last_msg_->states[2].state;
   EXPECT_LT((last_msg_->states[3].cn0 * 100 - 14.0763959885 * 100), 0.05)
       << "incorrect value for states[3].cn0, expected 14.0763959885, is "
       << last_msg_->states[3].cn0;
-  EXPECT_EQ(last_msg_->states[3].prn, 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[3].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[3].prn)),
+            7)
       << "incorrect value for states[3].prn, expected 7, is "
       << last_msg_->states[3].prn;
-  EXPECT_EQ(last_msg_->states[3].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[3].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[3].state)),
+            1)
       << "incorrect value for states[3].state, expected 1, is "
       << last_msg_->states[3].state;
   EXPECT_LT((last_msg_->states[4].cn0 * 100 - 7.6198182106 * 100), 0.05)
       << "incorrect value for states[4].cn0, expected 7.6198182106, is "
       << last_msg_->states[4].cn0;
-  EXPECT_EQ(last_msg_->states[4].prn, 10)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[4].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[4].prn)),
+            10)
       << "incorrect value for states[4].prn, expected 10, is "
       << last_msg_->states[4].prn;
-  EXPECT_EQ(last_msg_->states[4].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[4].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[4].state)),
+            1)
       << "incorrect value for states[4].state, expected 1, is "
       << last_msg_->states[4].state;
   EXPECT_LT((last_msg_->states[5].cn0 * 100 - 5.20837116241 * 100), 0.05)
       << "incorrect value for states[5].cn0, expected 5.20837116241, is "
       << last_msg_->states[5].cn0;
-  EXPECT_EQ(last_msg_->states[5].prn, 13)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[5].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[5].prn)),
+            13)
       << "incorrect value for states[5].prn, expected 13, is "
       << last_msg_->states[5].prn;
-  EXPECT_EQ(last_msg_->states[5].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[5].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[5].state)),
+            1)
       << "incorrect value for states[5].state, expected 1, is "
       << last_msg_->states[5].state;
   EXPECT_LT((last_msg_->states[6].cn0 * 100 - 6.29358720779 * 100), 0.05)
       << "incorrect value for states[6].cn0, expected 6.29358720779, is "
       << last_msg_->states[6].cn0;
-  EXPECT_EQ(last_msg_->states[6].prn, 22)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[6].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[6].prn)),
+            22)
       << "incorrect value for states[6].prn, expected 22, is "
       << last_msg_->states[6].prn;
-  EXPECT_EQ(last_msg_->states[6].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[6].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[6].state)),
+            1)
       << "incorrect value for states[6].state, expected 1, is "
       << last_msg_->states[6].state;
   EXPECT_LT((last_msg_->states[7].cn0 * 100 - 13.2323417664 * 100), 0.05)
       << "incorrect value for states[7].cn0, expected 13.2323417664, is "
       << last_msg_->states[7].cn0;
-  EXPECT_EQ(last_msg_->states[7].prn, 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[7].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[7].prn)),
+            30)
       << "incorrect value for states[7].prn, expected 30, is "
       << last_msg_->states[7].prn;
-  EXPECT_EQ(last_msg_->states[7].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[7].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[7].state)),
+            1)
       << "incorrect value for states[7].state, expected 1, is "
       << last_msg_->states[7].state;
   EXPECT_LT((last_msg_->states[8].cn0 * 100 - 15.5473461151 * 100), 0.05)
       << "incorrect value for states[8].cn0, expected 15.5473461151, is "
       << last_msg_->states[8].cn0;
-  EXPECT_EQ(last_msg_->states[8].prn, 31)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[8].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[8].prn)),
+            31)
       << "incorrect value for states[8].prn, expected 31, is "
       << last_msg_->states[8].prn;
-  EXPECT_EQ(last_msg_->states[8].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[8].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[8].state)),
+            1)
       << "incorrect value for states[8].state, expected 1, is "
       << last_msg_->states[8].state;
   EXPECT_LT((last_msg_->states[9].cn0 * 100 - 4.13096427917 * 100), 0.05)
       << "incorrect value for states[9].cn0, expected 4.13096427917, is "
       << last_msg_->states[9].cn0;
-  EXPECT_EQ(last_msg_->states[9].prn, 25)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[9].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[9].prn)),
+            25)
       << "incorrect value for states[9].prn, expected 25, is "
       << last_msg_->states[9].prn;
-  EXPECT_EQ(last_msg_->states[9].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[9].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[9].state)),
+            1)
       << "incorrect value for states[9].state, expected 1, is "
       << last_msg_->states[9].state;
   EXPECT_LT((last_msg_->states[10].cn0 * 100 - 2.85682320595 * 100), 0.05)
       << "incorrect value for states[10].cn0, expected 2.85682320595, is "
       << last_msg_->states[10].cn0;
-  EXPECT_EQ(last_msg_->states[10].prn, 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[10].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[10].prn)),
+            6)
       << "incorrect value for states[10].prn, expected 6, is "
       << last_msg_->states[10].prn;
-  EXPECT_EQ(last_msg_->states[10].state, 1)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[10].state)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[10].state)),
+      1)
       << "incorrect value for states[10].state, expected 1, is "
       << last_msg_->states[10].state;
 }
@@ -984,100 +1126,145 @@ TEST_F(Test_legacy_auto_check_sbp_tracking_MsgtrackingStateDepA3, Test) {
   EXPECT_LT((last_msg_->states[0].cn0 * 100 - 62.1398582458 * 100), 0.05)
       << "incorrect value for states[0].cn0, expected 62.1398582458, is "
       << last_msg_->states[0].cn0;
-  EXPECT_EQ(last_msg_->states[0].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[0].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[0].prn)),
+            0)
       << "incorrect value for states[0].prn, expected 0, is "
       << last_msg_->states[0].prn;
-  EXPECT_EQ(last_msg_->states[0].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[0].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[0].state)),
+            1)
       << "incorrect value for states[0].state, expected 1, is "
       << last_msg_->states[0].state;
   EXPECT_LT((last_msg_->states[1].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[1].cn0, expected -1.0, is "
       << last_msg_->states[1].cn0;
-  EXPECT_EQ(last_msg_->states[1].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[1].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[1].prn)),
+            0)
       << "incorrect value for states[1].prn, expected 0, is "
       << last_msg_->states[1].prn;
-  EXPECT_EQ(last_msg_->states[1].state, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[1].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[1].state)),
+            0)
       << "incorrect value for states[1].state, expected 0, is "
       << last_msg_->states[1].state;
   EXPECT_LT((last_msg_->states[2].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[2].cn0, expected -1.0, is "
       << last_msg_->states[2].cn0;
-  EXPECT_EQ(last_msg_->states[2].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[2].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[2].prn)),
+            0)
       << "incorrect value for states[2].prn, expected 0, is "
       << last_msg_->states[2].prn;
-  EXPECT_EQ(last_msg_->states[2].state, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[2].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[2].state)),
+            0)
       << "incorrect value for states[2].state, expected 0, is "
       << last_msg_->states[2].state;
   EXPECT_LT((last_msg_->states[3].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[3].cn0, expected -1.0, is "
       << last_msg_->states[3].cn0;
-  EXPECT_EQ(last_msg_->states[3].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[3].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[3].prn)),
+            0)
       << "incorrect value for states[3].prn, expected 0, is "
       << last_msg_->states[3].prn;
-  EXPECT_EQ(last_msg_->states[3].state, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[3].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[3].state)),
+            0)
       << "incorrect value for states[3].state, expected 0, is "
       << last_msg_->states[3].state;
   EXPECT_LT((last_msg_->states[4].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[4].cn0, expected -1.0, is "
       << last_msg_->states[4].cn0;
-  EXPECT_EQ(last_msg_->states[4].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[4].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[4].prn)),
+            0)
       << "incorrect value for states[4].prn, expected 0, is "
       << last_msg_->states[4].prn;
-  EXPECT_EQ(last_msg_->states[4].state, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[4].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[4].state)),
+            0)
       << "incorrect value for states[4].state, expected 0, is "
       << last_msg_->states[4].state;
   EXPECT_LT((last_msg_->states[5].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[5].cn0, expected -1.0, is "
       << last_msg_->states[5].cn0;
-  EXPECT_EQ(last_msg_->states[5].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[5].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[5].prn)),
+            0)
       << "incorrect value for states[5].prn, expected 0, is "
       << last_msg_->states[5].prn;
-  EXPECT_EQ(last_msg_->states[5].state, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[5].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[5].state)),
+            0)
       << "incorrect value for states[5].state, expected 0, is "
       << last_msg_->states[5].state;
   EXPECT_LT((last_msg_->states[6].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[6].cn0, expected -1.0, is "
       << last_msg_->states[6].cn0;
-  EXPECT_EQ(last_msg_->states[6].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[6].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[6].prn)),
+            0)
       << "incorrect value for states[6].prn, expected 0, is "
       << last_msg_->states[6].prn;
-  EXPECT_EQ(last_msg_->states[6].state, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[6].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[6].state)),
+            0)
       << "incorrect value for states[6].state, expected 0, is "
       << last_msg_->states[6].state;
   EXPECT_LT((last_msg_->states[7].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[7].cn0, expected -1.0, is "
       << last_msg_->states[7].cn0;
-  EXPECT_EQ(last_msg_->states[7].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[7].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[7].prn)),
+            0)
       << "incorrect value for states[7].prn, expected 0, is "
       << last_msg_->states[7].prn;
-  EXPECT_EQ(last_msg_->states[7].state, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[7].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[7].state)),
+            0)
       << "incorrect value for states[7].state, expected 0, is "
       << last_msg_->states[7].state;
   EXPECT_LT((last_msg_->states[8].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[8].cn0, expected -1.0, is "
       << last_msg_->states[8].cn0;
-  EXPECT_EQ(last_msg_->states[8].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[8].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[8].prn)),
+            0)
       << "incorrect value for states[8].prn, expected 0, is "
       << last_msg_->states[8].prn;
-  EXPECT_EQ(last_msg_->states[8].state, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[8].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[8].state)),
+            0)
       << "incorrect value for states[8].state, expected 0, is "
       << last_msg_->states[8].state;
   EXPECT_LT((last_msg_->states[9].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[9].cn0, expected -1.0, is "
       << last_msg_->states[9].cn0;
-  EXPECT_EQ(last_msg_->states[9].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[9].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[9].prn)),
+            0)
       << "incorrect value for states[9].prn, expected 0, is "
       << last_msg_->states[9].prn;
-  EXPECT_EQ(last_msg_->states[9].state, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[9].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[9].state)),
+            0)
       << "incorrect value for states[9].state, expected 0, is "
       << last_msg_->states[9].state;
   EXPECT_LT((last_msg_->states[10].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[10].cn0, expected -1.0, is "
       << last_msg_->states[10].cn0;
-  EXPECT_EQ(last_msg_->states[10].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[10].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[10].prn)),
+            0)
       << "incorrect value for states[10].prn, expected 0, is "
       << last_msg_->states[10].prn;
-  EXPECT_EQ(last_msg_->states[10].state, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[10].state)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[10].state)),
+      0)
       << "incorrect value for states[10].state, expected 0, is "
       << last_msg_->states[10].state;
 }
@@ -1247,100 +1434,145 @@ TEST_F(Test_legacy_auto_check_sbp_tracking_MsgtrackingStateDepA4, Test) {
   EXPECT_LT((last_msg_->states[0].cn0 * 100 - 36.764503479 * 100), 0.05)
       << "incorrect value for states[0].cn0, expected 36.764503479, is "
       << last_msg_->states[0].cn0;
-  EXPECT_EQ(last_msg_->states[0].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[0].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[0].prn)),
+            0)
       << "incorrect value for states[0].prn, expected 0, is "
       << last_msg_->states[0].prn;
-  EXPECT_EQ(last_msg_->states[0].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[0].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[0].state)),
+            1)
       << "incorrect value for states[0].state, expected 1, is "
       << last_msg_->states[0].state;
   EXPECT_LT((last_msg_->states[1].cn0 * 100 - 9.31343269348 * 100), 0.05)
       << "incorrect value for states[1].cn0, expected 9.31343269348, is "
       << last_msg_->states[1].cn0;
-  EXPECT_EQ(last_msg_->states[1].prn, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[1].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[1].prn)),
+            2)
       << "incorrect value for states[1].prn, expected 2, is "
       << last_msg_->states[1].prn;
-  EXPECT_EQ(last_msg_->states[1].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[1].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[1].state)),
+            1)
       << "incorrect value for states[1].state, expected 1, is "
       << last_msg_->states[1].state;
   EXPECT_LT((last_msg_->states[2].cn0 * 100 - 16.8549385071 * 100), 0.05)
       << "incorrect value for states[2].cn0, expected 16.8549385071, is "
       << last_msg_->states[2].cn0;
-  EXPECT_EQ(last_msg_->states[2].prn, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[2].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[2].prn)),
+            3)
       << "incorrect value for states[2].prn, expected 3, is "
       << last_msg_->states[2].prn;
-  EXPECT_EQ(last_msg_->states[2].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[2].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[2].state)),
+            1)
       << "incorrect value for states[2].state, expected 1, is "
       << last_msg_->states[2].state;
   EXPECT_LT((last_msg_->states[3].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[3].cn0, expected -1.0, is "
       << last_msg_->states[3].cn0;
-  EXPECT_EQ(last_msg_->states[3].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[3].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[3].prn)),
+            0)
       << "incorrect value for states[3].prn, expected 0, is "
       << last_msg_->states[3].prn;
-  EXPECT_EQ(last_msg_->states[3].state, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[3].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[3].state)),
+            0)
       << "incorrect value for states[3].state, expected 0, is "
       << last_msg_->states[3].state;
   EXPECT_LT((last_msg_->states[4].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[4].cn0, expected -1.0, is "
       << last_msg_->states[4].cn0;
-  EXPECT_EQ(last_msg_->states[4].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[4].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[4].prn)),
+            0)
       << "incorrect value for states[4].prn, expected 0, is "
       << last_msg_->states[4].prn;
-  EXPECT_EQ(last_msg_->states[4].state, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[4].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[4].state)),
+            0)
       << "incorrect value for states[4].state, expected 0, is "
       << last_msg_->states[4].state;
   EXPECT_LT((last_msg_->states[5].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[5].cn0, expected -1.0, is "
       << last_msg_->states[5].cn0;
-  EXPECT_EQ(last_msg_->states[5].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[5].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[5].prn)),
+            0)
       << "incorrect value for states[5].prn, expected 0, is "
       << last_msg_->states[5].prn;
-  EXPECT_EQ(last_msg_->states[5].state, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[5].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[5].state)),
+            0)
       << "incorrect value for states[5].state, expected 0, is "
       << last_msg_->states[5].state;
   EXPECT_LT((last_msg_->states[6].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[6].cn0, expected -1.0, is "
       << last_msg_->states[6].cn0;
-  EXPECT_EQ(last_msg_->states[6].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[6].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[6].prn)),
+            0)
       << "incorrect value for states[6].prn, expected 0, is "
       << last_msg_->states[6].prn;
-  EXPECT_EQ(last_msg_->states[6].state, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[6].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[6].state)),
+            0)
       << "incorrect value for states[6].state, expected 0, is "
       << last_msg_->states[6].state;
   EXPECT_LT((last_msg_->states[7].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[7].cn0, expected -1.0, is "
       << last_msg_->states[7].cn0;
-  EXPECT_EQ(last_msg_->states[7].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[7].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[7].prn)),
+            0)
       << "incorrect value for states[7].prn, expected 0, is "
       << last_msg_->states[7].prn;
-  EXPECT_EQ(last_msg_->states[7].state, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[7].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[7].state)),
+            0)
       << "incorrect value for states[7].state, expected 0, is "
       << last_msg_->states[7].state;
   EXPECT_LT((last_msg_->states[8].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[8].cn0, expected -1.0, is "
       << last_msg_->states[8].cn0;
-  EXPECT_EQ(last_msg_->states[8].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[8].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[8].prn)),
+            0)
       << "incorrect value for states[8].prn, expected 0, is "
       << last_msg_->states[8].prn;
-  EXPECT_EQ(last_msg_->states[8].state, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[8].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[8].state)),
+            0)
       << "incorrect value for states[8].state, expected 0, is "
       << last_msg_->states[8].state;
   EXPECT_LT((last_msg_->states[9].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[9].cn0, expected -1.0, is "
       << last_msg_->states[9].cn0;
-  EXPECT_EQ(last_msg_->states[9].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[9].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[9].prn)),
+            0)
       << "incorrect value for states[9].prn, expected 0, is "
       << last_msg_->states[9].prn;
-  EXPECT_EQ(last_msg_->states[9].state, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[9].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[9].state)),
+            0)
       << "incorrect value for states[9].state, expected 0, is "
       << last_msg_->states[9].state;
   EXPECT_LT((last_msg_->states[10].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[10].cn0, expected -1.0, is "
       << last_msg_->states[10].cn0;
-  EXPECT_EQ(last_msg_->states[10].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[10].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[10].prn)),
+            0)
       << "incorrect value for states[10].prn, expected 0, is "
       << last_msg_->states[10].prn;
-  EXPECT_EQ(last_msg_->states[10].state, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[10].state)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[10].state)),
+      0)
       << "incorrect value for states[10].state, expected 0, is "
       << last_msg_->states[10].state;
 }
@@ -1510,100 +1742,145 @@ TEST_F(Test_legacy_auto_check_sbp_tracking_MsgtrackingStateDepA5, Test) {
   EXPECT_LT((last_msg_->states[0].cn0 * 100 - 27.3942298889 * 100), 0.05)
       << "incorrect value for states[0].cn0, expected 27.3942298889, is "
       << last_msg_->states[0].cn0;
-  EXPECT_EQ(last_msg_->states[0].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[0].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[0].prn)),
+            0)
       << "incorrect value for states[0].prn, expected 0, is "
       << last_msg_->states[0].prn;
-  EXPECT_EQ(last_msg_->states[0].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[0].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[0].state)),
+            1)
       << "incorrect value for states[0].state, expected 1, is "
       << last_msg_->states[0].state;
   EXPECT_LT((last_msg_->states[1].cn0 * 100 - 2.875 * 100), 0.05)
       << "incorrect value for states[1].cn0, expected 2.875, is "
       << last_msg_->states[1].cn0;
-  EXPECT_EQ(last_msg_->states[1].prn, 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[1].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[1].prn)),
+            2)
       << "incorrect value for states[1].prn, expected 2, is "
       << last_msg_->states[1].prn;
-  EXPECT_EQ(last_msg_->states[1].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[1].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[1].state)),
+            1)
       << "incorrect value for states[1].state, expected 1, is "
       << last_msg_->states[1].state;
   EXPECT_LT((last_msg_->states[2].cn0 * 100 - 8.46764469147 * 100), 0.05)
       << "incorrect value for states[2].cn0, expected 8.46764469147, is "
       << last_msg_->states[2].cn0;
-  EXPECT_EQ(last_msg_->states[2].prn, 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[2].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[2].prn)),
+            3)
       << "incorrect value for states[2].prn, expected 3, is "
       << last_msg_->states[2].prn;
-  EXPECT_EQ(last_msg_->states[2].state, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[2].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[2].state)),
+            1)
       << "incorrect value for states[2].state, expected 1, is "
       << last_msg_->states[2].state;
   EXPECT_LT((last_msg_->states[3].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[3].cn0, expected -1.0, is "
       << last_msg_->states[3].cn0;
-  EXPECT_EQ(last_msg_->states[3].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[3].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[3].prn)),
+            0)
       << "incorrect value for states[3].prn, expected 0, is "
       << last_msg_->states[3].prn;
-  EXPECT_EQ(last_msg_->states[3].state, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[3].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[3].state)),
+            0)
       << "incorrect value for states[3].state, expected 0, is "
       << last_msg_->states[3].state;
   EXPECT_LT((last_msg_->states[4].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[4].cn0, expected -1.0, is "
       << last_msg_->states[4].cn0;
-  EXPECT_EQ(last_msg_->states[4].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[4].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[4].prn)),
+            0)
       << "incorrect value for states[4].prn, expected 0, is "
       << last_msg_->states[4].prn;
-  EXPECT_EQ(last_msg_->states[4].state, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[4].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[4].state)),
+            0)
       << "incorrect value for states[4].state, expected 0, is "
       << last_msg_->states[4].state;
   EXPECT_LT((last_msg_->states[5].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[5].cn0, expected -1.0, is "
       << last_msg_->states[5].cn0;
-  EXPECT_EQ(last_msg_->states[5].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[5].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[5].prn)),
+            0)
       << "incorrect value for states[5].prn, expected 0, is "
       << last_msg_->states[5].prn;
-  EXPECT_EQ(last_msg_->states[5].state, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[5].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[5].state)),
+            0)
       << "incorrect value for states[5].state, expected 0, is "
       << last_msg_->states[5].state;
   EXPECT_LT((last_msg_->states[6].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[6].cn0, expected -1.0, is "
       << last_msg_->states[6].cn0;
-  EXPECT_EQ(last_msg_->states[6].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[6].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[6].prn)),
+            0)
       << "incorrect value for states[6].prn, expected 0, is "
       << last_msg_->states[6].prn;
-  EXPECT_EQ(last_msg_->states[6].state, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[6].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[6].state)),
+            0)
       << "incorrect value for states[6].state, expected 0, is "
       << last_msg_->states[6].state;
   EXPECT_LT((last_msg_->states[7].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[7].cn0, expected -1.0, is "
       << last_msg_->states[7].cn0;
-  EXPECT_EQ(last_msg_->states[7].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[7].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[7].prn)),
+            0)
       << "incorrect value for states[7].prn, expected 0, is "
       << last_msg_->states[7].prn;
-  EXPECT_EQ(last_msg_->states[7].state, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[7].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[7].state)),
+            0)
       << "incorrect value for states[7].state, expected 0, is "
       << last_msg_->states[7].state;
   EXPECT_LT((last_msg_->states[8].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[8].cn0, expected -1.0, is "
       << last_msg_->states[8].cn0;
-  EXPECT_EQ(last_msg_->states[8].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[8].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[8].prn)),
+            0)
       << "incorrect value for states[8].prn, expected 0, is "
       << last_msg_->states[8].prn;
-  EXPECT_EQ(last_msg_->states[8].state, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[8].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[8].state)),
+            0)
       << "incorrect value for states[8].state, expected 0, is "
       << last_msg_->states[8].state;
   EXPECT_LT((last_msg_->states[9].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[9].cn0, expected -1.0, is "
       << last_msg_->states[9].cn0;
-  EXPECT_EQ(last_msg_->states[9].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[9].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[9].prn)),
+            0)
       << "incorrect value for states[9].prn, expected 0, is "
       << last_msg_->states[9].prn;
-  EXPECT_EQ(last_msg_->states[9].state, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[9].state)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[9].state)),
+            0)
       << "incorrect value for states[9].state, expected 0, is "
       << last_msg_->states[9].state;
   EXPECT_LT((last_msg_->states[10].cn0 * 100 - -1.0 * 100), 0.05)
       << "incorrect value for states[10].cn0, expected -1.0, is "
       << last_msg_->states[10].cn0;
-  EXPECT_EQ(last_msg_->states[10].prn, 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->states[10].prn)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->states[10].prn)),
+            0)
       << "incorrect value for states[10].prn, expected 0, is "
       << last_msg_->states[10].prn;
-  EXPECT_EQ(last_msg_->states[10].state, 0)
+  EXPECT_EQ(
+      get_as<decltype(last_msg_->states[10].state)>(
+          reinterpret_cast<const uint8_t *>(&last_msg_->states[10].state)),
+      0)
       << "incorrect value for states[10].state, expected 0, is "
       << last_msg_->states[10].state;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_user_MsgUserData.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_user_MsgUserData.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/user.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_user_MsgUserData0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -1401,769 +1408,1279 @@ TEST_F(Test_legacy_auto_check_sbp_user_MsgUserData0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 8574);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->contents[0], 53)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[0])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[0])),
+            53)
       << "incorrect value for contents[0], expected 53, is "
       << last_msg_->contents[0];
-  EXPECT_EQ(last_msg_->contents[1], 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[1])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[1])),
+            5)
       << "incorrect value for contents[1], expected 5, is "
       << last_msg_->contents[1];
-  EXPECT_EQ(last_msg_->contents[2], 172)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[2])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[2])),
+            172)
       << "incorrect value for contents[2], expected 172, is "
       << last_msg_->contents[2];
-  EXPECT_EQ(last_msg_->contents[3], 138)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[3])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[3])),
+            138)
       << "incorrect value for contents[3], expected 138, is "
       << last_msg_->contents[3];
-  EXPECT_EQ(last_msg_->contents[4], 50)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[4])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[4])),
+            50)
       << "incorrect value for contents[4], expected 50, is "
       << last_msg_->contents[4];
-  EXPECT_EQ(last_msg_->contents[5], 49)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[5])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[5])),
+            49)
       << "incorrect value for contents[5], expected 49, is "
       << last_msg_->contents[5];
-  EXPECT_EQ(last_msg_->contents[6], 206)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[6])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[6])),
+            206)
       << "incorrect value for contents[6], expected 206, is "
       << last_msg_->contents[6];
-  EXPECT_EQ(last_msg_->contents[7], 234)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[7])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[7])),
+            234)
       << "incorrect value for contents[7], expected 234, is "
       << last_msg_->contents[7];
-  EXPECT_EQ(last_msg_->contents[8], 149)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[8])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[8])),
+            149)
       << "incorrect value for contents[8], expected 149, is "
       << last_msg_->contents[8];
-  EXPECT_EQ(last_msg_->contents[9], 204)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[9])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[9])),
+            204)
       << "incorrect value for contents[9], expected 204, is "
       << last_msg_->contents[9];
-  EXPECT_EQ(last_msg_->contents[10], 113)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[10])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[10])),
+            113)
       << "incorrect value for contents[10], expected 113, is "
       << last_msg_->contents[10];
-  EXPECT_EQ(last_msg_->contents[11], 31)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[11])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[11])),
+            31)
       << "incorrect value for contents[11], expected 31, is "
       << last_msg_->contents[11];
-  EXPECT_EQ(last_msg_->contents[12], 108)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[12])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[12])),
+            108)
       << "incorrect value for contents[12], expected 108, is "
       << last_msg_->contents[12];
-  EXPECT_EQ(last_msg_->contents[13], 188)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[13])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[13])),
+            188)
       << "incorrect value for contents[13], expected 188, is "
       << last_msg_->contents[13];
-  EXPECT_EQ(last_msg_->contents[14], 179)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[14])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[14])),
+            179)
       << "incorrect value for contents[14], expected 179, is "
       << last_msg_->contents[14];
-  EXPECT_EQ(last_msg_->contents[15], 154)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[15])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[15])),
+            154)
       << "incorrect value for contents[15], expected 154, is "
       << last_msg_->contents[15];
-  EXPECT_EQ(last_msg_->contents[16], 156)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[16])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[16])),
+            156)
       << "incorrect value for contents[16], expected 156, is "
       << last_msg_->contents[16];
-  EXPECT_EQ(last_msg_->contents[17], 167)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[17])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[17])),
+            167)
       << "incorrect value for contents[17], expected 167, is "
       << last_msg_->contents[17];
-  EXPECT_EQ(last_msg_->contents[18], 145)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[18])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[18])),
+            145)
       << "incorrect value for contents[18], expected 145, is "
       << last_msg_->contents[18];
-  EXPECT_EQ(last_msg_->contents[19], 139)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[19])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[19])),
+            139)
       << "incorrect value for contents[19], expected 139, is "
       << last_msg_->contents[19];
-  EXPECT_EQ(last_msg_->contents[20], 42)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[20])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[20])),
+            42)
       << "incorrect value for contents[20], expected 42, is "
       << last_msg_->contents[20];
-  EXPECT_EQ(last_msg_->contents[21], 207)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[21])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[21])),
+            207)
       << "incorrect value for contents[21], expected 207, is "
       << last_msg_->contents[21];
-  EXPECT_EQ(last_msg_->contents[22], 126)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[22])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[22])),
+            126)
       << "incorrect value for contents[22], expected 126, is "
       << last_msg_->contents[22];
-  EXPECT_EQ(last_msg_->contents[23], 242)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[23])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[23])),
+            242)
       << "incorrect value for contents[23], expected 242, is "
       << last_msg_->contents[23];
-  EXPECT_EQ(last_msg_->contents[24], 193)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[24])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[24])),
+            193)
       << "incorrect value for contents[24], expected 193, is "
       << last_msg_->contents[24];
-  EXPECT_EQ(last_msg_->contents[25], 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[25])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[25])),
+            9)
       << "incorrect value for contents[25], expected 9, is "
       << last_msg_->contents[25];
-  EXPECT_EQ(last_msg_->contents[26], 58)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[26])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[26])),
+            58)
       << "incorrect value for contents[26], expected 58, is "
       << last_msg_->contents[26];
-  EXPECT_EQ(last_msg_->contents[27], 75)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[27])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[27])),
+            75)
       << "incorrect value for contents[27], expected 75, is "
       << last_msg_->contents[27];
-  EXPECT_EQ(last_msg_->contents[28], 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[28])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[28])),
+            8)
       << "incorrect value for contents[28], expected 8, is "
       << last_msg_->contents[28];
-  EXPECT_EQ(last_msg_->contents[29], 135)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[29])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[29])),
+            135)
       << "incorrect value for contents[29], expected 135, is "
       << last_msg_->contents[29];
-  EXPECT_EQ(last_msg_->contents[30], 11)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[30])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[30])),
+            11)
       << "incorrect value for contents[30], expected 11, is "
       << last_msg_->contents[30];
-  EXPECT_EQ(last_msg_->contents[31], 92)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[31])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[31])),
+            92)
       << "incorrect value for contents[31], expected 92, is "
       << last_msg_->contents[31];
-  EXPECT_EQ(last_msg_->contents[32], 131)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[32])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[32])),
+            131)
       << "incorrect value for contents[32], expected 131, is "
       << last_msg_->contents[32];
-  EXPECT_EQ(last_msg_->contents[33], 245)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[33])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[33])),
+            245)
       << "incorrect value for contents[33], expected 245, is "
       << last_msg_->contents[33];
-  EXPECT_EQ(last_msg_->contents[34], 24)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[34])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[34])),
+            24)
       << "incorrect value for contents[34], expected 24, is "
       << last_msg_->contents[34];
-  EXPECT_EQ(last_msg_->contents[35], 90)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[35])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[35])),
+            90)
       << "incorrect value for contents[35], expected 90, is "
       << last_msg_->contents[35];
-  EXPECT_EQ(last_msg_->contents[36], 255)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[36])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[36])),
+            255)
       << "incorrect value for contents[36], expected 255, is "
       << last_msg_->contents[36];
-  EXPECT_EQ(last_msg_->contents[37], 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[37])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[37])),
+            30)
       << "incorrect value for contents[37], expected 30, is "
       << last_msg_->contents[37];
-  EXPECT_EQ(last_msg_->contents[38], 58)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[38])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[38])),
+            58)
       << "incorrect value for contents[38], expected 58, is "
       << last_msg_->contents[38];
-  EXPECT_EQ(last_msg_->contents[39], 31)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[39])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[39])),
+            31)
       << "incorrect value for contents[39], expected 31, is "
       << last_msg_->contents[39];
-  EXPECT_EQ(last_msg_->contents[40], 109)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[40])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[40])),
+            109)
       << "incorrect value for contents[40], expected 109, is "
       << last_msg_->contents[40];
-  EXPECT_EQ(last_msg_->contents[41], 148)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[41])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[41])),
+            148)
       << "incorrect value for contents[41], expected 148, is "
       << last_msg_->contents[41];
-  EXPECT_EQ(last_msg_->contents[42], 56)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[42])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[42])),
+            56)
       << "incorrect value for contents[42], expected 56, is "
       << last_msg_->contents[42];
-  EXPECT_EQ(last_msg_->contents[43], 178)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[43])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[43])),
+            178)
       << "incorrect value for contents[43], expected 178, is "
       << last_msg_->contents[43];
-  EXPECT_EQ(last_msg_->contents[44], 140)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[44])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[44])),
+            140)
       << "incorrect value for contents[44], expected 140, is "
       << last_msg_->contents[44];
-  EXPECT_EQ(last_msg_->contents[45], 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[45])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[45])),
+            30)
       << "incorrect value for contents[45], expected 30, is "
       << last_msg_->contents[45];
-  EXPECT_EQ(last_msg_->contents[46], 159)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[46])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[46])),
+            159)
       << "incorrect value for contents[46], expected 159, is "
       << last_msg_->contents[46];
-  EXPECT_EQ(last_msg_->contents[47], 70)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[47])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[47])),
+            70)
       << "incorrect value for contents[47], expected 70, is "
       << last_msg_->contents[47];
-  EXPECT_EQ(last_msg_->contents[48], 17)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[48])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[48])),
+            17)
       << "incorrect value for contents[48], expected 17, is "
       << last_msg_->contents[48];
-  EXPECT_EQ(last_msg_->contents[49], 170)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[49])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[49])),
+            170)
       << "incorrect value for contents[49], expected 170, is "
       << last_msg_->contents[49];
-  EXPECT_EQ(last_msg_->contents[50], 50)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[50])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[50])),
+            50)
       << "incorrect value for contents[50], expected 50, is "
       << last_msg_->contents[50];
-  EXPECT_EQ(last_msg_->contents[51], 148)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[51])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[51])),
+            148)
       << "incorrect value for contents[51], expected 148, is "
       << last_msg_->contents[51];
-  EXPECT_EQ(last_msg_->contents[52], 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[52])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[52])),
+            1)
       << "incorrect value for contents[52], expected 1, is "
       << last_msg_->contents[52];
-  EXPECT_EQ(last_msg_->contents[53], 99)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[53])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[53])),
+            99)
       << "incorrect value for contents[53], expected 99, is "
       << last_msg_->contents[53];
-  EXPECT_EQ(last_msg_->contents[54], 112)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[54])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[54])),
+            112)
       << "incorrect value for contents[54], expected 112, is "
       << last_msg_->contents[54];
-  EXPECT_EQ(last_msg_->contents[55], 88)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[55])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[55])),
+            88)
       << "incorrect value for contents[55], expected 88, is "
       << last_msg_->contents[55];
-  EXPECT_EQ(last_msg_->contents[56], 217)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[56])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[56])),
+            217)
       << "incorrect value for contents[56], expected 217, is "
       << last_msg_->contents[56];
-  EXPECT_EQ(last_msg_->contents[57], 36)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[57])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[57])),
+            36)
       << "incorrect value for contents[57], expected 36, is "
       << last_msg_->contents[57];
-  EXPECT_EQ(last_msg_->contents[58], 84)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[58])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[58])),
+            84)
       << "incorrect value for contents[58], expected 84, is "
       << last_msg_->contents[58];
-  EXPECT_EQ(last_msg_->contents[59], 34)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[59])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[59])),
+            34)
       << "incorrect value for contents[59], expected 34, is "
       << last_msg_->contents[59];
-  EXPECT_EQ(last_msg_->contents[60], 234)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[60])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[60])),
+            234)
       << "incorrect value for contents[60], expected 234, is "
       << last_msg_->contents[60];
-  EXPECT_EQ(last_msg_->contents[61], 82)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[61])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[61])),
+            82)
       << "incorrect value for contents[61], expected 82, is "
       << last_msg_->contents[61];
-  EXPECT_EQ(last_msg_->contents[62], 144)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[62])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[62])),
+            144)
       << "incorrect value for contents[62], expected 144, is "
       << last_msg_->contents[62];
-  EXPECT_EQ(last_msg_->contents[63], 144)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[63])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[63])),
+            144)
       << "incorrect value for contents[63], expected 144, is "
       << last_msg_->contents[63];
-  EXPECT_EQ(last_msg_->contents[64], 97)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[64])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[64])),
+            97)
       << "incorrect value for contents[64], expected 97, is "
       << last_msg_->contents[64];
-  EXPECT_EQ(last_msg_->contents[65], 96)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[65])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[65])),
+            96)
       << "incorrect value for contents[65], expected 96, is "
       << last_msg_->contents[65];
-  EXPECT_EQ(last_msg_->contents[66], 75)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[66])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[66])),
+            75)
       << "incorrect value for contents[66], expected 75, is "
       << last_msg_->contents[66];
-  EXPECT_EQ(last_msg_->contents[67], 174)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[67])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[67])),
+            174)
       << "incorrect value for contents[67], expected 174, is "
       << last_msg_->contents[67];
-  EXPECT_EQ(last_msg_->contents[68], 58)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[68])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[68])),
+            58)
       << "incorrect value for contents[68], expected 58, is "
       << last_msg_->contents[68];
-  EXPECT_EQ(last_msg_->contents[69], 219)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[69])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[69])),
+            219)
       << "incorrect value for contents[69], expected 219, is "
       << last_msg_->contents[69];
-  EXPECT_EQ(last_msg_->contents[70], 180)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[70])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[70])),
+            180)
       << "incorrect value for contents[70], expected 180, is "
       << last_msg_->contents[70];
-  EXPECT_EQ(last_msg_->contents[71], 148)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[71])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[71])),
+            148)
       << "incorrect value for contents[71], expected 148, is "
       << last_msg_->contents[71];
-  EXPECT_EQ(last_msg_->contents[72], 247)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[72])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[72])),
+            247)
       << "incorrect value for contents[72], expected 247, is "
       << last_msg_->contents[72];
-  EXPECT_EQ(last_msg_->contents[73], 59)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[73])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[73])),
+            59)
       << "incorrect value for contents[73], expected 59, is "
       << last_msg_->contents[73];
-  EXPECT_EQ(last_msg_->contents[74], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[74])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[74])),
+            2)
       << "incorrect value for contents[74], expected 2, is "
       << last_msg_->contents[74];
-  EXPECT_EQ(last_msg_->contents[75], 116)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[75])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[75])),
+            116)
       << "incorrect value for contents[75], expected 116, is "
       << last_msg_->contents[75];
-  EXPECT_EQ(last_msg_->contents[76], 214)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[76])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[76])),
+            214)
       << "incorrect value for contents[76], expected 214, is "
       << last_msg_->contents[76];
-  EXPECT_EQ(last_msg_->contents[77], 114)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[77])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[77])),
+            114)
       << "incorrect value for contents[77], expected 114, is "
       << last_msg_->contents[77];
-  EXPECT_EQ(last_msg_->contents[78], 55)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[78])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[78])),
+            55)
       << "incorrect value for contents[78], expected 55, is "
       << last_msg_->contents[78];
-  EXPECT_EQ(last_msg_->contents[79], 134)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[79])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[79])),
+            134)
       << "incorrect value for contents[79], expected 134, is "
       << last_msg_->contents[79];
-  EXPECT_EQ(last_msg_->contents[80], 54)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[80])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[80])),
+            54)
       << "incorrect value for contents[80], expected 54, is "
       << last_msg_->contents[80];
-  EXPECT_EQ(last_msg_->contents[81], 119)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[81])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[81])),
+            119)
       << "incorrect value for contents[81], expected 119, is "
       << last_msg_->contents[81];
-  EXPECT_EQ(last_msg_->contents[82], 108)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[82])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[82])),
+            108)
       << "incorrect value for contents[82], expected 108, is "
       << last_msg_->contents[82];
-  EXPECT_EQ(last_msg_->contents[83], 128)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[83])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[83])),
+            128)
       << "incorrect value for contents[83], expected 128, is "
       << last_msg_->contents[83];
-  EXPECT_EQ(last_msg_->contents[84], 73)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[84])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[84])),
+            73)
       << "incorrect value for contents[84], expected 73, is "
       << last_msg_->contents[84];
-  EXPECT_EQ(last_msg_->contents[85], 181)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[85])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[85])),
+            181)
       << "incorrect value for contents[85], expected 181, is "
       << last_msg_->contents[85];
-  EXPECT_EQ(last_msg_->contents[86], 20)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[86])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[86])),
+            20)
       << "incorrect value for contents[86], expected 20, is "
       << last_msg_->contents[86];
-  EXPECT_EQ(last_msg_->contents[87], 233)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[87])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[87])),
+            233)
       << "incorrect value for contents[87], expected 233, is "
       << last_msg_->contents[87];
-  EXPECT_EQ(last_msg_->contents[88], 23)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[88])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[88])),
+            23)
       << "incorrect value for contents[88], expected 23, is "
       << last_msg_->contents[88];
-  EXPECT_EQ(last_msg_->contents[89], 23)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[89])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[89])),
+            23)
       << "incorrect value for contents[89], expected 23, is "
       << last_msg_->contents[89];
-  EXPECT_EQ(last_msg_->contents[90], 73)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[90])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[90])),
+            73)
       << "incorrect value for contents[90], expected 73, is "
       << last_msg_->contents[90];
-  EXPECT_EQ(last_msg_->contents[91], 119)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[91])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[91])),
+            119)
       << "incorrect value for contents[91], expected 119, is "
       << last_msg_->contents[91];
-  EXPECT_EQ(last_msg_->contents[92], 136)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[92])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[92])),
+            136)
       << "incorrect value for contents[92], expected 136, is "
       << last_msg_->contents[92];
-  EXPECT_EQ(last_msg_->contents[93], 231)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[93])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[93])),
+            231)
       << "incorrect value for contents[93], expected 231, is "
       << last_msg_->contents[93];
-  EXPECT_EQ(last_msg_->contents[94], 189)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[94])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[94])),
+            189)
       << "incorrect value for contents[94], expected 189, is "
       << last_msg_->contents[94];
-  EXPECT_EQ(last_msg_->contents[95], 26)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[95])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[95])),
+            26)
       << "incorrect value for contents[95], expected 26, is "
       << last_msg_->contents[95];
-  EXPECT_EQ(last_msg_->contents[96], 174)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[96])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[96])),
+            174)
       << "incorrect value for contents[96], expected 174, is "
       << last_msg_->contents[96];
-  EXPECT_EQ(last_msg_->contents[97], 128)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[97])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[97])),
+            128)
       << "incorrect value for contents[97], expected 128, is "
       << last_msg_->contents[97];
-  EXPECT_EQ(last_msg_->contents[98], 93)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[98])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[98])),
+            93)
       << "incorrect value for contents[98], expected 93, is "
       << last_msg_->contents[98];
-  EXPECT_EQ(last_msg_->contents[99], 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[99])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[99])),
+            30)
       << "incorrect value for contents[99], expected 30, is "
       << last_msg_->contents[99];
-  EXPECT_EQ(last_msg_->contents[100], 76)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[100])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[100])),
+            76)
       << "incorrect value for contents[100], expected 76, is "
       << last_msg_->contents[100];
-  EXPECT_EQ(last_msg_->contents[101], 45)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[101])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[101])),
+            45)
       << "incorrect value for contents[101], expected 45, is "
       << last_msg_->contents[101];
-  EXPECT_EQ(last_msg_->contents[102], 109)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[102])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[102])),
+            109)
       << "incorrect value for contents[102], expected 109, is "
       << last_msg_->contents[102];
-  EXPECT_EQ(last_msg_->contents[103], 134)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[103])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[103])),
+            134)
       << "incorrect value for contents[103], expected 134, is "
       << last_msg_->contents[103];
-  EXPECT_EQ(last_msg_->contents[104], 81)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[104])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[104])),
+            81)
       << "incorrect value for contents[104], expected 81, is "
       << last_msg_->contents[104];
-  EXPECT_EQ(last_msg_->contents[105], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[105])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[105])),
+            0)
       << "incorrect value for contents[105], expected 0, is "
       << last_msg_->contents[105];
-  EXPECT_EQ(last_msg_->contents[106], 116)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[106])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[106])),
+            116)
       << "incorrect value for contents[106], expected 116, is "
       << last_msg_->contents[106];
-  EXPECT_EQ(last_msg_->contents[107], 158)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[107])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[107])),
+            158)
       << "incorrect value for contents[107], expected 158, is "
       << last_msg_->contents[107];
-  EXPECT_EQ(last_msg_->contents[108], 127)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[108])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[108])),
+            127)
       << "incorrect value for contents[108], expected 127, is "
       << last_msg_->contents[108];
-  EXPECT_EQ(last_msg_->contents[109], 40)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[109])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[109])),
+            40)
       << "incorrect value for contents[109], expected 40, is "
       << last_msg_->contents[109];
-  EXPECT_EQ(last_msg_->contents[110], 133)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[110])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[110])),
+            133)
       << "incorrect value for contents[110], expected 133, is "
       << last_msg_->contents[110];
-  EXPECT_EQ(last_msg_->contents[111], 208)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[111])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[111])),
+            208)
       << "incorrect value for contents[111], expected 208, is "
       << last_msg_->contents[111];
-  EXPECT_EQ(last_msg_->contents[112], 134)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[112])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[112])),
+            134)
       << "incorrect value for contents[112], expected 134, is "
       << last_msg_->contents[112];
-  EXPECT_EQ(last_msg_->contents[113], 127)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[113])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[113])),
+            127)
       << "incorrect value for contents[113], expected 127, is "
       << last_msg_->contents[113];
-  EXPECT_EQ(last_msg_->contents[114], 140)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[114])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[114])),
+            140)
       << "incorrect value for contents[114], expected 140, is "
       << last_msg_->contents[114];
-  EXPECT_EQ(last_msg_->contents[115], 232)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[115])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[115])),
+            232)
       << "incorrect value for contents[115], expected 232, is "
       << last_msg_->contents[115];
-  EXPECT_EQ(last_msg_->contents[116], 183)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[116])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[116])),
+            183)
       << "incorrect value for contents[116], expected 183, is "
       << last_msg_->contents[116];
-  EXPECT_EQ(last_msg_->contents[117], 184)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[117])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[117])),
+            184)
       << "incorrect value for contents[117], expected 184, is "
       << last_msg_->contents[117];
-  EXPECT_EQ(last_msg_->contents[118], 108)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[118])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[118])),
+            108)
       << "incorrect value for contents[118], expected 108, is "
       << last_msg_->contents[118];
-  EXPECT_EQ(last_msg_->contents[119], 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[119])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[119])),
+            6)
       << "incorrect value for contents[119], expected 6, is "
       << last_msg_->contents[119];
-  EXPECT_EQ(last_msg_->contents[120], 228)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[120])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[120])),
+            228)
       << "incorrect value for contents[120], expected 228, is "
       << last_msg_->contents[120];
-  EXPECT_EQ(last_msg_->contents[121], 54)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[121])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[121])),
+            54)
       << "incorrect value for contents[121], expected 54, is "
       << last_msg_->contents[121];
-  EXPECT_EQ(last_msg_->contents[122], 238)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[122])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[122])),
+            238)
       << "incorrect value for contents[122], expected 238, is "
       << last_msg_->contents[122];
-  EXPECT_EQ(last_msg_->contents[123], 59)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[123])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[123])),
+            59)
       << "incorrect value for contents[123], expected 59, is "
       << last_msg_->contents[123];
-  EXPECT_EQ(last_msg_->contents[124], 220)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[124])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[124])),
+            220)
       << "incorrect value for contents[124], expected 220, is "
       << last_msg_->contents[124];
-  EXPECT_EQ(last_msg_->contents[125], 30)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[125])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[125])),
+            30)
       << "incorrect value for contents[125], expected 30, is "
       << last_msg_->contents[125];
-  EXPECT_EQ(last_msg_->contents[126], 228)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[126])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[126])),
+            228)
       << "incorrect value for contents[126], expected 228, is "
       << last_msg_->contents[126];
-  EXPECT_EQ(last_msg_->contents[127], 212)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[127])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[127])),
+            212)
       << "incorrect value for contents[127], expected 212, is "
       << last_msg_->contents[127];
-  EXPECT_EQ(last_msg_->contents[128], 50)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[128])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[128])),
+            50)
       << "incorrect value for contents[128], expected 50, is "
       << last_msg_->contents[128];
-  EXPECT_EQ(last_msg_->contents[129], 182)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[129])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[129])),
+            182)
       << "incorrect value for contents[129], expected 182, is "
       << last_msg_->contents[129];
-  EXPECT_EQ(last_msg_->contents[130], 97)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[130])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[130])),
+            97)
       << "incorrect value for contents[130], expected 97, is "
       << last_msg_->contents[130];
-  EXPECT_EQ(last_msg_->contents[131], 20)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[131])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[131])),
+            20)
       << "incorrect value for contents[131], expected 20, is "
       << last_msg_->contents[131];
-  EXPECT_EQ(last_msg_->contents[132], 41)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[132])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[132])),
+            41)
       << "incorrect value for contents[132], expected 41, is "
       << last_msg_->contents[132];
-  EXPECT_EQ(last_msg_->contents[133], 76)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[133])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[133])),
+            76)
       << "incorrect value for contents[133], expected 76, is "
       << last_msg_->contents[133];
-  EXPECT_EQ(last_msg_->contents[134], 227)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[134])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[134])),
+            227)
       << "incorrect value for contents[134], expected 227, is "
       << last_msg_->contents[134];
-  EXPECT_EQ(last_msg_->contents[135], 88)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[135])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[135])),
+            88)
       << "incorrect value for contents[135], expected 88, is "
       << last_msg_->contents[135];
-  EXPECT_EQ(last_msg_->contents[136], 12)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[136])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[136])),
+            12)
       << "incorrect value for contents[136], expected 12, is "
       << last_msg_->contents[136];
-  EXPECT_EQ(last_msg_->contents[137], 95)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[137])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[137])),
+            95)
       << "incorrect value for contents[137], expected 95, is "
       << last_msg_->contents[137];
-  EXPECT_EQ(last_msg_->contents[138], 112)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[138])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[138])),
+            112)
       << "incorrect value for contents[138], expected 112, is "
       << last_msg_->contents[138];
-  EXPECT_EQ(last_msg_->contents[139], 209)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[139])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[139])),
+            209)
       << "incorrect value for contents[139], expected 209, is "
       << last_msg_->contents[139];
-  EXPECT_EQ(last_msg_->contents[140], 183)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[140])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[140])),
+            183)
       << "incorrect value for contents[140], expected 183, is "
       << last_msg_->contents[140];
-  EXPECT_EQ(last_msg_->contents[141], 127)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[141])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[141])),
+            127)
       << "incorrect value for contents[141], expected 127, is "
       << last_msg_->contents[141];
-  EXPECT_EQ(last_msg_->contents[142], 4)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[142])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[142])),
+            4)
       << "incorrect value for contents[142], expected 4, is "
       << last_msg_->contents[142];
-  EXPECT_EQ(last_msg_->contents[143], 165)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[143])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[143])),
+            165)
       << "incorrect value for contents[143], expected 165, is "
       << last_msg_->contents[143];
-  EXPECT_EQ(last_msg_->contents[144], 189)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[144])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[144])),
+            189)
       << "incorrect value for contents[144], expected 189, is "
       << last_msg_->contents[144];
-  EXPECT_EQ(last_msg_->contents[145], 44)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[145])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[145])),
+            44)
       << "incorrect value for contents[145], expected 44, is "
       << last_msg_->contents[145];
-  EXPECT_EQ(last_msg_->contents[146], 239)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[146])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[146])),
+            239)
       << "incorrect value for contents[146], expected 239, is "
       << last_msg_->contents[146];
-  EXPECT_EQ(last_msg_->contents[147], 232)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[147])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[147])),
+            232)
       << "incorrect value for contents[147], expected 232, is "
       << last_msg_->contents[147];
-  EXPECT_EQ(last_msg_->contents[148], 132)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[148])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[148])),
+            132)
       << "incorrect value for contents[148], expected 132, is "
       << last_msg_->contents[148];
-  EXPECT_EQ(last_msg_->contents[149], 9)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[149])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[149])),
+            9)
       << "incorrect value for contents[149], expected 9, is "
       << last_msg_->contents[149];
-  EXPECT_EQ(last_msg_->contents[150], 114)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[150])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[150])),
+            114)
       << "incorrect value for contents[150], expected 114, is "
       << last_msg_->contents[150];
-  EXPECT_EQ(last_msg_->contents[151], 184)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[151])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[151])),
+            184)
       << "incorrect value for contents[151], expected 184, is "
       << last_msg_->contents[151];
-  EXPECT_EQ(last_msg_->contents[152], 249)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[152])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[152])),
+            249)
       << "incorrect value for contents[152], expected 249, is "
       << last_msg_->contents[152];
-  EXPECT_EQ(last_msg_->contents[153], 208)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[153])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[153])),
+            208)
       << "incorrect value for contents[153], expected 208, is "
       << last_msg_->contents[153];
-  EXPECT_EQ(last_msg_->contents[154], 246)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[154])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[154])),
+            246)
       << "incorrect value for contents[154], expected 246, is "
       << last_msg_->contents[154];
-  EXPECT_EQ(last_msg_->contents[155], 194)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[155])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[155])),
+            194)
       << "incorrect value for contents[155], expected 194, is "
       << last_msg_->contents[155];
-  EXPECT_EQ(last_msg_->contents[156], 250)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[156])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[156])),
+            250)
       << "incorrect value for contents[156], expected 250, is "
       << last_msg_->contents[156];
-  EXPECT_EQ(last_msg_->contents[157], 2)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[157])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[157])),
+            2)
       << "incorrect value for contents[157], expected 2, is "
       << last_msg_->contents[157];
-  EXPECT_EQ(last_msg_->contents[158], 97)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[158])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[158])),
+            97)
       << "incorrect value for contents[158], expected 97, is "
       << last_msg_->contents[158];
-  EXPECT_EQ(last_msg_->contents[159], 173)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[159])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[159])),
+            173)
       << "incorrect value for contents[159], expected 173, is "
       << last_msg_->contents[159];
-  EXPECT_EQ(last_msg_->contents[160], 157)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[160])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[160])),
+            157)
       << "incorrect value for contents[160], expected 157, is "
       << last_msg_->contents[160];
-  EXPECT_EQ(last_msg_->contents[161], 202)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[161])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[161])),
+            202)
       << "incorrect value for contents[161], expected 202, is "
       << last_msg_->contents[161];
-  EXPECT_EQ(last_msg_->contents[162], 172)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[162])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[162])),
+            172)
       << "incorrect value for contents[162], expected 172, is "
       << last_msg_->contents[162];
-  EXPECT_EQ(last_msg_->contents[163], 180)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[163])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[163])),
+            180)
       << "incorrect value for contents[163], expected 180, is "
       << last_msg_->contents[163];
-  EXPECT_EQ(last_msg_->contents[164], 150)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[164])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[164])),
+            150)
       << "incorrect value for contents[164], expected 150, is "
       << last_msg_->contents[164];
-  EXPECT_EQ(last_msg_->contents[165], 213)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[165])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[165])),
+            213)
       << "incorrect value for contents[165], expected 213, is "
       << last_msg_->contents[165];
-  EXPECT_EQ(last_msg_->contents[166], 193)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[166])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[166])),
+            193)
       << "incorrect value for contents[166], expected 193, is "
       << last_msg_->contents[166];
-  EXPECT_EQ(last_msg_->contents[167], 177)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[167])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[167])),
+            177)
       << "incorrect value for contents[167], expected 177, is "
       << last_msg_->contents[167];
-  EXPECT_EQ(last_msg_->contents[168], 209)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[168])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[168])),
+            209)
       << "incorrect value for contents[168], expected 209, is "
       << last_msg_->contents[168];
-  EXPECT_EQ(last_msg_->contents[169], 156)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[169])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[169])),
+            156)
       << "incorrect value for contents[169], expected 156, is "
       << last_msg_->contents[169];
-  EXPECT_EQ(last_msg_->contents[170], 20)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[170])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[170])),
+            20)
       << "incorrect value for contents[170], expected 20, is "
       << last_msg_->contents[170];
-  EXPECT_EQ(last_msg_->contents[171], 174)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[171])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[171])),
+            174)
       << "incorrect value for contents[171], expected 174, is "
       << last_msg_->contents[171];
-  EXPECT_EQ(last_msg_->contents[172], 18)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[172])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[172])),
+            18)
       << "incorrect value for contents[172], expected 18, is "
       << last_msg_->contents[172];
-  EXPECT_EQ(last_msg_->contents[173], 73)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[173])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[173])),
+            73)
       << "incorrect value for contents[173], expected 73, is "
       << last_msg_->contents[173];
-  EXPECT_EQ(last_msg_->contents[174], 132)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[174])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[174])),
+            132)
       << "incorrect value for contents[174], expected 132, is "
       << last_msg_->contents[174];
-  EXPECT_EQ(last_msg_->contents[175], 215)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[175])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[175])),
+            215)
       << "incorrect value for contents[175], expected 215, is "
       << last_msg_->contents[175];
-  EXPECT_EQ(last_msg_->contents[176], 115)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[176])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[176])),
+            115)
       << "incorrect value for contents[176], expected 115, is "
       << last_msg_->contents[176];
-  EXPECT_EQ(last_msg_->contents[177], 128)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[177])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[177])),
+            128)
       << "incorrect value for contents[177], expected 128, is "
       << last_msg_->contents[177];
-  EXPECT_EQ(last_msg_->contents[178], 175)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[178])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[178])),
+            175)
       << "incorrect value for contents[178], expected 175, is "
       << last_msg_->contents[178];
-  EXPECT_EQ(last_msg_->contents[179], 169)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[179])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[179])),
+            169)
       << "incorrect value for contents[179], expected 169, is "
       << last_msg_->contents[179];
-  EXPECT_EQ(last_msg_->contents[180], 116)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[180])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[180])),
+            116)
       << "incorrect value for contents[180], expected 116, is "
       << last_msg_->contents[180];
-  EXPECT_EQ(last_msg_->contents[181], 132)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[181])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[181])),
+            132)
       << "incorrect value for contents[181], expected 132, is "
       << last_msg_->contents[181];
-  EXPECT_EQ(last_msg_->contents[182], 100)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[182])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[182])),
+            100)
       << "incorrect value for contents[182], expected 100, is "
       << last_msg_->contents[182];
-  EXPECT_EQ(last_msg_->contents[183], 72)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[183])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[183])),
+            72)
       << "incorrect value for contents[183], expected 72, is "
       << last_msg_->contents[183];
-  EXPECT_EQ(last_msg_->contents[184], 45)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[184])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[184])),
+            45)
       << "incorrect value for contents[184], expected 45, is "
       << last_msg_->contents[184];
-  EXPECT_EQ(last_msg_->contents[185], 25)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[185])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[185])),
+            25)
       << "incorrect value for contents[185], expected 25, is "
       << last_msg_->contents[185];
-  EXPECT_EQ(last_msg_->contents[186], 14)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[186])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[186])),
+            14)
       << "incorrect value for contents[186], expected 14, is "
       << last_msg_->contents[186];
-  EXPECT_EQ(last_msg_->contents[187], 205)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[187])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[187])),
+            205)
       << "incorrect value for contents[187], expected 205, is "
       << last_msg_->contents[187];
-  EXPECT_EQ(last_msg_->contents[188], 213)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[188])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[188])),
+            213)
       << "incorrect value for contents[188], expected 213, is "
       << last_msg_->contents[188];
-  EXPECT_EQ(last_msg_->contents[189], 145)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[189])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[189])),
+            145)
       << "incorrect value for contents[189], expected 145, is "
       << last_msg_->contents[189];
-  EXPECT_EQ(last_msg_->contents[190], 68)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[190])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[190])),
+            68)
       << "incorrect value for contents[190], expected 68, is "
       << last_msg_->contents[190];
-  EXPECT_EQ(last_msg_->contents[191], 137)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[191])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[191])),
+            137)
       << "incorrect value for contents[191], expected 137, is "
       << last_msg_->contents[191];
-  EXPECT_EQ(last_msg_->contents[192], 249)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[192])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[192])),
+            249)
       << "incorrect value for contents[192], expected 249, is "
       << last_msg_->contents[192];
-  EXPECT_EQ(last_msg_->contents[193], 54)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[193])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[193])),
+            54)
       << "incorrect value for contents[193], expected 54, is "
       << last_msg_->contents[193];
-  EXPECT_EQ(last_msg_->contents[194], 40)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[194])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[194])),
+            40)
       << "incorrect value for contents[194], expected 40, is "
       << last_msg_->contents[194];
-  EXPECT_EQ(last_msg_->contents[195], 174)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[195])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[195])),
+            174)
       << "incorrect value for contents[195], expected 174, is "
       << last_msg_->contents[195];
-  EXPECT_EQ(last_msg_->contents[196], 215)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[196])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[196])),
+            215)
       << "incorrect value for contents[196], expected 215, is "
       << last_msg_->contents[196];
-  EXPECT_EQ(last_msg_->contents[197], 148)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[197])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[197])),
+            148)
       << "incorrect value for contents[197], expected 148, is "
       << last_msg_->contents[197];
-  EXPECT_EQ(last_msg_->contents[198], 166)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[198])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[198])),
+            166)
       << "incorrect value for contents[198], expected 166, is "
       << last_msg_->contents[198];
-  EXPECT_EQ(last_msg_->contents[199], 190)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[199])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[199])),
+            190)
       << "incorrect value for contents[199], expected 190, is "
       << last_msg_->contents[199];
-  EXPECT_EQ(last_msg_->contents[200], 63)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[200])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[200])),
+            63)
       << "incorrect value for contents[200], expected 63, is "
       << last_msg_->contents[200];
-  EXPECT_EQ(last_msg_->contents[201], 118)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[201])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[201])),
+            118)
       << "incorrect value for contents[201], expected 118, is "
       << last_msg_->contents[201];
-  EXPECT_EQ(last_msg_->contents[202], 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[202])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[202])),
+            6)
       << "incorrect value for contents[202], expected 6, is "
       << last_msg_->contents[202];
-  EXPECT_EQ(last_msg_->contents[203], 165)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[203])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[203])),
+            165)
       << "incorrect value for contents[203], expected 165, is "
       << last_msg_->contents[203];
-  EXPECT_EQ(last_msg_->contents[204], 212)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[204])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[204])),
+            212)
       << "incorrect value for contents[204], expected 212, is "
       << last_msg_->contents[204];
-  EXPECT_EQ(last_msg_->contents[205], 74)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[205])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[205])),
+            74)
       << "incorrect value for contents[205], expected 74, is "
       << last_msg_->contents[205];
-  EXPECT_EQ(last_msg_->contents[206], 68)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[206])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[206])),
+            68)
       << "incorrect value for contents[206], expected 68, is "
       << last_msg_->contents[206];
-  EXPECT_EQ(last_msg_->contents[207], 200)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[207])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[207])),
+            200)
       << "incorrect value for contents[207], expected 200, is "
       << last_msg_->contents[207];
-  EXPECT_EQ(last_msg_->contents[208], 38)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[208])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[208])),
+            38)
       << "incorrect value for contents[208], expected 38, is "
       << last_msg_->contents[208];
-  EXPECT_EQ(last_msg_->contents[209], 139)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[209])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[209])),
+            139)
       << "incorrect value for contents[209], expected 139, is "
       << last_msg_->contents[209];
-  EXPECT_EQ(last_msg_->contents[210], 212)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[210])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[210])),
+            212)
       << "incorrect value for contents[210], expected 212, is "
       << last_msg_->contents[210];
-  EXPECT_EQ(last_msg_->contents[211], 112)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[211])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[211])),
+            112)
       << "incorrect value for contents[211], expected 112, is "
       << last_msg_->contents[211];
-  EXPECT_EQ(last_msg_->contents[212], 45)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[212])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[212])),
+            45)
       << "incorrect value for contents[212], expected 45, is "
       << last_msg_->contents[212];
-  EXPECT_EQ(last_msg_->contents[213], 167)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[213])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[213])),
+            167)
       << "incorrect value for contents[213], expected 167, is "
       << last_msg_->contents[213];
-  EXPECT_EQ(last_msg_->contents[214], 236)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[214])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[214])),
+            236)
       << "incorrect value for contents[214], expected 236, is "
       << last_msg_->contents[214];
-  EXPECT_EQ(last_msg_->contents[215], 255)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[215])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[215])),
+            255)
       << "incorrect value for contents[215], expected 255, is "
       << last_msg_->contents[215];
-  EXPECT_EQ(last_msg_->contents[216], 106)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[216])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[216])),
+            106)
       << "incorrect value for contents[216], expected 106, is "
       << last_msg_->contents[216];
-  EXPECT_EQ(last_msg_->contents[217], 92)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[217])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[217])),
+            92)
       << "incorrect value for contents[217], expected 92, is "
       << last_msg_->contents[217];
-  EXPECT_EQ(last_msg_->contents[218], 132)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[218])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[218])),
+            132)
       << "incorrect value for contents[218], expected 132, is "
       << last_msg_->contents[218];
-  EXPECT_EQ(last_msg_->contents[219], 59)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[219])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[219])),
+            59)
       << "incorrect value for contents[219], expected 59, is "
       << last_msg_->contents[219];
-  EXPECT_EQ(last_msg_->contents[220], 61)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[220])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[220])),
+            61)
       << "incorrect value for contents[220], expected 61, is "
       << last_msg_->contents[220];
-  EXPECT_EQ(last_msg_->contents[221], 233)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[221])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[221])),
+            233)
       << "incorrect value for contents[221], expected 233, is "
       << last_msg_->contents[221];
-  EXPECT_EQ(last_msg_->contents[222], 3)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[222])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[222])),
+            3)
       << "incorrect value for contents[222], expected 3, is "
       << last_msg_->contents[222];
-  EXPECT_EQ(last_msg_->contents[223], 246)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[223])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[223])),
+            246)
       << "incorrect value for contents[223], expected 246, is "
       << last_msg_->contents[223];
-  EXPECT_EQ(last_msg_->contents[224], 158)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[224])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[224])),
+            158)
       << "incorrect value for contents[224], expected 158, is "
       << last_msg_->contents[224];
-  EXPECT_EQ(last_msg_->contents[225], 83)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[225])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[225])),
+            83)
       << "incorrect value for contents[225], expected 83, is "
       << last_msg_->contents[225];
-  EXPECT_EQ(last_msg_->contents[226], 134)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[226])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[226])),
+            134)
       << "incorrect value for contents[226], expected 134, is "
       << last_msg_->contents[226];
-  EXPECT_EQ(last_msg_->contents[227], 246)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[227])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[227])),
+            246)
       << "incorrect value for contents[227], expected 246, is "
       << last_msg_->contents[227];
-  EXPECT_EQ(last_msg_->contents[228], 154)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[228])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[228])),
+            154)
       << "incorrect value for contents[228], expected 154, is "
       << last_msg_->contents[228];
-  EXPECT_EQ(last_msg_->contents[229], 17)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[229])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[229])),
+            17)
       << "incorrect value for contents[229], expected 17, is "
       << last_msg_->contents[229];
-  EXPECT_EQ(last_msg_->contents[230], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[230])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[230])),
+            0)
       << "incorrect value for contents[230], expected 0, is "
       << last_msg_->contents[230];
-  EXPECT_EQ(last_msg_->contents[231], 6)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[231])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[231])),
+            6)
       << "incorrect value for contents[231], expected 6, is "
       << last_msg_->contents[231];
-  EXPECT_EQ(last_msg_->contents[232], 56)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[232])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[232])),
+            56)
       << "incorrect value for contents[232], expected 56, is "
       << last_msg_->contents[232];
-  EXPECT_EQ(last_msg_->contents[233], 216)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[233])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[233])),
+            216)
       << "incorrect value for contents[233], expected 216, is "
       << last_msg_->contents[233];
-  EXPECT_EQ(last_msg_->contents[234], 19)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[234])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[234])),
+            19)
       << "incorrect value for contents[234], expected 19, is "
       << last_msg_->contents[234];
-  EXPECT_EQ(last_msg_->contents[235], 216)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[235])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[235])),
+            216)
       << "incorrect value for contents[235], expected 216, is "
       << last_msg_->contents[235];
-  EXPECT_EQ(last_msg_->contents[236], 70)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[236])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[236])),
+            70)
       << "incorrect value for contents[236], expected 70, is "
       << last_msg_->contents[236];
-  EXPECT_EQ(last_msg_->contents[237], 71)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[237])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[237])),
+            71)
       << "incorrect value for contents[237], expected 71, is "
       << last_msg_->contents[237];
-  EXPECT_EQ(last_msg_->contents[238], 161)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[238])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[238])),
+            161)
       << "incorrect value for contents[238], expected 161, is "
       << last_msg_->contents[238];
-  EXPECT_EQ(last_msg_->contents[239], 184)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[239])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[239])),
+            184)
       << "incorrect value for contents[239], expected 184, is "
       << last_msg_->contents[239];
-  EXPECT_EQ(last_msg_->contents[240], 5)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[240])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[240])),
+            5)
       << "incorrect value for contents[240], expected 5, is "
       << last_msg_->contents[240];
-  EXPECT_EQ(last_msg_->contents[241], 177)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[241])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[241])),
+            177)
       << "incorrect value for contents[241], expected 177, is "
       << last_msg_->contents[241];
-  EXPECT_EQ(last_msg_->contents[242], 45)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[242])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[242])),
+            45)
       << "incorrect value for contents[242], expected 45, is "
       << last_msg_->contents[242];
-  EXPECT_EQ(last_msg_->contents[243], 37)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[243])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[243])),
+            37)
       << "incorrect value for contents[243], expected 37, is "
       << last_msg_->contents[243];
-  EXPECT_EQ(last_msg_->contents[244], 98)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[244])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[244])),
+            98)
       << "incorrect value for contents[244], expected 98, is "
       << last_msg_->contents[244];
-  EXPECT_EQ(last_msg_->contents[245], 56)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[245])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[245])),
+            56)
       << "incorrect value for contents[245], expected 56, is "
       << last_msg_->contents[245];
-  EXPECT_EQ(last_msg_->contents[246], 149)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[246])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[246])),
+            149)
       << "incorrect value for contents[246], expected 149, is "
       << last_msg_->contents[246];
-  EXPECT_EQ(last_msg_->contents[247], 0)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[247])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[247])),
+            0)
       << "incorrect value for contents[247], expected 0, is "
       << last_msg_->contents[247];
-  EXPECT_EQ(last_msg_->contents[248], 73)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[248])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[248])),
+            73)
       << "incorrect value for contents[248], expected 73, is "
       << last_msg_->contents[248];
-  EXPECT_EQ(last_msg_->contents[249], 221)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[249])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[249])),
+            221)
       << "incorrect value for contents[249], expected 221, is "
       << last_msg_->contents[249];
-  EXPECT_EQ(last_msg_->contents[250], 105)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[250])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[250])),
+            105)
       << "incorrect value for contents[250], expected 105, is "
       << last_msg_->contents[250];
-  EXPECT_EQ(last_msg_->contents[251], 239)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[251])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[251])),
+            239)
       << "incorrect value for contents[251], expected 239, is "
       << last_msg_->contents[251];
-  EXPECT_EQ(last_msg_->contents[252], 168)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[252])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[252])),
+            168)
       << "incorrect value for contents[252], expected 168, is "
       << last_msg_->contents[252];
-  EXPECT_EQ(last_msg_->contents[253], 205)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[253])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[253])),
+            205)
       << "incorrect value for contents[253], expected 205, is "
       << last_msg_->contents[253];
-  EXPECT_EQ(last_msg_->contents[254], 85)
+  EXPECT_EQ(get_as<decltype(last_msg_->contents[254])>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->contents[254])),
+            85)
       << "incorrect value for contents[254], expected 85, is "
       << last_msg_->contents[254];
 }

--- a/c/test/legacy/cpp/auto_check_sbp_vehicle_MsgOdometry.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_vehicle_MsgOdometry.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/vehicle.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_vehicle_MsgOdometry0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -112,10 +119,16 @@ TEST_F(Test_legacy_auto_check_sbp_vehicle_MsgOdometry0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 66);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            1)
       << "incorrect value for flags, expected 1, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->tow, 8)
+  EXPECT_EQ(get_as<decltype(last_msg_->tow)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->tow)),
+            8)
       << "incorrect value for tow, expected 8, is " << last_msg_->tow;
-  EXPECT_EQ(last_msg_->velocity, 7)
+  EXPECT_EQ(get_as<decltype(last_msg_->velocity)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->velocity)),
+            7)
       << "incorrect value for velocity, expected 7, is " << last_msg_->velocity;
 }

--- a/c/test/legacy/cpp/auto_check_sbp_vehicle_MsgWheeltick.cc
+++ b/c/test/legacy/cpp/auto_check_sbp_vehicle_MsgWheeltick.cc
@@ -29,6 +29,13 @@
 #include <libsbp/legacy/cpp/message_traits.h>
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/vehicle.h>
+
+template <typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
 class Test_legacy_auto_check_sbp_vehicle_MsgWheeltick0
     : public ::testing::Test,
       public sbp::LegacyState,
@@ -114,14 +121,22 @@ TEST_F(Test_legacy_auto_check_sbp_vehicle_MsgWheeltick0, Test) {
   EXPECT_EQ(n_callbacks_logged_, 1);
   EXPECT_EQ(last_sender_id_, 17771);
   EXPECT_EQ(last_msg_len_, test_msg_len);
-  EXPECT_EQ(last_msg_->flags, 1)
+  EXPECT_EQ(get_as<decltype(last_msg_->flags)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->flags)),
+            1)
       << "incorrect value for flags, expected 1, is " << last_msg_->flags;
-  EXPECT_EQ(last_msg_->source, 146)
+  EXPECT_EQ(get_as<decltype(last_msg_->source)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->source)),
+            146)
       << "incorrect value for source, expected 146, is " << last_msg_->source;
-  EXPECT_EQ(last_msg_->ticks, -771148831)
+  EXPECT_EQ(get_as<decltype(last_msg_->ticks)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->ticks)),
+            -771148831)
       << "incorrect value for ticks, expected -771148831, is "
       << last_msg_->ticks;
-  EXPECT_EQ(last_msg_->time, 112414825470)
+  EXPECT_EQ(get_as<decltype(last_msg_->time)>(
+                reinterpret_cast<const uint8_t *>(&last_msg_->time)),
+            112414825470)
       << "incorrect value for time, expected 112414825470, is "
       << last_msg_->time;
 }

--- a/c/test/legacy/cpp/test_sbp_stdio.cc
+++ b/c/test/legacy/cpp/test_sbp_stdio.cc
@@ -29,7 +29,7 @@ struct SbpHeaderParams {
   uint16_t sender_id;
   uint16_t msg_type;
   uint8_t payload_len;
-  msg_obs_t payload;
+  uint8_t payload[SBP_MAX_PAYLOAD_LEN];
 };
 
 class MsgObsHandler : private sbp::PayloadHandler<msg_obs_t> {
@@ -42,7 +42,7 @@ class MsgObsHandler : private sbp::PayloadHandler<msg_obs_t> {
     header_params_.sender_id = sender_id;
     header_params_.msg_type = SBP_MSG_OBS;
     header_params_.payload_len = message_length;
-    header_params_.payload = msg;
+    memcpy(&header_params_.payload[0], &msg, message_length);
   }
 
   void write_message() const {

--- a/generator/sbpg/targets/resources/c/test/legacy/sbp_cpp_test.cc.j2
+++ b/generator/sbpg/targets/resources/c/test/legacy/sbp_cpp_test.cc.j2
@@ -28,6 +28,13 @@
 #include <libsbp/legacy/cpp/payload_handler.h>
 #include <libsbp/legacy/cpp/legacy_state.h>
 
+template<typename T, typename U = std::remove_reference_t<T>>
+U get_as(const uint8_t *buf) {
+  U v;
+  memcpy(&v, buf, sizeof(T));
+  return v;
+}
+
 ((*- for t in s.tests *))                                                     
 ((*- if t.fields *))
 class Test_legacy_(((s.suite_name)))(((loop.index0))) : 
@@ -111,7 +118,7 @@ TEST_F(Test_legacy_(((s.suite_name)))(((loop.index0))), Test)
         literal precision unchanged whether generated under Python 2.7 or 3.x. =))
     EXPECT_LT((last_msg_->(((prefix)))*100 - ((("%.12g"|format(value)|float)))*100), 0.05) << "incorrect value for (((prefix))), expected ((("%.12g"|format(value)|float))), is " << last_msg_->(((prefix)));
     ((*- else *))
-    EXPECT_EQ(last_msg_->(((prefix))), (((value)))) << "incorrect value for (((prefix))), expected (((value))), is " << last_msg_->(((prefix)));
+    EXPECT_EQ(get_as<decltype(last_msg_->(((prefix))))>(reinterpret_cast<const uint8_t *>(&last_msg_->(((prefix))))), (((value)))) << "incorrect value for (((prefix))), expected (((value))), is " << last_msg_->(((prefix)));
     ((*- endif *))
     ((*- endmacro *))
 

--- a/generator/sbpg/targets/resources/c/test/v4/sbp_cpp_test.cc.j2
+++ b/generator/sbpg/targets/resources/c/test/v4/sbp_cpp_test.cc.j2
@@ -376,7 +376,7 @@ void comparison_tests(const (((t.struct_name))) &lesser,
 template <typename T, 
 std::enable_if_t<std::is_integral<T>::value, bool> = true> 
 void make_lesser_greater(T &lesser, T &greater) {
-  if (greater == std::numeric_limits<T>::max()) {
+  if (lesser > std::numeric_limits<T>::min()) {
     lesser--;
   } else {
     greater++;


### PR DESCRIPTION
# Description

@swift-nav/devinfra

Add bazel config to build with ASAN, UBSAN, TSAN, or MSAN

Add CI stages to run tests with ASAN and UBSAN. The other sanitizers aren't important to run regularly given the nature of code in this repository, but they exist for consistency with other projects and to enable manually running those sanitizer if required

A couple of fixes to problems in code which were discovered by the sanitizer. No breaking changes though

# API compatibility

No

## API compatibility plan

No

# JIRA Reference

https://swift-nav.atlassian.net/browse/AP-1386
