### PR TITLE
Add description for constellation identifier to bounds messages [OC-1087]

### DIFF
--- a/c/include/libsbp/ssr_macros.h
+++ b/c/include/libsbp/ssr_macros.h
@@ -495,6 +495,22 @@
 #define SBP_ORBIT_CLOCK_BOUND_ENCODED_LEN 9u
 
 #define SBP_MSG_SSR_ORBIT_CLOCK_BOUNDS 0x05DE
+#define SBP_SSR_ORBIT_CLOCK_BOUNDS__MASK (0xffu)
+#define SBP_SSR_ORBIT_CLOCK_BOUNDS__SHIFT (0u)
+#define SBP_SSR_ORBIT_CLOCK_BOUNDS__GET(flags)               \
+  ((u8)((u8)((flags) >> SBP_SSR_ORBIT_CLOCK_BOUNDS__SHIFT) & \
+        SBP_SSR_ORBIT_CLOCK_BOUNDS__MASK))
+#define SBP_SSR_ORBIT_CLOCK_BOUNDS__SET(flags, val)                      \
+  do {                                                                   \
+    (flags) = (u8)((flags & (~(SBP_SSR_ORBIT_CLOCK_BOUNDS__MASK          \
+                               << SBP_SSR_ORBIT_CLOCK_BOUNDS__SHIFT))) | \
+                   (((val) & (SBP_SSR_ORBIT_CLOCK_BOUNDS__MASK))         \
+                    << (SBP_SSR_ORBIT_CLOCK_BOUNDS__SHIFT)));            \
+  } while (0)
+
+#define SBP_SSR_ORBIT_CLOCK_BOUNDS_GPS (0)
+#define SBP_SSR_ORBIT_CLOCK_BOUNDS_BDS (3)
+#define SBP_SSR_ORBIT_CLOCK_BOUNDS_GAL (5)
 /**
  * The maximum number of items that can be stored in
  * sbp_msg_ssr_orbit_clock_bounds_t::orbit_clock_bounds (V4 API) or
@@ -525,6 +541,22 @@
 #define SBP_CODE_PHASE_BIASES_SAT_SIG_ENCODED_LEN 6u
 
 #define SBP_MSG_SSR_CODE_PHASE_BIASES_BOUNDS 0x05EC
+#define SBP_SSR_CODE_PHASE_BIASES_BOUNDS__MASK (0xffu)
+#define SBP_SSR_CODE_PHASE_BIASES_BOUNDS__SHIFT (0u)
+#define SBP_SSR_CODE_PHASE_BIASES_BOUNDS__GET(flags)               \
+  ((u8)((u8)((flags) >> SBP_SSR_CODE_PHASE_BIASES_BOUNDS__SHIFT) & \
+        SBP_SSR_CODE_PHASE_BIASES_BOUNDS__MASK))
+#define SBP_SSR_CODE_PHASE_BIASES_BOUNDS__SET(flags, val)                      \
+  do {                                                                         \
+    (flags) = (u8)((flags & (~(SBP_SSR_CODE_PHASE_BIASES_BOUNDS__MASK          \
+                               << SBP_SSR_CODE_PHASE_BIASES_BOUNDS__SHIFT))) | \
+                   (((val) & (SBP_SSR_CODE_PHASE_BIASES_BOUNDS__MASK))         \
+                    << (SBP_SSR_CODE_PHASE_BIASES_BOUNDS__SHIFT)));            \
+  } while (0)
+
+#define SBP_SSR_CODE_PHASE_BIASES_BOUNDS_GPS (0)
+#define SBP_SSR_CODE_PHASE_BIASES_BOUNDS_BDS (3)
+#define SBP_SSR_CODE_PHASE_BIASES_BOUNDS_GAL (5)
 /**
  * The maximum number of items that can be stored in
  * sbp_msg_ssr_code_phase_biases_bounds_t::satellites_signals (V4 API) or
@@ -555,6 +587,23 @@
 #define SBP_ORBIT_CLOCK_BOUND_DEGRADATION_ENCODED_LEN 8u
 
 #define SBP_MSG_SSR_ORBIT_CLOCK_BOUNDS_DEGRADATION 0x05DF
+#define SBP_SSR_ORBIT_CLOCK_BOUNDS_DEGRADATION__MASK (0xffu)
+#define SBP_SSR_ORBIT_CLOCK_BOUNDS_DEGRADATION__SHIFT (0u)
+#define SBP_SSR_ORBIT_CLOCK_BOUNDS_DEGRADATION__GET(flags)               \
+  ((u8)((u8)((flags) >> SBP_SSR_ORBIT_CLOCK_BOUNDS_DEGRADATION__SHIFT) & \
+        SBP_SSR_ORBIT_CLOCK_BOUNDS_DEGRADATION__MASK))
+#define SBP_SSR_ORBIT_CLOCK_BOUNDS_DEGRADATION__SET(flags, val)                \
+  do {                                                                         \
+    (flags) =                                                                  \
+        (u8)((flags & (~(SBP_SSR_ORBIT_CLOCK_BOUNDS_DEGRADATION__MASK          \
+                         << SBP_SSR_ORBIT_CLOCK_BOUNDS_DEGRADATION__SHIFT))) | \
+             (((val) & (SBP_SSR_ORBIT_CLOCK_BOUNDS_DEGRADATION__MASK))         \
+              << (SBP_SSR_ORBIT_CLOCK_BOUNDS_DEGRADATION__SHIFT)));            \
+  } while (0)
+
+#define SBP_SSR_ORBIT_CLOCK_BOUNDS_DEGRADATION_GPS (0)
+#define SBP_SSR_ORBIT_CLOCK_BOUNDS_DEGRADATION_BDS (3)
+#define SBP_SSR_ORBIT_CLOCK_BOUNDS_DEGRADATION_GAL (5)
 /**
  * Encoded length of sbp_msg_ssr_orbit_clock_bounds_degradation_t (V4 API) and
  * msg_ssr_orbit_clock_bounds_degradation_t (legacy API)

--- a/rust/sbp/src/link.rs
+++ b/rust/sbp/src/link.rs
@@ -351,6 +351,7 @@ mod tests {
         assert_eq!(*count.borrow(), 1);
     }
 
+    #[allow(dead_code)]
     #[test]
     fn test_custom_event() {
         enum ObsMsg {

--- a/rust/sbp/src/link.rs
+++ b/rust/sbp/src/link.rs
@@ -351,7 +351,6 @@ mod tests {
         assert_eq!(*count.borrow(), 1);
     }
 
-    #[allow(dead_code)]
     #[test]
     fn test_custom_event() {
         enum ObsMsg {

--- a/rust/sbp/src/messages/ssr.rs
+++ b/rust/sbp/src/messages/ssr.rs
@@ -608,6 +608,22 @@ pub mod msg_ssr_code_phase_biases_bounds {
         pub satellites_signals: Vec<CodePhaseBiasesSatSig>,
     }
 
+    impl MsgSsrCodePhaseBiasesBounds {
+        /// Gets the [ConstId][self::ConstId] stored in the `const_id` bitfield.
+        ///
+        /// Returns `Ok` if the bitrange contains a known `ConstId` variant.
+        /// Otherwise the value of the bitrange is returned as an `Err(u8)`. This may be because of a malformed message,
+        /// or because new variants of `ConstId` were added.
+        pub fn const_id(&self) -> Result<ConstId, u8> {
+            get_bit_range!(self.const_id, u8, u8, 7, 0).try_into()
+        }
+
+        /// Set the bitrange corresponding to the [ConstId][ConstId] of the `const_id` bitfield.
+        pub fn set_const_id(&mut self, const_id: ConstId) {
+            set_bit_range!(&mut self.const_id, const_id, u8, u8, 7, 0);
+        }
+    }
+
     impl ConcreteMessage for MsgSsrCodePhaseBiasesBounds {
         const MESSAGE_TYPE: u16 = 1516;
         const MESSAGE_NAME: &'static str = "MSG_SSR_CODE_PHASE_BIASES_BOUNDS";
@@ -681,6 +697,40 @@ pub mod msg_ssr_code_phase_biases_bounds {
                 const_id: WireFormat::parse_unchecked(buf),
                 n_sats_signals: WireFormat::parse_unchecked(buf),
                 satellites_signals: WireFormat::parse_unchecked(buf),
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub enum ConstId {
+        /// GPS
+        Gps = 0,
+
+        /// BDS
+        Bds = 3,
+
+        /// GAL
+        Gal = 5,
+    }
+
+    impl std::fmt::Display for ConstId {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                ConstId::Gps => f.write_str("GPS"),
+                ConstId::Bds => f.write_str("BDS"),
+                ConstId::Gal => f.write_str("GAL"),
+            }
+        }
+    }
+
+    impl TryFrom<u8> for ConstId {
+        type Error = u8;
+        fn try_from(i: u8) -> Result<Self, u8> {
+            match i {
+                0 => Ok(ConstId::Gps),
+                3 => Ok(ConstId::Bds),
+                5 => Ok(ConstId::Gal),
+                i => Err(i),
             }
         }
     }
@@ -1490,6 +1540,22 @@ pub mod msg_ssr_orbit_clock_bounds {
         pub orbit_clock_bounds: Vec<OrbitClockBound>,
     }
 
+    impl MsgSsrOrbitClockBounds {
+        /// Gets the [ConstId][self::ConstId] stored in the `const_id` bitfield.
+        ///
+        /// Returns `Ok` if the bitrange contains a known `ConstId` variant.
+        /// Otherwise the value of the bitrange is returned as an `Err(u8)`. This may be because of a malformed message,
+        /// or because new variants of `ConstId` were added.
+        pub fn const_id(&self) -> Result<ConstId, u8> {
+            get_bit_range!(self.const_id, u8, u8, 7, 0).try_into()
+        }
+
+        /// Set the bitrange corresponding to the [ConstId][ConstId] of the `const_id` bitfield.
+        pub fn set_const_id(&mut self, const_id: ConstId) {
+            set_bit_range!(&mut self.const_id, const_id, u8, u8, 7, 0);
+        }
+    }
+
     impl ConcreteMessage for MsgSsrOrbitClockBounds {
         const MESSAGE_TYPE: u16 = 1502;
         const MESSAGE_NAME: &'static str = "MSG_SSR_ORBIT_CLOCK_BOUNDS";
@@ -1566,6 +1632,40 @@ pub mod msg_ssr_orbit_clock_bounds {
             }
         }
     }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub enum ConstId {
+        /// GPS
+        Gps = 0,
+
+        /// BDS
+        Bds = 3,
+
+        /// GAL
+        Gal = 5,
+    }
+
+    impl std::fmt::Display for ConstId {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                ConstId::Gps => f.write_str("GPS"),
+                ConstId::Bds => f.write_str("BDS"),
+                ConstId::Gal => f.write_str("GAL"),
+            }
+        }
+    }
+
+    impl TryFrom<u8> for ConstId {
+        type Error = u8;
+        fn try_from(i: u8) -> Result<Self, u8> {
+            match i {
+                0 => Ok(ConstId::Gps),
+                3 => Ok(ConstId::Bds),
+                5 => Ok(ConstId::Gal),
+                i => Err(i),
+            }
+        }
+    }
 }
 
 pub mod msg_ssr_orbit_clock_bounds_degradation {
@@ -1599,6 +1699,22 @@ pub mod msg_ssr_orbit_clock_bounds_degradation {
         /// Orbit and Clock Bounds Degradation Parameters
         #[cfg_attr(feature = "serde", serde(rename = "orbit_clock_bounds_degradation"))]
         pub orbit_clock_bounds_degradation: OrbitClockBoundDegradation,
+    }
+
+    impl MsgSsrOrbitClockBoundsDegradation {
+        /// Gets the [ConstId][self::ConstId] stored in the `const_id` bitfield.
+        ///
+        /// Returns `Ok` if the bitrange contains a known `ConstId` variant.
+        /// Otherwise the value of the bitrange is returned as an `Err(u8)`. This may be because of a malformed message,
+        /// or because new variants of `ConstId` were added.
+        pub fn const_id(&self) -> Result<ConstId, u8> {
+            get_bit_range!(self.const_id, u8, u8, 7, 0).try_into()
+        }
+
+        /// Set the bitrange corresponding to the [ConstId][ConstId] of the `const_id` bitfield.
+        pub fn set_const_id(&mut self, const_id: ConstId) {
+            set_bit_range!(&mut self.const_id, const_id, u8, u8, 7, 0);
+        }
     }
 
     impl ConcreteMessage for MsgSsrOrbitClockBoundsDegradation {
@@ -1674,6 +1790,40 @@ pub mod msg_ssr_orbit_clock_bounds_degradation {
                 const_id: WireFormat::parse_unchecked(buf),
                 sat_bitmask: WireFormat::parse_unchecked(buf),
                 orbit_clock_bounds_degradation: WireFormat::parse_unchecked(buf),
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub enum ConstId {
+        /// GPS
+        Gps = 0,
+
+        /// BDS
+        Bds = 3,
+
+        /// GAL
+        Gal = 5,
+    }
+
+    impl std::fmt::Display for ConstId {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                ConstId::Gps => f.write_str("GPS"),
+                ConstId::Bds => f.write_str("BDS"),
+                ConstId::Gal => f.write_str("GAL"),
+            }
+        }
+    }
+
+    impl TryFrom<u8> for ConstId {
+        type Error = u8;
+        fn try_from(i: u8) -> Result<Self, u8> {
+            match i {
+                0 => Ok(ConstId::Gps),
+                3 => Ok(ConstId::Bds),
+                5 => Ok(ConstId::Gal),
+                i => Err(i),
             }
         }
     }

--- a/spec/yaml/swiftnav/sbp/ssr.yaml
+++ b/spec/yaml/swiftnav/sbp/ssr.yaml
@@ -1267,6 +1267,12 @@ definitions:
        - const_id:
            type: u8
            desc: Constellation ID to which the SVs belong.
+           fields:
+           - 0-7:
+               values:
+                   - 0: GPS
+                   - 3: BDS
+                   - 5: GAL
        - n_sats:
            type: u8
            desc: Number of satellites.
@@ -1328,6 +1334,12 @@ definitions:
        - const_id:
            type: u8
            desc: Constellation ID to which the SVs belong.
+           fields:
+           - 0-7:
+               values:
+                   - 0: GPS
+                   - 3: BDS
+                   - 5: GAL
        - n_sats_signals:
            type: u8
            desc: Number of satellite-signal couples.
@@ -1403,6 +1415,12 @@ definitions:
        - const_id:
            type: u8
            desc: Constellation ID to which the SVs belong.
+           fields:
+           - 0-7:
+               values:
+                   - 0: GPS
+                   - 3: BDS
+                   - 5: GAL
        - sat_bitmask:
            type: u64
            desc: >


### PR DESCRIPTION
# Description

Add description for what the constellation identifier means in the orbit&clock bounds, code&phase biases bounds, orbit&clock bounds degradations messages.

# API compatibility

Does this change introduce a API compatibility risk?

No, it's just adding clarifying documentation to the SBP spec.

# JIRA Reference

https://swift-nav.atlassian.net/browse/OC-1087
