### PR TITLE
Change highwater -> high water, add mutexes to spelling wordlist [AP-650]

### DIFF
--- a/c/include/libsbp/profiling/MSG_PROFILING_THREAD_INFO.h
+++ b/c/include/libsbp/profiling/MSG_PROFILING_THREAD_INFO.h
@@ -66,7 +66,7 @@ typedef struct {
   u32 stack_size;
 
   /**
-   * Stack highwater usage in bytes
+   * Stack high water usage in bytes
    */
   u32 stack_usage;
 

--- a/haskell/src/SwiftNav/SBP/Profiling.hs
+++ b/haskell/src/SwiftNav/SBP/Profiling.hs
@@ -148,7 +148,7 @@ data MsgProfilingThreadInfo = MsgProfilingThreadInfo
   , _msgProfilingThreadInfo_stack_size   :: !Word32
     -- ^ Stack size in bytes
   , _msgProfilingThreadInfo_stack_usage  :: !Word32
-    -- ^ Stack highwater usage in bytes
+    -- ^ Stack high water usage in bytes
   , _msgProfilingThreadInfo_name         :: !Text
     -- ^ Thread name
   } deriving ( Show, Read, Eq )

--- a/java/src/com/swiftnav/sbp/profiling/MsgProfilingThreadInfo.java
+++ b/java/src/com/swiftnav/sbp/profiling/MsgProfilingThreadInfo.java
@@ -43,7 +43,7 @@ public class MsgProfilingThreadInfo extends SBPMessage {
     /** Stack size in bytes */
     public long stack_size;
 
-    /** Stack highwater usage in bytes */
+    /** Stack high water usage in bytes */
     public long stack_usage;
 
     /** Thread name */

--- a/javascript/sbp/profiling.js
+++ b/javascript/sbp/profiling.js
@@ -127,7 +127,7 @@ MsgProfilingSystemInfo.prototype.fieldSpec.push(['heap_usage', 'writeUInt32LE', 
  * @field age number (unsigned 64-bit int, 8 bytes) Age of the thread in microseconds
  * @field state number (unsigned 8-bit int, 1 byte) Thread state
  * @field stack_size number (unsigned 32-bit int, 4 bytes) Stack size in bytes
- * @field stack_usage number (unsigned 32-bit int, 4 bytes) Stack highwater usage in bytes
+ * @field stack_usage number (unsigned 32-bit int, 4 bytes) Stack high water usage in bytes
  * @field name string Thread name
  *
  * @param sbp An SBP object with a payload to be decoded.

--- a/kaitai/ksy/profiling.ksy
+++ b/kaitai/ksy/profiling.ksy
@@ -113,7 +113,7 @@ types:
         type: u4
       - id: stack_usage
         doc: |
-          Stack highwater usage in bytes
+          Stack high water usage in bytes
         type: u4
       - id: name
         doc: |

--- a/python/docs/source/spelling_wordlist.txt
+++ b/python/docs/source/spelling_wordlist.txt
@@ -100,6 +100,7 @@ lon
 mesid
 msg
 msgs
+mutexes
 nd
 ndb
 netlink

--- a/python/sbp/profiling.py
+++ b/python/sbp/profiling.py
@@ -374,7 +374,7 @@ class MsgProfilingThreadInfo(SBP):
   stack_size : int
     Stack size in bytes
   stack_usage : int
-    Stack highwater usage in bytes
+    Stack high water usage in bytes
   name : string
     Thread name
   sender : int

--- a/rust/sbp/src/messages/profiling.rs
+++ b/rust/sbp/src/messages/profiling.rs
@@ -399,7 +399,7 @@ pub mod msg_profiling_thread_info {
         /// Stack size in bytes
         #[cfg_attr(feature = "serde", serde(rename = "stack_size"))]
         pub stack_size: u32,
-        /// Stack highwater usage in bytes
+        /// Stack high water usage in bytes
         #[cfg_attr(feature = "serde", serde(rename = "stack_usage"))]
         pub stack_usage: u32,
         /// Thread name

--- a/spec/yaml/swiftnav/sbp/profiling.yaml
+++ b/spec/yaml/swiftnav/sbp/profiling.yaml
@@ -105,7 +105,7 @@ definitions:
           desc: Stack size in bytes
       - stack_usage:
           type: u32
-          desc: Stack highwater usage in bytes
+          desc: Stack high water usage in bytes
       - name:
           type: string
           encoding: null_terminated


### PR DESCRIPTION
# Description

@swift-nav/devinfra

- Change `highwater` -> `high water` in documentation for profiling message
- Add `mutexes` to spelling wordlist

# API compatibility

Does this change introduce a API compatibility risk?

No

## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan:

No

# JIRA Reference

https://swift-nav.atlassian.net/browse/AP-650
