### PR TITLE
Fix license

### DIFF
--- a/c/cmake/Toolchain-gcc-arm-embedded.cmake
+++ b/c/cmake/Toolchain-gcc-arm-embedded.cmake
@@ -5,7 +5,7 @@
 # Contact: Fergus Noble <fergus@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/acquisition.h
+++ b/c/include/libsbp/acquisition.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/acquisition/AcqSvProfile.h
+++ b/c/include/libsbp/acquisition/AcqSvProfile.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/acquisition/AcqSvProfileDep.h
+++ b/c/include/libsbp/acquisition/AcqSvProfileDep.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/acquisition/MSG_ACQ_RESULT.h
+++ b/c/include/libsbp/acquisition/MSG_ACQ_RESULT.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/acquisition/MSG_ACQ_RESULT_DEP_A.h
+++ b/c/include/libsbp/acquisition/MSG_ACQ_RESULT_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/acquisition/MSG_ACQ_RESULT_DEP_B.h
+++ b/c/include/libsbp/acquisition/MSG_ACQ_RESULT_DEP_B.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/acquisition/MSG_ACQ_RESULT_DEP_C.h
+++ b/c/include/libsbp/acquisition/MSG_ACQ_RESULT_DEP_C.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/acquisition/MSG_ACQ_SV_PROFILE.h
+++ b/c/include/libsbp/acquisition/MSG_ACQ_SV_PROFILE.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/acquisition/MSG_ACQ_SV_PROFILE_DEP.h
+++ b/c/include/libsbp/acquisition/MSG_ACQ_SV_PROFILE_DEP.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/acquisition_macros.h
+++ b/c/include/libsbp/acquisition_macros.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/bootload.h
+++ b/c/include/libsbp/bootload.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/bootload/MSG_BOOTLOADER_HANDSHAKE_DEP_A.h
+++ b/c/include/libsbp/bootload/MSG_BOOTLOADER_HANDSHAKE_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/bootload/MSG_BOOTLOADER_HANDSHAKE_REQ.h
+++ b/c/include/libsbp/bootload/MSG_BOOTLOADER_HANDSHAKE_REQ.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/bootload/MSG_BOOTLOADER_HANDSHAKE_RESP.h
+++ b/c/include/libsbp/bootload/MSG_BOOTLOADER_HANDSHAKE_RESP.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/bootload/MSG_BOOTLOADER_JUMP_TO_APP.h
+++ b/c/include/libsbp/bootload/MSG_BOOTLOADER_JUMP_TO_APP.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/bootload/MSG_NAP_DEVICE_DNA_REQ.h
+++ b/c/include/libsbp/bootload/MSG_NAP_DEVICE_DNA_REQ.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/bootload/MSG_NAP_DEVICE_DNA_RESP.h
+++ b/c/include/libsbp/bootload/MSG_NAP_DEVICE_DNA_RESP.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/bootload_macros.h
+++ b/c/include/libsbp/bootload_macros.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/common.h
+++ b/c/include/libsbp/common.h
@@ -3,7 +3,7 @@
  * Contact: Swift Navigation <dev@swift-nav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/cpp/message_handler.h
+++ b/c/include/libsbp/cpp/message_handler.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/cpp/message_traits.h
+++ b/c/include/libsbp/cpp/message_traits.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/cpp/state.h
+++ b/c/include/libsbp/cpp/state.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/edc.h
+++ b/c/include/libsbp/edc.h
@@ -3,7 +3,7 @@
  * Contact: Swift Navigation <dev@swift-nav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ext_events.h
+++ b/c/include/libsbp/ext_events.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ext_events/MSG_EXT_EVENT.h
+++ b/c/include/libsbp/ext_events/MSG_EXT_EVENT.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ext_events_macros.h
+++ b/c/include/libsbp/ext_events_macros.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/file_io.h
+++ b/c/include/libsbp/file_io.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/file_io/MSG_FILEIO_CONFIG_REQ.h
+++ b/c/include/libsbp/file_io/MSG_FILEIO_CONFIG_REQ.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/file_io/MSG_FILEIO_CONFIG_RESP.h
+++ b/c/include/libsbp/file_io/MSG_FILEIO_CONFIG_RESP.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/file_io/MSG_FILEIO_READ_DIR_REQ.h
+++ b/c/include/libsbp/file_io/MSG_FILEIO_READ_DIR_REQ.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/file_io/MSG_FILEIO_READ_DIR_RESP.h
+++ b/c/include/libsbp/file_io/MSG_FILEIO_READ_DIR_RESP.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/file_io/MSG_FILEIO_READ_REQ.h
+++ b/c/include/libsbp/file_io/MSG_FILEIO_READ_REQ.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/file_io/MSG_FILEIO_READ_RESP.h
+++ b/c/include/libsbp/file_io/MSG_FILEIO_READ_RESP.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/file_io/MSG_FILEIO_REMOVE.h
+++ b/c/include/libsbp/file_io/MSG_FILEIO_REMOVE.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/file_io/MSG_FILEIO_WRITE_REQ.h
+++ b/c/include/libsbp/file_io/MSG_FILEIO_WRITE_REQ.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/file_io/MSG_FILEIO_WRITE_RESP.h
+++ b/c/include/libsbp/file_io/MSG_FILEIO_WRITE_RESP.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/file_io_macros.h
+++ b/c/include/libsbp/file_io_macros.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/flash.h
+++ b/c/include/libsbp/flash.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/flash/MSG_FLASH_DONE.h
+++ b/c/include/libsbp/flash/MSG_FLASH_DONE.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/flash/MSG_FLASH_ERASE.h
+++ b/c/include/libsbp/flash/MSG_FLASH_ERASE.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/flash/MSG_FLASH_PROGRAM.h
+++ b/c/include/libsbp/flash/MSG_FLASH_PROGRAM.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/flash/MSG_FLASH_READ_REQ.h
+++ b/c/include/libsbp/flash/MSG_FLASH_READ_REQ.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/flash/MSG_FLASH_READ_RESP.h
+++ b/c/include/libsbp/flash/MSG_FLASH_READ_RESP.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/flash/MSG_M25_FLASH_WRITE_STATUS.h
+++ b/c/include/libsbp/flash/MSG_M25_FLASH_WRITE_STATUS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/flash/MSG_STM_FLASH_LOCK_SECTOR.h
+++ b/c/include/libsbp/flash/MSG_STM_FLASH_LOCK_SECTOR.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/flash/MSG_STM_FLASH_UNLOCK_SECTOR.h
+++ b/c/include/libsbp/flash/MSG_STM_FLASH_UNLOCK_SECTOR.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/flash/MSG_STM_UNIQUE_ID_REQ.h
+++ b/c/include/libsbp/flash/MSG_STM_UNIQUE_ID_REQ.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/flash/MSG_STM_UNIQUE_ID_RESP.h
+++ b/c/include/libsbp/flash/MSG_STM_UNIQUE_ID_RESP.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/flash_macros.h
+++ b/c/include/libsbp/flash_macros.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/gnss.h
+++ b/c/include/libsbp/gnss.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/gnss/CarrierPhase.h
+++ b/c/include/libsbp/gnss/CarrierPhase.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/gnss/GPSTime.h
+++ b/c/include/libsbp/gnss/GPSTime.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/gnss/GPSTimeDep.h
+++ b/c/include/libsbp/gnss/GPSTimeDep.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/gnss/GPSTimeSec.h
+++ b/c/include/libsbp/gnss/GPSTimeSec.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/gnss/GnssSignal.h
+++ b/c/include/libsbp/gnss/GnssSignal.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/gnss/GnssSignalDep.h
+++ b/c/include/libsbp/gnss/GnssSignalDep.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/gnss/SvId.h
+++ b/c/include/libsbp/gnss/SvId.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/gnss_macros.h
+++ b/c/include/libsbp/gnss_macros.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/imu.h
+++ b/c/include/libsbp/imu.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/imu/MSG_IMU_AUX.h
+++ b/c/include/libsbp/imu/MSG_IMU_AUX.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/imu/MSG_IMU_RAW.h
+++ b/c/include/libsbp/imu/MSG_IMU_RAW.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/imu_macros.h
+++ b/c/include/libsbp/imu_macros.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/integrity.h
+++ b/c/include/libsbp/integrity.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/integrity/IntegritySSRHeader.h
+++ b/c/include/libsbp/integrity/IntegritySSRHeader.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/integrity/MSG_ACKNOWLEDGE.h
+++ b/c/include/libsbp/integrity/MSG_ACKNOWLEDGE.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/integrity/MSG_SSR_FLAG_HIGH_LEVEL.h
+++ b/c/include/libsbp/integrity/MSG_SSR_FLAG_HIGH_LEVEL.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/integrity/MSG_SSR_FLAG_IONO_GRID_POINTS.h
+++ b/c/include/libsbp/integrity/MSG_SSR_FLAG_IONO_GRID_POINTS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/integrity/MSG_SSR_FLAG_IONO_GRID_POINT_SAT_LOS.h
+++ b/c/include/libsbp/integrity/MSG_SSR_FLAG_IONO_GRID_POINT_SAT_LOS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/integrity/MSG_SSR_FLAG_IONO_TILE_SAT_LOS.h
+++ b/c/include/libsbp/integrity/MSG_SSR_FLAG_IONO_TILE_SAT_LOS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/integrity/MSG_SSR_FLAG_SATELLITES.h
+++ b/c/include/libsbp/integrity/MSG_SSR_FLAG_SATELLITES.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/integrity/MSG_SSR_FLAG_TROPO_GRID_POINTS.h
+++ b/c/include/libsbp/integrity/MSG_SSR_FLAG_TROPO_GRID_POINTS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/integrity_macros.h
+++ b/c/include/libsbp/integrity_macros.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/linux.h
+++ b/c/include/libsbp/linux.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/linux/MSG_LINUX_CPU_STATE.h
+++ b/c/include/libsbp/linux/MSG_LINUX_CPU_STATE.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/linux/MSG_LINUX_CPU_STATE_DEP_A.h
+++ b/c/include/libsbp/linux/MSG_LINUX_CPU_STATE_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/linux/MSG_LINUX_MEM_STATE.h
+++ b/c/include/libsbp/linux/MSG_LINUX_MEM_STATE.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/linux/MSG_LINUX_MEM_STATE_DEP_A.h
+++ b/c/include/libsbp/linux/MSG_LINUX_MEM_STATE_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/linux/MSG_LINUX_PROCESS_FD_COUNT.h
+++ b/c/include/libsbp/linux/MSG_LINUX_PROCESS_FD_COUNT.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/linux/MSG_LINUX_PROCESS_FD_SUMMARY.h
+++ b/c/include/libsbp/linux/MSG_LINUX_PROCESS_FD_SUMMARY.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/linux/MSG_LINUX_PROCESS_SOCKET_COUNTS.h
+++ b/c/include/libsbp/linux/MSG_LINUX_PROCESS_SOCKET_COUNTS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/linux/MSG_LINUX_PROCESS_SOCKET_QUEUES.h
+++ b/c/include/libsbp/linux/MSG_LINUX_PROCESS_SOCKET_QUEUES.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/linux/MSG_LINUX_SOCKET_USAGE.h
+++ b/c/include/libsbp/linux/MSG_LINUX_SOCKET_USAGE.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/linux/MSG_LINUX_SYS_STATE.h
+++ b/c/include/libsbp/linux/MSG_LINUX_SYS_STATE.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/linux/MSG_LINUX_SYS_STATE_DEP_A.h
+++ b/c/include/libsbp/linux/MSG_LINUX_SYS_STATE_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/linux_macros.h
+++ b/c/include/libsbp/linux_macros.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/logging.h
+++ b/c/include/libsbp/logging.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/logging/MSG_FWD.h
+++ b/c/include/libsbp/logging/MSG_FWD.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/logging/MSG_LOG.h
+++ b/c/include/libsbp/logging/MSG_LOG.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/logging/MSG_PRINT_DEP.h
+++ b/c/include/libsbp/logging/MSG_PRINT_DEP.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/logging_macros.h
+++ b/c/include/libsbp/logging_macros.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/mag.h
+++ b/c/include/libsbp/mag.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/mag/MSG_MAG_RAW.h
+++ b/c/include/libsbp/mag/MSG_MAG_RAW.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/mag_macros.h
+++ b/c/include/libsbp/mag_macros.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation.h
+++ b/c/include/libsbp/navigation.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/EstimatedHorizontalErrorEllipse.h
+++ b/c/include/libsbp/navigation/EstimatedHorizontalErrorEllipse.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_AGE_CORRECTIONS.h
+++ b/c/include/libsbp/navigation/MSG_AGE_CORRECTIONS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_BASELINE_ECEF.h
+++ b/c/include/libsbp/navigation/MSG_BASELINE_ECEF.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_BASELINE_ECEF_DEP_A.h
+++ b/c/include/libsbp/navigation/MSG_BASELINE_ECEF_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_BASELINE_HEADING_DEP_A.h
+++ b/c/include/libsbp/navigation/MSG_BASELINE_HEADING_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_BASELINE_NED.h
+++ b/c/include/libsbp/navigation/MSG_BASELINE_NED.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_BASELINE_NED_DEP_A.h
+++ b/c/include/libsbp/navigation/MSG_BASELINE_NED_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_DOPS.h
+++ b/c/include/libsbp/navigation/MSG_DOPS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_DOPS_DEP_A.h
+++ b/c/include/libsbp/navigation/MSG_DOPS_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_GPS_TIME.h
+++ b/c/include/libsbp/navigation/MSG_GPS_TIME.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_GPS_TIME_DEP_A.h
+++ b/c/include/libsbp/navigation/MSG_GPS_TIME_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_GPS_TIME_GNSS.h
+++ b/c/include/libsbp/navigation/MSG_GPS_TIME_GNSS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_POSE_RELATIVE.h
+++ b/c/include/libsbp/navigation/MSG_POSE_RELATIVE.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_POS_ECEF.h
+++ b/c/include/libsbp/navigation/MSG_POS_ECEF.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_POS_ECEF_COV.h
+++ b/c/include/libsbp/navigation/MSG_POS_ECEF_COV.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_POS_ECEF_COV_GNSS.h
+++ b/c/include/libsbp/navigation/MSG_POS_ECEF_COV_GNSS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_POS_ECEF_DEP_A.h
+++ b/c/include/libsbp/navigation/MSG_POS_ECEF_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_POS_ECEF_GNSS.h
+++ b/c/include/libsbp/navigation/MSG_POS_ECEF_GNSS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_POS_LLH.h
+++ b/c/include/libsbp/navigation/MSG_POS_LLH.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_POS_LLH_ACC.h
+++ b/c/include/libsbp/navigation/MSG_POS_LLH_ACC.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_POS_LLH_COV.h
+++ b/c/include/libsbp/navigation/MSG_POS_LLH_COV.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_POS_LLH_COV_GNSS.h
+++ b/c/include/libsbp/navigation/MSG_POS_LLH_COV_GNSS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_POS_LLH_DEP_A.h
+++ b/c/include/libsbp/navigation/MSG_POS_LLH_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_POS_LLH_GNSS.h
+++ b/c/include/libsbp/navigation/MSG_POS_LLH_GNSS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_PROTECTION_LEVEL.h
+++ b/c/include/libsbp/navigation/MSG_PROTECTION_LEVEL.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_PROTECTION_LEVEL_DEP_A.h
+++ b/c/include/libsbp/navigation/MSG_PROTECTION_LEVEL_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_REFERENCE_FRAME_PARAM.h
+++ b/c/include/libsbp/navigation/MSG_REFERENCE_FRAME_PARAM.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_UTC_LEAP_SECOND.h
+++ b/c/include/libsbp/navigation/MSG_UTC_LEAP_SECOND.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_UTC_TIME.h
+++ b/c/include/libsbp/navigation/MSG_UTC_TIME.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_UTC_TIME_GNSS.h
+++ b/c/include/libsbp/navigation/MSG_UTC_TIME_GNSS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_VEL_BODY.h
+++ b/c/include/libsbp/navigation/MSG_VEL_BODY.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_VEL_COG.h
+++ b/c/include/libsbp/navigation/MSG_VEL_COG.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_VEL_ECEF.h
+++ b/c/include/libsbp/navigation/MSG_VEL_ECEF.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_VEL_ECEF_COV.h
+++ b/c/include/libsbp/navigation/MSG_VEL_ECEF_COV.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_VEL_ECEF_COV_GNSS.h
+++ b/c/include/libsbp/navigation/MSG_VEL_ECEF_COV_GNSS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_VEL_ECEF_DEP_A.h
+++ b/c/include/libsbp/navigation/MSG_VEL_ECEF_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_VEL_ECEF_GNSS.h
+++ b/c/include/libsbp/navigation/MSG_VEL_ECEF_GNSS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_VEL_NED.h
+++ b/c/include/libsbp/navigation/MSG_VEL_NED.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_VEL_NED_COV.h
+++ b/c/include/libsbp/navigation/MSG_VEL_NED_COV.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_VEL_NED_COV_GNSS.h
+++ b/c/include/libsbp/navigation/MSG_VEL_NED_COV_GNSS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_VEL_NED_DEP_A.h
+++ b/c/include/libsbp/navigation/MSG_VEL_NED_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation/MSG_VEL_NED_GNSS.h
+++ b/c/include/libsbp/navigation/MSG_VEL_NED_GNSS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/navigation_macros.h
+++ b/c/include/libsbp/navigation_macros.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ndb.h
+++ b/c/include/libsbp/ndb.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ndb/MSG_NDB_EVENT.h
+++ b/c/include/libsbp/ndb/MSG_NDB_EVENT.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ndb_macros.h
+++ b/c/include/libsbp/ndb_macros.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation.h
+++ b/c/include/libsbp/observation.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/AlmanacCommonContent.h
+++ b/c/include/libsbp/observation/AlmanacCommonContent.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/AlmanacCommonContentDep.h
+++ b/c/include/libsbp/observation/AlmanacCommonContentDep.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/CarrierPhaseDepA.h
+++ b/c/include/libsbp/observation/CarrierPhaseDepA.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/Doppler.h
+++ b/c/include/libsbp/observation/Doppler.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/EphemerisCommonContent.h
+++ b/c/include/libsbp/observation/EphemerisCommonContent.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/EphemerisCommonContentDepA.h
+++ b/c/include/libsbp/observation/EphemerisCommonContentDepA.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/EphemerisCommonContentDepB.h
+++ b/c/include/libsbp/observation/EphemerisCommonContentDepB.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/GnssCapb.h
+++ b/c/include/libsbp/observation/GnssCapb.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_ALMANAC_GLO.h
+++ b/c/include/libsbp/observation/MSG_ALMANAC_GLO.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_ALMANAC_GLO_DEP.h
+++ b/c/include/libsbp/observation/MSG_ALMANAC_GLO_DEP.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_ALMANAC_GPS.h
+++ b/c/include/libsbp/observation/MSG_ALMANAC_GPS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_ALMANAC_GPS_DEP.h
+++ b/c/include/libsbp/observation/MSG_ALMANAC_GPS_DEP.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_BASE_POS_ECEF.h
+++ b/c/include/libsbp/observation/MSG_BASE_POS_ECEF.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_BASE_POS_LLH.h
+++ b/c/include/libsbp/observation/MSG_BASE_POS_LLH.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_EPHEMERIS_BDS.h
+++ b/c/include/libsbp/observation/MSG_EPHEMERIS_BDS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_EPHEMERIS_DEP_A.h
+++ b/c/include/libsbp/observation/MSG_EPHEMERIS_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_EPHEMERIS_DEP_B.h
+++ b/c/include/libsbp/observation/MSG_EPHEMERIS_DEP_B.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_EPHEMERIS_DEP_C.h
+++ b/c/include/libsbp/observation/MSG_EPHEMERIS_DEP_C.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_EPHEMERIS_DEP_D.h
+++ b/c/include/libsbp/observation/MSG_EPHEMERIS_DEP_D.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_EPHEMERIS_GAL.h
+++ b/c/include/libsbp/observation/MSG_EPHEMERIS_GAL.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_EPHEMERIS_GAL_DEP_A.h
+++ b/c/include/libsbp/observation/MSG_EPHEMERIS_GAL_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_EPHEMERIS_GLO.h
+++ b/c/include/libsbp/observation/MSG_EPHEMERIS_GLO.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_EPHEMERIS_GLO_DEP_A.h
+++ b/c/include/libsbp/observation/MSG_EPHEMERIS_GLO_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_EPHEMERIS_GLO_DEP_B.h
+++ b/c/include/libsbp/observation/MSG_EPHEMERIS_GLO_DEP_B.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_EPHEMERIS_GLO_DEP_C.h
+++ b/c/include/libsbp/observation/MSG_EPHEMERIS_GLO_DEP_C.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_EPHEMERIS_GLO_DEP_D.h
+++ b/c/include/libsbp/observation/MSG_EPHEMERIS_GLO_DEP_D.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_EPHEMERIS_GPS.h
+++ b/c/include/libsbp/observation/MSG_EPHEMERIS_GPS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_EPHEMERIS_GPS_DEP_E.h
+++ b/c/include/libsbp/observation/MSG_EPHEMERIS_GPS_DEP_E.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_EPHEMERIS_GPS_DEP_F.h
+++ b/c/include/libsbp/observation/MSG_EPHEMERIS_GPS_DEP_F.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_EPHEMERIS_QZSS.h
+++ b/c/include/libsbp/observation/MSG_EPHEMERIS_QZSS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_EPHEMERIS_SBAS.h
+++ b/c/include/libsbp/observation/MSG_EPHEMERIS_SBAS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_EPHEMERIS_SBAS_DEP_A.h
+++ b/c/include/libsbp/observation/MSG_EPHEMERIS_SBAS_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_EPHEMERIS_SBAS_DEP_B.h
+++ b/c/include/libsbp/observation/MSG_EPHEMERIS_SBAS_DEP_B.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_GLO_BIASES.h
+++ b/c/include/libsbp/observation/MSG_GLO_BIASES.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_GNSS_CAPB.h
+++ b/c/include/libsbp/observation/MSG_GNSS_CAPB.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_GROUP_DELAY.h
+++ b/c/include/libsbp/observation/MSG_GROUP_DELAY.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_GROUP_DELAY_DEP_A.h
+++ b/c/include/libsbp/observation/MSG_GROUP_DELAY_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_GROUP_DELAY_DEP_B.h
+++ b/c/include/libsbp/observation/MSG_GROUP_DELAY_DEP_B.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_IONO.h
+++ b/c/include/libsbp/observation/MSG_IONO.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_OBS.h
+++ b/c/include/libsbp/observation/MSG_OBS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_OBS_DEP_A.h
+++ b/c/include/libsbp/observation/MSG_OBS_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_OBS_DEP_B.h
+++ b/c/include/libsbp/observation/MSG_OBS_DEP_B.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_OBS_DEP_C.h
+++ b/c/include/libsbp/observation/MSG_OBS_DEP_C.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_OSR.h
+++ b/c/include/libsbp/observation/MSG_OSR.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_SV_AZ_EL.h
+++ b/c/include/libsbp/observation/MSG_SV_AZ_EL.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/MSG_SV_CONFIGURATION_GPS_DEP.h
+++ b/c/include/libsbp/observation/MSG_SV_CONFIGURATION_GPS_DEP.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/ObservationHeader.h
+++ b/c/include/libsbp/observation/ObservationHeader.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/ObservationHeaderDep.h
+++ b/c/include/libsbp/observation/ObservationHeaderDep.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/PackedObsContent.h
+++ b/c/include/libsbp/observation/PackedObsContent.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/PackedObsContentDepA.h
+++ b/c/include/libsbp/observation/PackedObsContentDepA.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/PackedObsContentDepB.h
+++ b/c/include/libsbp/observation/PackedObsContentDepB.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/PackedObsContentDepC.h
+++ b/c/include/libsbp/observation/PackedObsContentDepC.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/PackedOsrContent.h
+++ b/c/include/libsbp/observation/PackedOsrContent.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation/SvAzEl.h
+++ b/c/include/libsbp/observation/SvAzEl.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/observation_macros.h
+++ b/c/include/libsbp/observation_macros.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/orientation.h
+++ b/c/include/libsbp/orientation.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/orientation/MSG_ANGULAR_RATE.h
+++ b/c/include/libsbp/orientation/MSG_ANGULAR_RATE.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/orientation/MSG_BASELINE_HEADING.h
+++ b/c/include/libsbp/orientation/MSG_BASELINE_HEADING.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/orientation/MSG_ORIENT_EULER.h
+++ b/c/include/libsbp/orientation/MSG_ORIENT_EULER.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/orientation/MSG_ORIENT_QUAT.h
+++ b/c/include/libsbp/orientation/MSG_ORIENT_QUAT.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/orientation_macros.h
+++ b/c/include/libsbp/orientation_macros.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/piksi.h
+++ b/c/include/libsbp/piksi.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/piksi/Latency.h
+++ b/c/include/libsbp/piksi/Latency.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/piksi/MSG_ALMANAC.h
+++ b/c/include/libsbp/piksi/MSG_ALMANAC.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/piksi/MSG_CELL_MODEM_STATUS.h
+++ b/c/include/libsbp/piksi/MSG_CELL_MODEM_STATUS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/piksi/MSG_COMMAND_OUTPUT.h
+++ b/c/include/libsbp/piksi/MSG_COMMAND_OUTPUT.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/piksi/MSG_COMMAND_REQ.h
+++ b/c/include/libsbp/piksi/MSG_COMMAND_REQ.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/piksi/MSG_COMMAND_RESP.h
+++ b/c/include/libsbp/piksi/MSG_COMMAND_RESP.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/piksi/MSG_CW_RESULTS.h
+++ b/c/include/libsbp/piksi/MSG_CW_RESULTS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/piksi/MSG_CW_START.h
+++ b/c/include/libsbp/piksi/MSG_CW_START.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/piksi/MSG_DEVICE_MONITOR.h
+++ b/c/include/libsbp/piksi/MSG_DEVICE_MONITOR.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/piksi/MSG_FRONT_END_GAIN.h
+++ b/c/include/libsbp/piksi/MSG_FRONT_END_GAIN.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/piksi/MSG_IAR_STATE.h
+++ b/c/include/libsbp/piksi/MSG_IAR_STATE.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/piksi/MSG_INIT_BASE_DEP.h
+++ b/c/include/libsbp/piksi/MSG_INIT_BASE_DEP.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/piksi/MSG_MASK_SATELLITE.h
+++ b/c/include/libsbp/piksi/MSG_MASK_SATELLITE.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/piksi/MSG_MASK_SATELLITE_DEP.h
+++ b/c/include/libsbp/piksi/MSG_MASK_SATELLITE_DEP.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/piksi/MSG_NETWORK_BANDWIDTH_USAGE.h
+++ b/c/include/libsbp/piksi/MSG_NETWORK_BANDWIDTH_USAGE.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/piksi/MSG_NETWORK_STATE_REQ.h
+++ b/c/include/libsbp/piksi/MSG_NETWORK_STATE_REQ.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/piksi/MSG_NETWORK_STATE_RESP.h
+++ b/c/include/libsbp/piksi/MSG_NETWORK_STATE_RESP.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/piksi/MSG_RESET.h
+++ b/c/include/libsbp/piksi/MSG_RESET.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/piksi/MSG_RESET_DEP.h
+++ b/c/include/libsbp/piksi/MSG_RESET_DEP.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/piksi/MSG_RESET_FILTERS.h
+++ b/c/include/libsbp/piksi/MSG_RESET_FILTERS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/piksi/MSG_SET_TIME.h
+++ b/c/include/libsbp/piksi/MSG_SET_TIME.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/piksi/MSG_SPECAN.h
+++ b/c/include/libsbp/piksi/MSG_SPECAN.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/piksi/MSG_SPECAN_DEP.h
+++ b/c/include/libsbp/piksi/MSG_SPECAN_DEP.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/piksi/MSG_THREAD_STATE.h
+++ b/c/include/libsbp/piksi/MSG_THREAD_STATE.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/piksi/MSG_UART_STATE.h
+++ b/c/include/libsbp/piksi/MSG_UART_STATE.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/piksi/MSG_UART_STATE_DEPA.h
+++ b/c/include/libsbp/piksi/MSG_UART_STATE_DEPA.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/piksi/NetworkUsage.h
+++ b/c/include/libsbp/piksi/NetworkUsage.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/piksi/Period.h
+++ b/c/include/libsbp/piksi/Period.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/piksi/UARTChannel.h
+++ b/c/include/libsbp/piksi/UARTChannel.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/piksi_macros.h
+++ b/c/include/libsbp/piksi_macros.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/profiling.h
+++ b/c/include/libsbp/profiling.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/profiling/MSG_MEASUREMENT_POINT.h
+++ b/c/include/libsbp/profiling/MSG_MEASUREMENT_POINT.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/profiling/MSG_PROFILING_RESOURCE_COUNTER.h
+++ b/c/include/libsbp/profiling/MSG_PROFILING_RESOURCE_COUNTER.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/profiling/MSG_PROFILING_SYSTEM_INFO.h
+++ b/c/include/libsbp/profiling/MSG_PROFILING_SYSTEM_INFO.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/profiling/MSG_PROFILING_THREAD_INFO.h
+++ b/c/include/libsbp/profiling/MSG_PROFILING_THREAD_INFO.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/profiling/ResourceBucket.h
+++ b/c/include/libsbp/profiling/ResourceBucket.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/profiling_macros.h
+++ b/c/include/libsbp/profiling_macros.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/sbas.h
+++ b/c/include/libsbp/sbas.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/sbas/MSG_SBAS_RAW.h
+++ b/c/include/libsbp/sbas/MSG_SBAS_RAW.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/sbas_macros.h
+++ b/c/include/libsbp/sbas_macros.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/sbp.h
+++ b/c/include/libsbp/sbp.h
@@ -3,7 +3,7 @@
  * Contact: Swift Navigation <dev@swift-nav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/sbp_msg.h
+++ b/c/include/libsbp/sbp_msg.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/sbp_msg_type.h
+++ b/c/include/libsbp/sbp_msg_type.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/settings.h
+++ b/c/include/libsbp/settings.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/settings/MSG_SETTINGS_READ_BY_INDEX_DONE.h
+++ b/c/include/libsbp/settings/MSG_SETTINGS_READ_BY_INDEX_DONE.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/settings/MSG_SETTINGS_READ_BY_INDEX_REQ.h
+++ b/c/include/libsbp/settings/MSG_SETTINGS_READ_BY_INDEX_REQ.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/settings/MSG_SETTINGS_READ_BY_INDEX_RESP.h
+++ b/c/include/libsbp/settings/MSG_SETTINGS_READ_BY_INDEX_RESP.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/settings/MSG_SETTINGS_READ_REQ.h
+++ b/c/include/libsbp/settings/MSG_SETTINGS_READ_REQ.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/settings/MSG_SETTINGS_READ_RESP.h
+++ b/c/include/libsbp/settings/MSG_SETTINGS_READ_RESP.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/settings/MSG_SETTINGS_REGISTER.h
+++ b/c/include/libsbp/settings/MSG_SETTINGS_REGISTER.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/settings/MSG_SETTINGS_REGISTER_RESP.h
+++ b/c/include/libsbp/settings/MSG_SETTINGS_REGISTER_RESP.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/settings/MSG_SETTINGS_SAVE.h
+++ b/c/include/libsbp/settings/MSG_SETTINGS_SAVE.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/settings/MSG_SETTINGS_WRITE.h
+++ b/c/include/libsbp/settings/MSG_SETTINGS_WRITE.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/settings/MSG_SETTINGS_WRITE_RESP.h
+++ b/c/include/libsbp/settings/MSG_SETTINGS_WRITE_RESP.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/settings_macros.h
+++ b/c/include/libsbp/settings_macros.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/signing.h
+++ b/c/include/libsbp/signing.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/signing/ECDSASignature.h
+++ b/c/include/libsbp/signing/ECDSASignature.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/signing/MSG_CERTIFICATE_CHAIN.h
+++ b/c/include/libsbp/signing/MSG_CERTIFICATE_CHAIN.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/signing/MSG_CERTIFICATE_CHAIN_DEP.h
+++ b/c/include/libsbp/signing/MSG_CERTIFICATE_CHAIN_DEP.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/signing/MSG_ECDSA_CERTIFICATE.h
+++ b/c/include/libsbp/signing/MSG_ECDSA_CERTIFICATE.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/signing/MSG_ECDSA_SIGNATURE.h
+++ b/c/include/libsbp/signing/MSG_ECDSA_SIGNATURE.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/signing/MSG_ECDSA_SIGNATURE_DEP_A.h
+++ b/c/include/libsbp/signing/MSG_ECDSA_SIGNATURE_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/signing/MSG_ECDSA_SIGNATURE_DEP_B.h
+++ b/c/include/libsbp/signing/MSG_ECDSA_SIGNATURE_DEP_B.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/signing/MSG_ED25519_CERTIFICATE_DEP.h
+++ b/c/include/libsbp/signing/MSG_ED25519_CERTIFICATE_DEP.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/signing/MSG_ED25519_SIGNATURE_DEP_A.h
+++ b/c/include/libsbp/signing/MSG_ED25519_SIGNATURE_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/signing/MSG_ED25519_SIGNATURE_DEP_B.h
+++ b/c/include/libsbp/signing/MSG_ED25519_SIGNATURE_DEP_B.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/signing/UtcTime.h
+++ b/c/include/libsbp/signing/UtcTime.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/signing_macros.h
+++ b/c/include/libsbp/signing_macros.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/solution_meta.h
+++ b/c/include/libsbp/solution_meta.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/solution_meta/GNSSInputType.h
+++ b/c/include/libsbp/solution_meta/GNSSInputType.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/solution_meta/IMUInputType.h
+++ b/c/include/libsbp/solution_meta/IMUInputType.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/solution_meta/MSG_SOLN_META.h
+++ b/c/include/libsbp/solution_meta/MSG_SOLN_META.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/solution_meta/MSG_SOLN_META_DEP_A.h
+++ b/c/include/libsbp/solution_meta/MSG_SOLN_META_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/solution_meta/OdoInputType.h
+++ b/c/include/libsbp/solution_meta/OdoInputType.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/solution_meta/SolutionInputType.h
+++ b/c/include/libsbp/solution_meta/SolutionInputType.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/solution_meta_macros.h
+++ b/c/include/libsbp/solution_meta_macros.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr.h
+++ b/c/include/libsbp/ssr.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/BoundsHeader.h
+++ b/c/include/libsbp/ssr/BoundsHeader.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/CodeBiasesContent.h
+++ b/c/include/libsbp/ssr/CodeBiasesContent.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/CodePhaseBiasesSatSig.h
+++ b/c/include/libsbp/ssr/CodePhaseBiasesSatSig.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/GridDefinitionHeaderDepA.h
+++ b/c/include/libsbp/ssr/GridDefinitionHeaderDepA.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/GriddedCorrectionHeader.h
+++ b/c/include/libsbp/ssr/GriddedCorrectionHeader.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/GriddedCorrectionHeaderDepA.h
+++ b/c/include/libsbp/ssr/GriddedCorrectionHeaderDepA.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/MSG_SSR_CODE_BIASES.h
+++ b/c/include/libsbp/ssr/MSG_SSR_CODE_BIASES.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/MSG_SSR_CODE_PHASE_BIASES_BOUNDS.h
+++ b/c/include/libsbp/ssr/MSG_SSR_CODE_PHASE_BIASES_BOUNDS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/MSG_SSR_GRIDDED_CORRECTION.h
+++ b/c/include/libsbp/ssr/MSG_SSR_GRIDDED_CORRECTION.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/MSG_SSR_GRIDDED_CORRECTION_BOUNDS.h
+++ b/c/include/libsbp/ssr/MSG_SSR_GRIDDED_CORRECTION_BOUNDS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/MSG_SSR_GRIDDED_CORRECTION_DEP_A.h
+++ b/c/include/libsbp/ssr/MSG_SSR_GRIDDED_CORRECTION_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/MSG_SSR_GRIDDED_CORRECTION_NO_STD_DEP_A.h
+++ b/c/include/libsbp/ssr/MSG_SSR_GRIDDED_CORRECTION_NO_STD_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/MSG_SSR_GRID_DEFINITION_DEP_A.h
+++ b/c/include/libsbp/ssr/MSG_SSR_GRID_DEFINITION_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/MSG_SSR_ORBIT_CLOCK.h
+++ b/c/include/libsbp/ssr/MSG_SSR_ORBIT_CLOCK.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/MSG_SSR_ORBIT_CLOCK_BOUNDS.h
+++ b/c/include/libsbp/ssr/MSG_SSR_ORBIT_CLOCK_BOUNDS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/MSG_SSR_ORBIT_CLOCK_BOUNDS_DEGRADATION.h
+++ b/c/include/libsbp/ssr/MSG_SSR_ORBIT_CLOCK_BOUNDS_DEGRADATION.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/MSG_SSR_ORBIT_CLOCK_DEP_A.h
+++ b/c/include/libsbp/ssr/MSG_SSR_ORBIT_CLOCK_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/MSG_SSR_PHASE_BIASES.h
+++ b/c/include/libsbp/ssr/MSG_SSR_PHASE_BIASES.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/MSG_SSR_SATELLITE_APC.h
+++ b/c/include/libsbp/ssr/MSG_SSR_SATELLITE_APC.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/MSG_SSR_SATELLITE_APC_DEP.h
+++ b/c/include/libsbp/ssr/MSG_SSR_SATELLITE_APC_DEP.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/MSG_SSR_STEC_CORRECTION.h
+++ b/c/include/libsbp/ssr/MSG_SSR_STEC_CORRECTION.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/MSG_SSR_STEC_CORRECTION_DEP.h
+++ b/c/include/libsbp/ssr/MSG_SSR_STEC_CORRECTION_DEP.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/MSG_SSR_STEC_CORRECTION_DEP_A.h
+++ b/c/include/libsbp/ssr/MSG_SSR_STEC_CORRECTION_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/MSG_SSR_TILE_DEFINITION.h
+++ b/c/include/libsbp/ssr/MSG_SSR_TILE_DEFINITION.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/MSG_SSR_TILE_DEFINITION_DEP_A.h
+++ b/c/include/libsbp/ssr/MSG_SSR_TILE_DEFINITION_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/MSG_SSR_TILE_DEFINITION_DEP_B.h
+++ b/c/include/libsbp/ssr/MSG_SSR_TILE_DEFINITION_DEP_B.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/OrbitClockBound.h
+++ b/c/include/libsbp/ssr/OrbitClockBound.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/OrbitClockBoundDegradation.h
+++ b/c/include/libsbp/ssr/OrbitClockBoundDegradation.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/PhaseBiasesContent.h
+++ b/c/include/libsbp/ssr/PhaseBiasesContent.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/STECHeader.h
+++ b/c/include/libsbp/ssr/STECHeader.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/STECHeaderDepA.h
+++ b/c/include/libsbp/ssr/STECHeaderDepA.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/STECResidual.h
+++ b/c/include/libsbp/ssr/STECResidual.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/STECResidualNoStd.h
+++ b/c/include/libsbp/ssr/STECResidualNoStd.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/STECSatElement.h
+++ b/c/include/libsbp/ssr/STECSatElement.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/STECSatElementIntegrity.h
+++ b/c/include/libsbp/ssr/STECSatElementIntegrity.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/SatelliteAPC.h
+++ b/c/include/libsbp/ssr/SatelliteAPC.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/TroposphericDelayCorrection.h
+++ b/c/include/libsbp/ssr/TroposphericDelayCorrection.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr/TroposphericDelayCorrectionNoStd.h
+++ b/c/include/libsbp/ssr/TroposphericDelayCorrectionNoStd.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/ssr_macros.h
+++ b/c/include/libsbp/ssr_macros.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/system.h
+++ b/c/include/libsbp/system.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/system/MSG_CSAC_TELEMETRY.h
+++ b/c/include/libsbp/system/MSG_CSAC_TELEMETRY.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/system/MSG_CSAC_TELEMETRY_LABELS.h
+++ b/c/include/libsbp/system/MSG_CSAC_TELEMETRY_LABELS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/system/MSG_DGNSS_STATUS.h
+++ b/c/include/libsbp/system/MSG_DGNSS_STATUS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/system/MSG_GNSS_TIME_OFFSET.h
+++ b/c/include/libsbp/system/MSG_GNSS_TIME_OFFSET.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/system/MSG_GROUP_META.h
+++ b/c/include/libsbp/system/MSG_GROUP_META.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/system/MSG_HEARTBEAT.h
+++ b/c/include/libsbp/system/MSG_HEARTBEAT.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/system/MSG_INS_STATUS.h
+++ b/c/include/libsbp/system/MSG_INS_STATUS.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/system/MSG_INS_UPDATES.h
+++ b/c/include/libsbp/system/MSG_INS_UPDATES.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/system/MSG_PPS_TIME.h
+++ b/c/include/libsbp/system/MSG_PPS_TIME.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/system/MSG_SENSOR_AID_EVENT.h
+++ b/c/include/libsbp/system/MSG_SENSOR_AID_EVENT.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/system/MSG_STARTUP.h
+++ b/c/include/libsbp/system/MSG_STARTUP.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/system/MSG_STATUS_JOURNAL.h
+++ b/c/include/libsbp/system/MSG_STATUS_JOURNAL.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/system/MSG_STATUS_REPORT.h
+++ b/c/include/libsbp/system/MSG_STATUS_REPORT.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/system/StatusJournalItem.h
+++ b/c/include/libsbp/system/StatusJournalItem.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/system/SubSystemReport.h
+++ b/c/include/libsbp/system/SubSystemReport.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/system_macros.h
+++ b/c/include/libsbp/system_macros.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/telemetry.h
+++ b/c/include/libsbp/telemetry.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/telemetry/MSG_TEL_SV.h
+++ b/c/include/libsbp/telemetry/MSG_TEL_SV.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/telemetry/TelemetrySV.h
+++ b/c/include/libsbp/telemetry/TelemetrySV.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/telemetry_macros.h
+++ b/c/include/libsbp/telemetry_macros.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/tracking.h
+++ b/c/include/libsbp/tracking.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/tracking/MSG_MEASUREMENT_STATE.h
+++ b/c/include/libsbp/tracking/MSG_MEASUREMENT_STATE.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/tracking/MSG_TRACKING_IQ.h
+++ b/c/include/libsbp/tracking/MSG_TRACKING_IQ.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/tracking/MSG_TRACKING_IQ_DEP_A.h
+++ b/c/include/libsbp/tracking/MSG_TRACKING_IQ_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/tracking/MSG_TRACKING_IQ_DEP_B.h
+++ b/c/include/libsbp/tracking/MSG_TRACKING_IQ_DEP_B.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/tracking/MSG_TRACKING_STATE.h
+++ b/c/include/libsbp/tracking/MSG_TRACKING_STATE.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/tracking/MSG_TRACKING_STATE_DEP_A.h
+++ b/c/include/libsbp/tracking/MSG_TRACKING_STATE_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/tracking/MSG_TRACKING_STATE_DEP_B.h
+++ b/c/include/libsbp/tracking/MSG_TRACKING_STATE_DEP_B.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/tracking/MSG_TRACKING_STATE_DETAILED_DEP.h
+++ b/c/include/libsbp/tracking/MSG_TRACKING_STATE_DETAILED_DEP.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/tracking/MSG_TRACKING_STATE_DETAILED_DEP_A.h
+++ b/c/include/libsbp/tracking/MSG_TRACKING_STATE_DETAILED_DEP_A.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/tracking/MeasurementState.h
+++ b/c/include/libsbp/tracking/MeasurementState.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/tracking/TrackingChannelCorrelation.h
+++ b/c/include/libsbp/tracking/TrackingChannelCorrelation.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/tracking/TrackingChannelCorrelationDep.h
+++ b/c/include/libsbp/tracking/TrackingChannelCorrelationDep.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/tracking/TrackingChannelState.h
+++ b/c/include/libsbp/tracking/TrackingChannelState.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/tracking/TrackingChannelStateDepA.h
+++ b/c/include/libsbp/tracking/TrackingChannelStateDepA.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/tracking/TrackingChannelStateDepB.h
+++ b/c/include/libsbp/tracking/TrackingChannelStateDepB.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/tracking_macros.h
+++ b/c/include/libsbp/tracking_macros.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/user.h
+++ b/c/include/libsbp/user.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/user/MSG_USER_DATA.h
+++ b/c/include/libsbp/user/MSG_USER_DATA.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/user_macros.h
+++ b/c/include/libsbp/user_macros.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/vehicle.h
+++ b/c/include/libsbp/vehicle.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/vehicle/MSG_ODOMETRY.h
+++ b/c/include/libsbp/vehicle/MSG_ODOMETRY.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/vehicle/MSG_WHEELTICK.h
+++ b/c/include/libsbp/vehicle/MSG_WHEELTICK.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/vehicle_macros.h
+++ b/c/include/libsbp/vehicle_macros.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/libsbp/version.h
+++ b/c/include/libsbp/version.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/edc.c
+++ b/c/src/edc.c
@@ -3,7 +3,7 @@
  * Contact: Swift Navigation <dev@swift-nav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/acquisition.h
+++ b/c/src/include/libsbp/internal/acquisition.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/bootload.h
+++ b/c/src/include/libsbp/internal/bootload.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/ext_events.h
+++ b/c/src/include/libsbp/internal/ext_events.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/file_io.h
+++ b/c/src/include/libsbp/internal/file_io.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/flash.h
+++ b/c/src/include/libsbp/internal/flash.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/gnss.h
+++ b/c/src/include/libsbp/internal/gnss.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/imu.h
+++ b/c/src/include/libsbp/internal/imu.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/integrity.h
+++ b/c/src/include/libsbp/internal/integrity.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/linux.h
+++ b/c/src/include/libsbp/internal/linux.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/logging.h
+++ b/c/src/include/libsbp/internal/logging.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/mag.h
+++ b/c/src/include/libsbp/internal/mag.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/navigation.h
+++ b/c/src/include/libsbp/internal/navigation.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/ndb.h
+++ b/c/src/include/libsbp/internal/ndb.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/observation.h
+++ b/c/src/include/libsbp/internal/observation.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/orientation.h
+++ b/c/src/include/libsbp/internal/orientation.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/piksi.h
+++ b/c/src/include/libsbp/internal/piksi.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/profiling.h
+++ b/c/src/include/libsbp/internal/profiling.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/sbas.h
+++ b/c/src/include/libsbp/internal/sbas.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/settings.h
+++ b/c/src/include/libsbp/internal/settings.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/signing.h
+++ b/c/src/include/libsbp/internal/signing.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/solution_meta.h
+++ b/c/src/include/libsbp/internal/solution_meta.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/ssr.h
+++ b/c/src/include/libsbp/internal/ssr.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/string/double_null_terminated.h
+++ b/c/src/include/libsbp/internal/string/double_null_terminated.h
@@ -3,7 +3,7 @@
  * Contact: Swift Navigation <dev@swift-nav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/string/multipart.h
+++ b/c/src/include/libsbp/internal/string/multipart.h
@@ -3,7 +3,7 @@
  * Contact: Swift Navigation <dev@swift-nav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/string/null_terminated.h
+++ b/c/src/include/libsbp/internal/string/null_terminated.h
@@ -3,7 +3,7 @@
  * Contact: Swift Navigation <dev@swift-nav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/string/sbp_string.h
+++ b/c/src/include/libsbp/internal/string/sbp_string.h
@@ -3,7 +3,7 @@
  * Contact: Swift Navigation <dev@swift-nav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/string/sbp_strnlen.h
+++ b/c/src/include/libsbp/internal/string/sbp_strnlen.h
@@ -3,7 +3,7 @@
  * Contact: Swift Navigation <dev@swift-nav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/string/unterminated.h
+++ b/c/src/include/libsbp/internal/string/unterminated.h
@@ -3,7 +3,7 @@
  * Contact: Swift Navigation <dev@swift-nav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/system.h
+++ b/c/src/include/libsbp/internal/system.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/telemetry.h
+++ b/c/src/include/libsbp/internal/telemetry.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/tracking.h
+++ b/c/src/include/libsbp/internal/tracking.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/user.h
+++ b/c/src/include/libsbp/internal/user.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/include/libsbp/internal/vehicle.h
+++ b/c/src/include/libsbp/internal/vehicle.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/src/sbp.c
+++ b/c/src/sbp.c
@@ -3,7 +3,7 @@
  * Contact: Swift Navigation <dev@swift-nav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/CMakeLists.txt
+++ b/c/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 find_package(Threads)
-set(TEST_LIBS ${TEST_LIBS} check Threads::Threads sbp)
+set(TEST_LIBS ${TEST_LIBS} check Threads::Threads swiftnav::sbp)
 
 # Check needs to be linked against Librt on Linux
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")

--- a/c/test/auto_check_sbp_acquisition_MsgAcqResult.c
+++ b/c/test/auto_check_sbp_acquisition_MsgAcqResult.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_acquisition_MsgAcqResultDepA.c
+++ b/c/test/auto_check_sbp_acquisition_MsgAcqResultDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_acquisition_MsgAcqResultDepB.c
+++ b/c/test/auto_check_sbp_acquisition_MsgAcqResultDepB.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_acquisition_MsgAcqResultDepC.c
+++ b/c/test/auto_check_sbp_acquisition_MsgAcqResultDepC.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_acquisition_MsgAcqSvProfile.c
+++ b/c/test/auto_check_sbp_acquisition_MsgAcqSvProfile.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_acquisition_MsgAcqSvProfileDep.c
+++ b/c/test/auto_check_sbp_acquisition_MsgAcqSvProfileDep.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_bootload_MsgBootloaderHandshakeReq.c
+++ b/c/test/auto_check_sbp_bootload_MsgBootloaderHandshakeReq.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_bootload_MsgBootloaderHandshakeResp.c
+++ b/c/test/auto_check_sbp_bootload_MsgBootloaderHandshakeResp.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_bootload_MsgBootloaderJumptoApp.c
+++ b/c/test/auto_check_sbp_bootload_MsgBootloaderJumptoApp.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_bootload_MsgNapDeviceDnaReq.c
+++ b/c/test/auto_check_sbp_bootload_MsgNapDeviceDnaReq.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_bootload_MsgNapDeviceDnaResp.c
+++ b/c/test/auto_check_sbp_bootload_MsgNapDeviceDnaResp.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_ext_events_MsgExtEvent.c
+++ b/c/test/auto_check_sbp_ext_events_MsgExtEvent.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_file_io_MsgFileioConfigReq.c
+++ b/c/test/auto_check_sbp_file_io_MsgFileioConfigReq.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_file_io_MsgFileioConfigResp.c
+++ b/c/test/auto_check_sbp_file_io_MsgFileioConfigResp.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_file_io_MsgFileioReadDirReq.c
+++ b/c/test/auto_check_sbp_file_io_MsgFileioReadDirReq.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_file_io_MsgFileioReadDirResp.c
+++ b/c/test/auto_check_sbp_file_io_MsgFileioReadDirResp.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_file_io_MsgFileioReadReq.c
+++ b/c/test/auto_check_sbp_file_io_MsgFileioReadReq.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_file_io_MsgFileioReadResp.c
+++ b/c/test/auto_check_sbp_file_io_MsgFileioReadResp.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_file_io_MsgFileioRemove.c
+++ b/c/test/auto_check_sbp_file_io_MsgFileioRemove.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_file_io_MsgFileioWriteResp.c
+++ b/c/test/auto_check_sbp_file_io_MsgFileioWriteResp.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_flash_MsgFlashDone.c
+++ b/c/test/auto_check_sbp_flash_MsgFlashDone.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_flash_MsgFlashErase.c
+++ b/c/test/auto_check_sbp_flash_MsgFlashErase.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_flash_MsgFlashProgram.c
+++ b/c/test/auto_check_sbp_flash_MsgFlashProgram.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_flash_MsgFlashReadReq.c
+++ b/c/test/auto_check_sbp_flash_MsgFlashReadReq.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_flash_MsgFlashReadResp.c
+++ b/c/test/auto_check_sbp_flash_MsgFlashReadResp.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_flash_MsgM25FlashWriteStatus.c
+++ b/c/test/auto_check_sbp_flash_MsgM25FlashWriteStatus.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_flash_MsgStmFlashLockSector.c
+++ b/c/test/auto_check_sbp_flash_MsgStmFlashLockSector.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_flash_MsgStmFlashUnlockSector.c
+++ b/c/test/auto_check_sbp_flash_MsgStmFlashUnlockSector.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_flash_MsgStmUniqueIdReq.c
+++ b/c/test/auto_check_sbp_flash_MsgStmUniqueIdReq.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_flash_MsgStmUniqueIdResp.c
+++ b/c/test/auto_check_sbp_flash_MsgStmUniqueIdResp.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_imu_MsgImuAux.c
+++ b/c/test/auto_check_sbp_imu_MsgImuAux.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_imu_MsgImuRaw.c
+++ b/c/test/auto_check_sbp_imu_MsgImuRaw.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_integrity_MsgAcknowledge.c
+++ b/c/test/auto_check_sbp_integrity_MsgAcknowledge.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_integrity_MsgSsrFlagHighLevel.c
+++ b/c/test/auto_check_sbp_integrity_MsgSsrFlagHighLevel.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_integrity_MsgSsrFlagIonoGridPointSatLos.c
+++ b/c/test/auto_check_sbp_integrity_MsgSsrFlagIonoGridPointSatLos.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_integrity_MsgSsrFlagIonoGridPoints.c
+++ b/c/test/auto_check_sbp_integrity_MsgSsrFlagIonoGridPoints.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_integrity_MsgSsrFlagIonoTileSatLos.c
+++ b/c/test/auto_check_sbp_integrity_MsgSsrFlagIonoTileSatLos.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_integrity_MsgSsrFlagSatellites.c
+++ b/c/test/auto_check_sbp_integrity_MsgSsrFlagSatellites.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_integrity_MsgSsrFlagTropoGridPoints.c
+++ b/c/test/auto_check_sbp_integrity_MsgSsrFlagTropoGridPoints.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_linux_MsgLinuxCpuState.c
+++ b/c/test/auto_check_sbp_linux_MsgLinuxCpuState.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_linux_MsgLinuxCpuStateDepA.c
+++ b/c/test/auto_check_sbp_linux_MsgLinuxCpuStateDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_linux_MsgLinuxMemState.c
+++ b/c/test/auto_check_sbp_linux_MsgLinuxMemState.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_linux_MsgLinuxMemStateDepA.c
+++ b/c/test/auto_check_sbp_linux_MsgLinuxMemStateDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_linux_MsgLinuxProcessFdCount.c
+++ b/c/test/auto_check_sbp_linux_MsgLinuxProcessFdCount.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_linux_MsgLinuxProcessFdSummary.c
+++ b/c/test/auto_check_sbp_linux_MsgLinuxProcessFdSummary.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_linux_MsgLinuxProcessSocketCounts.c
+++ b/c/test/auto_check_sbp_linux_MsgLinuxProcessSocketCounts.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_linux_MsgLinuxProcessSocketQueues.c
+++ b/c/test/auto_check_sbp_linux_MsgLinuxProcessSocketQueues.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_linux_MsgLinuxSocketUsage.c
+++ b/c/test/auto_check_sbp_linux_MsgLinuxSocketUsage.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_linux_MsgLinuxSysState.c
+++ b/c/test/auto_check_sbp_linux_MsgLinuxSysState.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_linux_MsgLinuxSysStateDepA.c
+++ b/c/test/auto_check_sbp_linux_MsgLinuxSysStateDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_logging_MsgFwd.c
+++ b/c/test/auto_check_sbp_logging_MsgFwd.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_logging_MsgLog.c
+++ b/c/test/auto_check_sbp_logging_MsgLog.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_logging_MsgPrintDep.c
+++ b/c/test/auto_check_sbp_logging_MsgPrintDep.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_mag_MsgMagRaw.c
+++ b/c/test/auto_check_sbp_mag_MsgMagRaw.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgAgeCorrections.c
+++ b/c/test/auto_check_sbp_navigation_MsgAgeCorrections.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgBaselineECEF.c
+++ b/c/test/auto_check_sbp_navigation_MsgBaselineECEF.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgBaselineECEFDepA.c
+++ b/c/test/auto_check_sbp_navigation_MsgBaselineECEFDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgBaselineHeadingDepA.c
+++ b/c/test/auto_check_sbp_navigation_MsgBaselineHeadingDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgBaselineNED.c
+++ b/c/test/auto_check_sbp_navigation_MsgBaselineNED.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgBaselineNEDDepA.c
+++ b/c/test/auto_check_sbp_navigation_MsgBaselineNEDDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgDops.c
+++ b/c/test/auto_check_sbp_navigation_MsgDops.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgDopsDepA.c
+++ b/c/test/auto_check_sbp_navigation_MsgDopsDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgGPSTime.c
+++ b/c/test/auto_check_sbp_navigation_MsgGPSTime.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgGPSTimeDepA.c
+++ b/c/test/auto_check_sbp_navigation_MsgGPSTimeDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgGPSTimeGNSS.c
+++ b/c/test/auto_check_sbp_navigation_MsgGPSTimeGNSS.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgPosECEF.c
+++ b/c/test/auto_check_sbp_navigation_MsgPosECEF.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgPosECEFCov.c
+++ b/c/test/auto_check_sbp_navigation_MsgPosECEFCov.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgPosECEFCovGNSS.c
+++ b/c/test/auto_check_sbp_navigation_MsgPosECEFCovGNSS.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgPosECEFDepA.c
+++ b/c/test/auto_check_sbp_navigation_MsgPosECEFDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgPosECEFGNSS.c
+++ b/c/test/auto_check_sbp_navigation_MsgPosECEFGNSS.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgPosLLH.c
+++ b/c/test/auto_check_sbp_navigation_MsgPosLLH.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgPosLLHCov.c
+++ b/c/test/auto_check_sbp_navigation_MsgPosLLHCov.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgPosLLHDepA.c
+++ b/c/test/auto_check_sbp_navigation_MsgPosLLHDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgPosLlhAcc.c
+++ b/c/test/auto_check_sbp_navigation_MsgPosLlhAcc.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgPosLlhCovGnss.c
+++ b/c/test/auto_check_sbp_navigation_MsgPosLlhCovGnss.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgPosLlhGnss.c
+++ b/c/test/auto_check_sbp_navigation_MsgPosLlhGnss.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgPoseRelative.c
+++ b/c/test/auto_check_sbp_navigation_MsgPoseRelative.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgProtectionLevel.c
+++ b/c/test/auto_check_sbp_navigation_MsgProtectionLevel.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgProtectionLevelDepA.c
+++ b/c/test/auto_check_sbp_navigation_MsgProtectionLevelDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgReferenceFrameParam.c
+++ b/c/test/auto_check_sbp_navigation_MsgReferenceFrameParam.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgUTCLeapSecond.c
+++ b/c/test/auto_check_sbp_navigation_MsgUTCLeapSecond.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgUTCTime.c
+++ b/c/test/auto_check_sbp_navigation_MsgUTCTime.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgUTCTimeGNSS.c
+++ b/c/test/auto_check_sbp_navigation_MsgUTCTimeGNSS.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgVelBody.c
+++ b/c/test/auto_check_sbp_navigation_MsgVelBody.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgVelCog.c
+++ b/c/test/auto_check_sbp_navigation_MsgVelCog.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgVelECEF.c
+++ b/c/test/auto_check_sbp_navigation_MsgVelECEF.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgVelECEFCov.c
+++ b/c/test/auto_check_sbp_navigation_MsgVelECEFCov.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgVelECEFDepA.c
+++ b/c/test/auto_check_sbp_navigation_MsgVelECEFDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgVelEcefCovGnss.c
+++ b/c/test/auto_check_sbp_navigation_MsgVelEcefCovGnss.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgVelEcefGnss.c
+++ b/c/test/auto_check_sbp_navigation_MsgVelEcefGnss.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgVelNED.c
+++ b/c/test/auto_check_sbp_navigation_MsgVelNED.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgVelNEDCOV.c
+++ b/c/test/auto_check_sbp_navigation_MsgVelNEDCOV.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgVelNEDDepA.c
+++ b/c/test/auto_check_sbp_navigation_MsgVelNEDDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgVelNedCovGnss.c
+++ b/c/test/auto_check_sbp_navigation_MsgVelNedCovGnss.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_navigation_MsgVelNedGnss.c
+++ b/c/test/auto_check_sbp_navigation_MsgVelNedGnss.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_ndb_MsgNdbEvent.c
+++ b/c/test/auto_check_sbp_ndb_MsgNdbEvent.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgAlmanacGLO.c
+++ b/c/test/auto_check_sbp_observation_MsgAlmanacGLO.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgAlmanacGLODep.c
+++ b/c/test/auto_check_sbp_observation_MsgAlmanacGLODep.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgAlmanacGPS.c
+++ b/c/test/auto_check_sbp_observation_MsgAlmanacGPS.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgAlmanacGPSDep.c
+++ b/c/test/auto_check_sbp_observation_MsgAlmanacGPSDep.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgBasePosEcef.c
+++ b/c/test/auto_check_sbp_observation_MsgBasePosEcef.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgBasePosLLH.c
+++ b/c/test/auto_check_sbp_observation_MsgBasePosLLH.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgEphemerisBds.c
+++ b/c/test/auto_check_sbp_observation_MsgEphemerisBds.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgEphemerisDepA.c
+++ b/c/test/auto_check_sbp_observation_MsgEphemerisDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgEphemerisDepC.c
+++ b/c/test/auto_check_sbp_observation_MsgEphemerisDepC.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgEphemerisDepD.c
+++ b/c/test/auto_check_sbp_observation_MsgEphemerisDepD.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgEphemerisGLO.c
+++ b/c/test/auto_check_sbp_observation_MsgEphemerisGLO.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgEphemerisGLODepA.c
+++ b/c/test/auto_check_sbp_observation_MsgEphemerisGLODepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgEphemerisGLODepB.c
+++ b/c/test/auto_check_sbp_observation_MsgEphemerisGLODepB.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgEphemerisGLODepC.c
+++ b/c/test/auto_check_sbp_observation_MsgEphemerisGLODepC.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgEphemerisGLODepD.c
+++ b/c/test/auto_check_sbp_observation_MsgEphemerisGLODepD.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgEphemerisGPS.c
+++ b/c/test/auto_check_sbp_observation_MsgEphemerisGPS.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgEphemerisGPSDepE.c
+++ b/c/test/auto_check_sbp_observation_MsgEphemerisGPSDepE.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgEphemerisGPSDepF.c
+++ b/c/test/auto_check_sbp_observation_MsgEphemerisGPSDepF.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgEphemerisGal.c
+++ b/c/test/auto_check_sbp_observation_MsgEphemerisGal.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgEphemerisGalDepA.c
+++ b/c/test/auto_check_sbp_observation_MsgEphemerisGalDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgEphemerisSbas.c
+++ b/c/test/auto_check_sbp_observation_MsgEphemerisSbas.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgEphemerisSbasDepA.c
+++ b/c/test/auto_check_sbp_observation_MsgEphemerisSbasDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgEphemerisSbasDepB.c
+++ b/c/test/auto_check_sbp_observation_MsgEphemerisSbasDepB.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgGloBiases.c
+++ b/c/test/auto_check_sbp_observation_MsgGloBiases.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgGnssCapb.c
+++ b/c/test/auto_check_sbp_observation_MsgGnssCapb.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgGroupDelay.c
+++ b/c/test/auto_check_sbp_observation_MsgGroupDelay.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgGroupDelayDepA.c
+++ b/c/test/auto_check_sbp_observation_MsgGroupDelayDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgGroupDelayDepB.c
+++ b/c/test/auto_check_sbp_observation_MsgGroupDelayDepB.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgIono.c
+++ b/c/test/auto_check_sbp_observation_MsgIono.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgObs.c
+++ b/c/test/auto_check_sbp_observation_MsgObs.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgObsDepB.c
+++ b/c/test/auto_check_sbp_observation_MsgObsDepB.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgObsDepC.c
+++ b/c/test/auto_check_sbp_observation_MsgObsDepC.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgOsr.c
+++ b/c/test/auto_check_sbp_observation_MsgOsr.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgSvAzEl.c
+++ b/c/test/auto_check_sbp_observation_MsgSvAzEl.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_MsgSvConfigurationGpsDep.c
+++ b/c/test/auto_check_sbp_observation_MsgSvConfigurationGpsDep.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_msgEphemerisDepB.c
+++ b/c/test/auto_check_sbp_observation_msgEphemerisDepB.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_msgEphemerisQzss.c
+++ b/c/test/auto_check_sbp_observation_msgEphemerisQzss.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_observation_msgObsDepA.c
+++ b/c/test/auto_check_sbp_observation_msgObsDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_orientation_MsgAngularRate.c
+++ b/c/test/auto_check_sbp_orientation_MsgAngularRate.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_orientation_MsgBaselineHeading.c
+++ b/c/test/auto_check_sbp_orientation_MsgBaselineHeading.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_orientation_MsgOrientEuler.c
+++ b/c/test/auto_check_sbp_orientation_MsgOrientEuler.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_orientation_MsgOrientQuat.c
+++ b/c/test/auto_check_sbp_orientation_MsgOrientQuat.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_piksi_MsgAlmanac.c
+++ b/c/test/auto_check_sbp_piksi_MsgAlmanac.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_piksi_MsgCellModemStatus.c
+++ b/c/test/auto_check_sbp_piksi_MsgCellModemStatus.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_piksi_MsgCommandOutput.c
+++ b/c/test/auto_check_sbp_piksi_MsgCommandOutput.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_piksi_MsgCommandReq.c
+++ b/c/test/auto_check_sbp_piksi_MsgCommandReq.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_piksi_MsgCommandResp.c
+++ b/c/test/auto_check_sbp_piksi_MsgCommandResp.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_piksi_MsgCwResults.c
+++ b/c/test/auto_check_sbp_piksi_MsgCwResults.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_piksi_MsgCwStart.c
+++ b/c/test/auto_check_sbp_piksi_MsgCwStart.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_piksi_MsgDeviceMonitor.c
+++ b/c/test/auto_check_sbp_piksi_MsgDeviceMonitor.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_piksi_MsgFrontEndGain.c
+++ b/c/test/auto_check_sbp_piksi_MsgFrontEndGain.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_piksi_MsgIarState.c
+++ b/c/test/auto_check_sbp_piksi_MsgIarState.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_piksi_MsgInitBaseDep.c
+++ b/c/test/auto_check_sbp_piksi_MsgInitBaseDep.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_piksi_MsgMaskSatellite.c
+++ b/c/test/auto_check_sbp_piksi_MsgMaskSatellite.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_piksi_MsgMaskSatelliteDep.c
+++ b/c/test/auto_check_sbp_piksi_MsgMaskSatelliteDep.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_piksi_MsgNetworkBandwidthUsage.c
+++ b/c/test/auto_check_sbp_piksi_MsgNetworkBandwidthUsage.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_piksi_MsgNetworkStateReq.c
+++ b/c/test/auto_check_sbp_piksi_MsgNetworkStateReq.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_piksi_MsgNetworkStateResp.c
+++ b/c/test/auto_check_sbp_piksi_MsgNetworkStateResp.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_piksi_MsgReset.c
+++ b/c/test/auto_check_sbp_piksi_MsgReset.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_piksi_MsgResetDep.c
+++ b/c/test/auto_check_sbp_piksi_MsgResetDep.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_piksi_MsgResetFilters.c
+++ b/c/test/auto_check_sbp_piksi_MsgResetFilters.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_piksi_MsgSetTime.c
+++ b/c/test/auto_check_sbp_piksi_MsgSetTime.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_piksi_MsgSpecan.c
+++ b/c/test/auto_check_sbp_piksi_MsgSpecan.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_piksi_MsgSpecanDep.c
+++ b/c/test/auto_check_sbp_piksi_MsgSpecanDep.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_piksi_MsgThreadState.c
+++ b/c/test/auto_check_sbp_piksi_MsgThreadState.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_piksi_MsgUartState.c
+++ b/c/test/auto_check_sbp_piksi_MsgUartState.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_piksi_MsgUartStateDepA.c
+++ b/c/test/auto_check_sbp_piksi_MsgUartStateDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_profiling_MsgMeasurementPoint.c
+++ b/c/test/auto_check_sbp_profiling_MsgMeasurementPoint.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_profiling_MsgProfilingResourceCounter.c
+++ b/c/test/auto_check_sbp_profiling_MsgProfilingResourceCounter.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_profiling_MsgProfilingSystemInfo.c
+++ b/c/test/auto_check_sbp_profiling_MsgProfilingSystemInfo.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_profiling_MsgProfilingThreadInfo.c
+++ b/c/test/auto_check_sbp_profiling_MsgProfilingThreadInfo.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_sbas_MsgSbasRaw.c
+++ b/c/test/auto_check_sbp_sbas_MsgSbasRaw.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_settings_MsgSettingsReadByIndexDone.c
+++ b/c/test/auto_check_sbp_settings_MsgSettingsReadByIndexDone.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_settings_MsgSettingsReadByIndexReq.c
+++ b/c/test/auto_check_sbp_settings_MsgSettingsReadByIndexReq.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_settings_MsgSettingsReadByIndexResp.c
+++ b/c/test/auto_check_sbp_settings_MsgSettingsReadByIndexResp.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_settings_MsgSettingsReadReq.c
+++ b/c/test/auto_check_sbp_settings_MsgSettingsReadReq.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_settings_MsgSettingsReadResp.c
+++ b/c/test/auto_check_sbp_settings_MsgSettingsReadResp.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_settings_MsgSettingsRegister.c
+++ b/c/test/auto_check_sbp_settings_MsgSettingsRegister.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_settings_MsgSettingsRegisterResp.c
+++ b/c/test/auto_check_sbp_settings_MsgSettingsRegisterResp.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_settings_MsgSettingsSave.c
+++ b/c/test/auto_check_sbp_settings_MsgSettingsSave.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_settings_MsgSettingsWrite.c
+++ b/c/test/auto_check_sbp_settings_MsgSettingsWrite.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_settings_MsgSettingsWriteResp.c
+++ b/c/test/auto_check_sbp_settings_MsgSettingsWriteResp.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_signing_MsgCertificateChain.c
+++ b/c/test/auto_check_sbp_signing_MsgCertificateChain.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_signing_MsgCertificateChainDep.c
+++ b/c/test/auto_check_sbp_signing_MsgCertificateChainDep.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_signing_MsgEcdsaCertificate.c
+++ b/c/test/auto_check_sbp_signing_MsgEcdsaCertificate.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_signing_MsgEcdsaSignature.c
+++ b/c/test/auto_check_sbp_signing_MsgEcdsaSignature.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_signing_MsgEcdsaSignatureDepA.c
+++ b/c/test/auto_check_sbp_signing_MsgEcdsaSignatureDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_signing_MsgEcdsaSignatureDepB.c
+++ b/c/test/auto_check_sbp_signing_MsgEcdsaSignatureDepB.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_signing_MsgEd25519CertificateDep.c
+++ b/c/test/auto_check_sbp_signing_MsgEd25519CertificateDep.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_signing_MsgEd25519SignatureDepA.c
+++ b/c/test/auto_check_sbp_signing_MsgEd25519SignatureDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_signing_MsgEd25519SignatureDepB.c
+++ b/c/test/auto_check_sbp_signing_MsgEd25519SignatureDepB.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_solution_meta_MsgSolnMeta.c
+++ b/c/test/auto_check_sbp_solution_meta_MsgSolnMeta.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_solution_meta_MsgSolnMetaDepA.c
+++ b/c/test/auto_check_sbp_solution_meta_MsgSolnMetaDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_ssr_MsgSsrCodeBiases.c
+++ b/c/test/auto_check_sbp_ssr_MsgSsrCodeBiases.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_ssr_MsgSsrCodePhaseBiasesBounds.c
+++ b/c/test/auto_check_sbp_ssr_MsgSsrCodePhaseBiasesBounds.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_ssr_MsgSsrGridDefinitionDepA.c
+++ b/c/test/auto_check_sbp_ssr_MsgSsrGridDefinitionDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_ssr_MsgSsrGriddedCorrection.c
+++ b/c/test/auto_check_sbp_ssr_MsgSsrGriddedCorrection.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_ssr_MsgSsrGriddedCorrectionBounds.c
+++ b/c/test/auto_check_sbp_ssr_MsgSsrGriddedCorrectionBounds.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_ssr_MsgSsrGriddedCorrectionDepA.c
+++ b/c/test/auto_check_sbp_ssr_MsgSsrGriddedCorrectionDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_ssr_MsgSsrGriddedCorrectionNoStdDepA.c
+++ b/c/test/auto_check_sbp_ssr_MsgSsrGriddedCorrectionNoStdDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_ssr_MsgSsrOrbitClock.c
+++ b/c/test/auto_check_sbp_ssr_MsgSsrOrbitClock.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_ssr_MsgSsrOrbitClockBounds.c
+++ b/c/test/auto_check_sbp_ssr_MsgSsrOrbitClockBounds.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_ssr_MsgSsrOrbitClockBoundsDegradation.c
+++ b/c/test/auto_check_sbp_ssr_MsgSsrOrbitClockBoundsDegradation.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_ssr_MsgSsrOrbitClockDepA.c
+++ b/c/test/auto_check_sbp_ssr_MsgSsrOrbitClockDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_ssr_MsgSsrPhaseBiases.c
+++ b/c/test/auto_check_sbp_ssr_MsgSsrPhaseBiases.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_ssr_MsgSsrSatelliteApc.c
+++ b/c/test/auto_check_sbp_ssr_MsgSsrSatelliteApc.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_ssr_MsgSsrSatelliteApcDepA.c
+++ b/c/test/auto_check_sbp_ssr_MsgSsrSatelliteApcDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_ssr_MsgSsrStecCorrection.c
+++ b/c/test/auto_check_sbp_ssr_MsgSsrStecCorrection.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_ssr_MsgSsrStecCorrectionDep.c
+++ b/c/test/auto_check_sbp_ssr_MsgSsrStecCorrectionDep.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_ssr_MsgSsrStecCorrectionDepA.c
+++ b/c/test/auto_check_sbp_ssr_MsgSsrStecCorrectionDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_ssr_MsgSsrTileDefinition.c
+++ b/c/test/auto_check_sbp_ssr_MsgSsrTileDefinition.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_ssr_MsgSsrTileDefinitionDepA.c
+++ b/c/test/auto_check_sbp_ssr_MsgSsrTileDefinitionDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_ssr_MsgSsrTileDefinitionDepB.c
+++ b/c/test/auto_check_sbp_ssr_MsgSsrTileDefinitionDepB.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_system_MsgCsacTelemetry.c
+++ b/c/test/auto_check_sbp_system_MsgCsacTelemetry.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_system_MsgCsacTelemetryLabels.c
+++ b/c/test/auto_check_sbp_system_MsgCsacTelemetryLabels.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_system_MsgDgnssStatus.c
+++ b/c/test/auto_check_sbp_system_MsgDgnssStatus.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_system_MsgGnssTimeOffset.c
+++ b/c/test/auto_check_sbp_system_MsgGnssTimeOffset.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_system_MsgGroupMeta.c
+++ b/c/test/auto_check_sbp_system_MsgGroupMeta.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_system_MsgHeartbeat.c
+++ b/c/test/auto_check_sbp_system_MsgHeartbeat.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_system_MsgInsStatus.c
+++ b/c/test/auto_check_sbp_system_MsgInsStatus.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_system_MsgInsUpdates.c
+++ b/c/test/auto_check_sbp_system_MsgInsUpdates.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_system_MsgPpsTime.c
+++ b/c/test/auto_check_sbp_system_MsgPpsTime.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_system_MsgSensorAidEvent.c
+++ b/c/test/auto_check_sbp_system_MsgSensorAidEvent.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_system_MsgStartup.c
+++ b/c/test/auto_check_sbp_system_MsgStartup.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_system_MsgStatusJournal.c
+++ b/c/test/auto_check_sbp_system_MsgStatusJournal.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_system_MsgStatusReport.c
+++ b/c/test/auto_check_sbp_system_MsgStatusReport.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_telemetry_MsgTelSv.c
+++ b/c/test/auto_check_sbp_telemetry_MsgTelSv.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_tracking_MsgMeasurementState.c
+++ b/c/test/auto_check_sbp_tracking_MsgMeasurementState.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_tracking_MsgTrackingIq.c
+++ b/c/test/auto_check_sbp_tracking_MsgTrackingIq.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_tracking_MsgTrackingIqDepA.c
+++ b/c/test/auto_check_sbp_tracking_MsgTrackingIqDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_tracking_MsgTrackingIqDepB.c
+++ b/c/test/auto_check_sbp_tracking_MsgTrackingIqDepB.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_tracking_MsgTrackingState.c
+++ b/c/test/auto_check_sbp_tracking_MsgTrackingState.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_tracking_MsgTrackingStateDepB.c
+++ b/c/test/auto_check_sbp_tracking_MsgTrackingStateDepB.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_tracking_MsgTrackingStateDetailedDep.c
+++ b/c/test/auto_check_sbp_tracking_MsgTrackingStateDetailedDep.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_tracking_MsgTrackingStateDetailedDepA.c
+++ b/c/test/auto_check_sbp_tracking_MsgTrackingStateDetailedDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_tracking_MsgtrackingStateDepA.c
+++ b/c/test/auto_check_sbp_tracking_MsgtrackingStateDepA.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_user_MsgUserData.c
+++ b/c/test/auto_check_sbp_user_MsgUserData.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_vehicle_MsgOdometry.c
+++ b/c/test/auto_check_sbp_vehicle_MsgOdometry.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/auto_check_sbp_vehicle_MsgWheeltick.c
+++ b/c/test/auto_check_sbp_vehicle_MsgWheeltick.c
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/check_bitfield_macros.c
+++ b/c/test/check_bitfield_macros.c
@@ -3,7 +3,7 @@
  * Contact: Swift Navigation <dev@swift-nav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/check_edc.c
+++ b/c/test/check_edc.c
@@ -3,7 +3,7 @@
  * Contact: Swift Navigation <dev@swift-nav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/check_main.c
+++ b/c/test/check_main.c
@@ -3,7 +3,7 @@
  * Contact: Swift Navigation <dev@swift-nav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/check_sbp.c
+++ b/c/test/check_sbp.c
@@ -3,7 +3,7 @@
  * Contact: Swift Navigation <dev@swift-nav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/check_suites.h
+++ b/c/test/check_suites.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/CMakeLists.txt
+++ b/c/test/cpp/CMakeLists.txt
@@ -7,8 +7,9 @@ swift_add_test(test-libsbp-cpp
     INCLUDE
         ${PROJECT_SOURCE_DIR}/include/libsbp
     LINK
-        sbp
-        gtest_main)
+        gtest_main
+        swiftnav::sbp
+)
 swift_set_language_standards(test-libsbp-cpp)
 swift_set_compile_options(test-libsbp-cpp)
 

--- a/c/test/cpp/auto_check_sbp_acquisition_MsgAcqResult.cc
+++ b/c/test/cpp/auto_check_sbp_acquisition_MsgAcqResult.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_acquisition_MsgAcqResultDepA.cc
+++ b/c/test/cpp/auto_check_sbp_acquisition_MsgAcqResultDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_acquisition_MsgAcqResultDepB.cc
+++ b/c/test/cpp/auto_check_sbp_acquisition_MsgAcqResultDepB.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_acquisition_MsgAcqResultDepC.cc
+++ b/c/test/cpp/auto_check_sbp_acquisition_MsgAcqResultDepC.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_acquisition_MsgAcqSvProfile.cc
+++ b/c/test/cpp/auto_check_sbp_acquisition_MsgAcqSvProfile.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_acquisition_MsgAcqSvProfileDep.cc
+++ b/c/test/cpp/auto_check_sbp_acquisition_MsgAcqSvProfileDep.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_bootload_MsgBootloaderHandshakeReq.cc
+++ b/c/test/cpp/auto_check_sbp_bootload_MsgBootloaderHandshakeReq.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_bootload_MsgBootloaderHandshakeResp.cc
+++ b/c/test/cpp/auto_check_sbp_bootload_MsgBootloaderHandshakeResp.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_bootload_MsgBootloaderJumptoApp.cc
+++ b/c/test/cpp/auto_check_sbp_bootload_MsgBootloaderJumptoApp.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_bootload_MsgNapDeviceDnaReq.cc
+++ b/c/test/cpp/auto_check_sbp_bootload_MsgNapDeviceDnaReq.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_bootload_MsgNapDeviceDnaResp.cc
+++ b/c/test/cpp/auto_check_sbp_bootload_MsgNapDeviceDnaResp.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_ext_events_MsgExtEvent.cc
+++ b/c/test/cpp/auto_check_sbp_ext_events_MsgExtEvent.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_file_io_MsgFileioConfigReq.cc
+++ b/c/test/cpp/auto_check_sbp_file_io_MsgFileioConfigReq.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_file_io_MsgFileioConfigResp.cc
+++ b/c/test/cpp/auto_check_sbp_file_io_MsgFileioConfigResp.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_file_io_MsgFileioReadDirReq.cc
+++ b/c/test/cpp/auto_check_sbp_file_io_MsgFileioReadDirReq.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_file_io_MsgFileioReadDirResp.cc
+++ b/c/test/cpp/auto_check_sbp_file_io_MsgFileioReadDirResp.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_file_io_MsgFileioReadReq.cc
+++ b/c/test/cpp/auto_check_sbp_file_io_MsgFileioReadReq.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_file_io_MsgFileioReadResp.cc
+++ b/c/test/cpp/auto_check_sbp_file_io_MsgFileioReadResp.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_file_io_MsgFileioRemove.cc
+++ b/c/test/cpp/auto_check_sbp_file_io_MsgFileioRemove.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_file_io_MsgFileioWriteResp.cc
+++ b/c/test/cpp/auto_check_sbp_file_io_MsgFileioWriteResp.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_flash_MsgFlashDone.cc
+++ b/c/test/cpp/auto_check_sbp_flash_MsgFlashDone.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_flash_MsgFlashErase.cc
+++ b/c/test/cpp/auto_check_sbp_flash_MsgFlashErase.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_flash_MsgFlashProgram.cc
+++ b/c/test/cpp/auto_check_sbp_flash_MsgFlashProgram.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_flash_MsgFlashReadReq.cc
+++ b/c/test/cpp/auto_check_sbp_flash_MsgFlashReadReq.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_flash_MsgFlashReadResp.cc
+++ b/c/test/cpp/auto_check_sbp_flash_MsgFlashReadResp.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_flash_MsgM25FlashWriteStatus.cc
+++ b/c/test/cpp/auto_check_sbp_flash_MsgM25FlashWriteStatus.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_flash_MsgStmFlashLockSector.cc
+++ b/c/test/cpp/auto_check_sbp_flash_MsgStmFlashLockSector.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_flash_MsgStmFlashUnlockSector.cc
+++ b/c/test/cpp/auto_check_sbp_flash_MsgStmFlashUnlockSector.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_flash_MsgStmUniqueIdReq.cc
+++ b/c/test/cpp/auto_check_sbp_flash_MsgStmUniqueIdReq.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_flash_MsgStmUniqueIdResp.cc
+++ b/c/test/cpp/auto_check_sbp_flash_MsgStmUniqueIdResp.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_gnss_gnss_structs.cc
+++ b/c/test/cpp/auto_check_sbp_gnss_gnss_structs.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_imu_MsgImuAux.cc
+++ b/c/test/cpp/auto_check_sbp_imu_MsgImuAux.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_imu_MsgImuRaw.cc
+++ b/c/test/cpp/auto_check_sbp_imu_MsgImuRaw.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_integrity_MsgAcknowledge.cc
+++ b/c/test/cpp/auto_check_sbp_integrity_MsgAcknowledge.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_integrity_MsgSsrFlagHighLevel.cc
+++ b/c/test/cpp/auto_check_sbp_integrity_MsgSsrFlagHighLevel.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_integrity_MsgSsrFlagIonoGridPointSatLos.cc
+++ b/c/test/cpp/auto_check_sbp_integrity_MsgSsrFlagIonoGridPointSatLos.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_integrity_MsgSsrFlagIonoGridPoints.cc
+++ b/c/test/cpp/auto_check_sbp_integrity_MsgSsrFlagIonoGridPoints.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_integrity_MsgSsrFlagIonoTileSatLos.cc
+++ b/c/test/cpp/auto_check_sbp_integrity_MsgSsrFlagIonoTileSatLos.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_integrity_MsgSsrFlagSatellites.cc
+++ b/c/test/cpp/auto_check_sbp_integrity_MsgSsrFlagSatellites.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_integrity_MsgSsrFlagTropoGridPoints.cc
+++ b/c/test/cpp/auto_check_sbp_integrity_MsgSsrFlagTropoGridPoints.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_integrity_integrity_structs.cc
+++ b/c/test/cpp/auto_check_sbp_integrity_integrity_structs.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_linux_MsgLinuxCpuState.cc
+++ b/c/test/cpp/auto_check_sbp_linux_MsgLinuxCpuState.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_linux_MsgLinuxCpuStateDepA.cc
+++ b/c/test/cpp/auto_check_sbp_linux_MsgLinuxCpuStateDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_linux_MsgLinuxMemState.cc
+++ b/c/test/cpp/auto_check_sbp_linux_MsgLinuxMemState.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_linux_MsgLinuxMemStateDepA.cc
+++ b/c/test/cpp/auto_check_sbp_linux_MsgLinuxMemStateDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_linux_MsgLinuxProcessFdCount.cc
+++ b/c/test/cpp/auto_check_sbp_linux_MsgLinuxProcessFdCount.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_linux_MsgLinuxProcessFdSummary.cc
+++ b/c/test/cpp/auto_check_sbp_linux_MsgLinuxProcessFdSummary.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_linux_MsgLinuxProcessSocketCounts.cc
+++ b/c/test/cpp/auto_check_sbp_linux_MsgLinuxProcessSocketCounts.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_linux_MsgLinuxProcessSocketQueues.cc
+++ b/c/test/cpp/auto_check_sbp_linux_MsgLinuxProcessSocketQueues.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_linux_MsgLinuxSocketUsage.cc
+++ b/c/test/cpp/auto_check_sbp_linux_MsgLinuxSocketUsage.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_linux_MsgLinuxSysState.cc
+++ b/c/test/cpp/auto_check_sbp_linux_MsgLinuxSysState.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_linux_MsgLinuxSysStateDepA.cc
+++ b/c/test/cpp/auto_check_sbp_linux_MsgLinuxSysStateDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_logging_MsgFwd.cc
+++ b/c/test/cpp/auto_check_sbp_logging_MsgFwd.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_logging_MsgLog.cc
+++ b/c/test/cpp/auto_check_sbp_logging_MsgLog.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_logging_MsgPrintDep.cc
+++ b/c/test/cpp/auto_check_sbp_logging_MsgPrintDep.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_mag_MsgMagRaw.cc
+++ b/c/test/cpp/auto_check_sbp_mag_MsgMagRaw.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgAgeCorrections.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgAgeCorrections.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgBaselineECEF.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgBaselineECEF.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgBaselineECEFDepA.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgBaselineECEFDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgBaselineHeadingDepA.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgBaselineHeadingDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgBaselineNED.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgBaselineNED.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgBaselineNEDDepA.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgBaselineNEDDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgDops.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgDops.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgDopsDepA.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgDopsDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgGPSTime.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgGPSTime.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgGPSTimeDepA.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgGPSTimeDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgGPSTimeGNSS.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgGPSTimeGNSS.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgPosECEF.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgPosECEF.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgPosECEFCov.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgPosECEFCov.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgPosECEFCovGNSS.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgPosECEFCovGNSS.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgPosECEFDepA.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgPosECEFDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgPosECEFGNSS.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgPosECEFGNSS.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgPosLLH.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgPosLLH.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgPosLLHCov.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgPosLLHCov.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgPosLLHDepA.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgPosLLHDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgPosLlhAcc.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgPosLlhAcc.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgPosLlhCovGnss.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgPosLlhCovGnss.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgPosLlhGnss.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgPosLlhGnss.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgPoseRelative.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgPoseRelative.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgProtectionLevel.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgProtectionLevel.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgProtectionLevelDepA.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgProtectionLevelDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgReferenceFrameParam.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgReferenceFrameParam.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgUTCLeapSecond.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgUTCLeapSecond.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgUTCTime.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgUTCTime.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgUTCTimeGNSS.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgUTCTimeGNSS.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgVelBody.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgVelBody.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgVelCog.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgVelCog.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgVelECEF.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgVelECEF.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgVelECEFCov.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgVelECEFCov.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgVelECEFDepA.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgVelECEFDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgVelEcefCovGnss.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgVelEcefCovGnss.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgVelEcefGnss.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgVelEcefGnss.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgVelNED.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgVelNED.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgVelNEDCOV.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgVelNEDCOV.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgVelNEDDepA.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgVelNEDDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgVelNedCovGnss.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgVelNedCovGnss.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_MsgVelNedGnss.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_MsgVelNedGnss.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_navigation_navigation_structs.cc
+++ b/c/test/cpp/auto_check_sbp_navigation_navigation_structs.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_ndb_MsgNdbEvent.cc
+++ b/c/test/cpp/auto_check_sbp_ndb_MsgNdbEvent.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgAlmanacGLO.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgAlmanacGLO.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgAlmanacGLODep.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgAlmanacGLODep.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgAlmanacGPS.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgAlmanacGPS.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgAlmanacGPSDep.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgAlmanacGPSDep.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgBasePosEcef.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgBasePosEcef.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgBasePosLLH.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgBasePosLLH.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisBds.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisBds.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisDepA.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisDepC.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisDepC.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisDepD.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisDepD.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGLO.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGLO.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGLODepA.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGLODepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGLODepB.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGLODepB.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGLODepC.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGLODepC.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGLODepD.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGLODepD.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGPS.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGPS.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGPSDepE.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGPSDepE.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGPSDepF.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGPSDepF.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGal.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGal.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGalDepA.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisGalDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisSbas.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisSbas.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisSbasDepA.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisSbasDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgEphemerisSbasDepB.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgEphemerisSbasDepB.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgGloBiases.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgGloBiases.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgGnssCapb.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgGnssCapb.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgGroupDelay.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgGroupDelay.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgGroupDelayDepA.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgGroupDelayDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgGroupDelayDepB.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgGroupDelayDepB.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgIono.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgIono.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgObs.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgObs.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgObsDepB.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgObsDepB.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgObsDepC.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgObsDepC.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgOsr.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgOsr.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgSvAzEl.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgSvAzEl.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_MsgSvConfigurationGpsDep.cc
+++ b/c/test/cpp/auto_check_sbp_observation_MsgSvConfigurationGpsDep.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_msgEphemerisDepB.cc
+++ b/c/test/cpp/auto_check_sbp_observation_msgEphemerisDepB.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_msgEphemerisQzss.cc
+++ b/c/test/cpp/auto_check_sbp_observation_msgEphemerisQzss.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_msgObsDepA.cc
+++ b/c/test/cpp/auto_check_sbp_observation_msgObsDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_observation_observation_structs.cc
+++ b/c/test/cpp/auto_check_sbp_observation_observation_structs.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_orientation_MsgAngularRate.cc
+++ b/c/test/cpp/auto_check_sbp_orientation_MsgAngularRate.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_orientation_MsgBaselineHeading.cc
+++ b/c/test/cpp/auto_check_sbp_orientation_MsgBaselineHeading.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_orientation_MsgOrientEuler.cc
+++ b/c/test/cpp/auto_check_sbp_orientation_MsgOrientEuler.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_orientation_MsgOrientQuat.cc
+++ b/c/test/cpp/auto_check_sbp_orientation_MsgOrientQuat.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_piksi_MsgAlmanac.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgAlmanac.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_piksi_MsgCellModemStatus.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgCellModemStatus.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_piksi_MsgCommandOutput.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgCommandOutput.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_piksi_MsgCommandReq.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgCommandReq.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_piksi_MsgCommandResp.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgCommandResp.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_piksi_MsgCwResults.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgCwResults.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_piksi_MsgCwStart.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgCwStart.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_piksi_MsgDeviceMonitor.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgDeviceMonitor.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_piksi_MsgFrontEndGain.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgFrontEndGain.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_piksi_MsgIarState.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgIarState.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_piksi_MsgInitBaseDep.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgInitBaseDep.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_piksi_MsgMaskSatellite.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgMaskSatellite.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_piksi_MsgMaskSatelliteDep.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgMaskSatelliteDep.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_piksi_MsgNetworkBandwidthUsage.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgNetworkBandwidthUsage.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_piksi_MsgNetworkStateReq.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgNetworkStateReq.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_piksi_MsgNetworkStateResp.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgNetworkStateResp.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_piksi_MsgReset.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgReset.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_piksi_MsgResetDep.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgResetDep.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_piksi_MsgResetFilters.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgResetFilters.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_piksi_MsgSetTime.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgSetTime.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_piksi_MsgSpecan.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgSpecan.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_piksi_MsgSpecanDep.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgSpecanDep.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_piksi_MsgThreadState.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgThreadState.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_piksi_MsgUartState.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgUartState.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_piksi_MsgUartStateDepA.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_MsgUartStateDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_piksi_piksi_structs.cc
+++ b/c/test/cpp/auto_check_sbp_piksi_piksi_structs.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_profiling_MsgMeasurementPoint.cc
+++ b/c/test/cpp/auto_check_sbp_profiling_MsgMeasurementPoint.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_profiling_MsgProfilingResourceCounter.cc
+++ b/c/test/cpp/auto_check_sbp_profiling_MsgProfilingResourceCounter.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_profiling_MsgProfilingSystemInfo.cc
+++ b/c/test/cpp/auto_check_sbp_profiling_MsgProfilingSystemInfo.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_profiling_MsgProfilingThreadInfo.cc
+++ b/c/test/cpp/auto_check_sbp_profiling_MsgProfilingThreadInfo.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_sbas_MsgSbasRaw.cc
+++ b/c/test/cpp/auto_check_sbp_sbas_MsgSbasRaw.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_settings_MsgSettingsReadByIndexDone.cc
+++ b/c/test/cpp/auto_check_sbp_settings_MsgSettingsReadByIndexDone.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_settings_MsgSettingsReadByIndexReq.cc
+++ b/c/test/cpp/auto_check_sbp_settings_MsgSettingsReadByIndexReq.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_settings_MsgSettingsReadByIndexResp.cc
+++ b/c/test/cpp/auto_check_sbp_settings_MsgSettingsReadByIndexResp.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_settings_MsgSettingsReadReq.cc
+++ b/c/test/cpp/auto_check_sbp_settings_MsgSettingsReadReq.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_settings_MsgSettingsReadResp.cc
+++ b/c/test/cpp/auto_check_sbp_settings_MsgSettingsReadResp.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_settings_MsgSettingsRegister.cc
+++ b/c/test/cpp/auto_check_sbp_settings_MsgSettingsRegister.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_settings_MsgSettingsRegisterResp.cc
+++ b/c/test/cpp/auto_check_sbp_settings_MsgSettingsRegisterResp.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_settings_MsgSettingsSave.cc
+++ b/c/test/cpp/auto_check_sbp_settings_MsgSettingsSave.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_settings_MsgSettingsWrite.cc
+++ b/c/test/cpp/auto_check_sbp_settings_MsgSettingsWrite.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_settings_MsgSettingsWriteResp.cc
+++ b/c/test/cpp/auto_check_sbp_settings_MsgSettingsWriteResp.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_signing_MsgCertificateChain.cc
+++ b/c/test/cpp/auto_check_sbp_signing_MsgCertificateChain.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_signing_MsgCertificateChainDep.cc
+++ b/c/test/cpp/auto_check_sbp_signing_MsgCertificateChainDep.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_signing_MsgEcdsaCertificate.cc
+++ b/c/test/cpp/auto_check_sbp_signing_MsgEcdsaCertificate.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_signing_MsgEcdsaSignature.cc
+++ b/c/test/cpp/auto_check_sbp_signing_MsgEcdsaSignature.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_signing_MsgEcdsaSignatureDepA.cc
+++ b/c/test/cpp/auto_check_sbp_signing_MsgEcdsaSignatureDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_signing_MsgEcdsaSignatureDepB.cc
+++ b/c/test/cpp/auto_check_sbp_signing_MsgEcdsaSignatureDepB.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_signing_MsgEd25519CertificateDep.cc
+++ b/c/test/cpp/auto_check_sbp_signing_MsgEd25519CertificateDep.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_signing_MsgEd25519SignatureDepA.cc
+++ b/c/test/cpp/auto_check_sbp_signing_MsgEd25519SignatureDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_signing_MsgEd25519SignatureDepB.cc
+++ b/c/test/cpp/auto_check_sbp_signing_MsgEd25519SignatureDepB.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_signing_signing_structs.cc
+++ b/c/test/cpp/auto_check_sbp_signing_signing_structs.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_soln_meta_soln_meta_structs.cc
+++ b/c/test/cpp/auto_check_sbp_soln_meta_soln_meta_structs.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_solution_meta_MsgSolnMeta.cc
+++ b/c/test/cpp/auto_check_sbp_solution_meta_MsgSolnMeta.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_solution_meta_MsgSolnMetaDepA.cc
+++ b/c/test/cpp/auto_check_sbp_solution_meta_MsgSolnMetaDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrCodeBiases.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrCodeBiases.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrCodePhaseBiasesBounds.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrCodePhaseBiasesBounds.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrGridDefinitionDepA.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrGridDefinitionDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrGriddedCorrection.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrGriddedCorrection.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrGriddedCorrectionBounds.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrGriddedCorrectionBounds.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrGriddedCorrectionDepA.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrGriddedCorrectionDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrGriddedCorrectionNoStdDepA.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrGriddedCorrectionNoStdDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrOrbitClock.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrOrbitClock.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrOrbitClockBounds.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrOrbitClockBounds.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrOrbitClockBoundsDegradation.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrOrbitClockBoundsDegradation.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrOrbitClockDepA.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrOrbitClockDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrPhaseBiases.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrPhaseBiases.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrSatelliteApc.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrSatelliteApc.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrSatelliteApcDepA.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrSatelliteApcDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrStecCorrection.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrStecCorrection.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrStecCorrectionDep.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrStecCorrectionDep.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrStecCorrectionDepA.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrStecCorrectionDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrTileDefinition.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrTileDefinition.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrTileDefinitionDepA.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrTileDefinitionDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_ssr_MsgSsrTileDefinitionDepB.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_MsgSsrTileDefinitionDepB.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_ssr_ssr_structs.cc
+++ b/c/test/cpp/auto_check_sbp_ssr_ssr_structs.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_system_MsgCsacTelemetry.cc
+++ b/c/test/cpp/auto_check_sbp_system_MsgCsacTelemetry.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_system_MsgCsacTelemetryLabels.cc
+++ b/c/test/cpp/auto_check_sbp_system_MsgCsacTelemetryLabels.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_system_MsgDgnssStatus.cc
+++ b/c/test/cpp/auto_check_sbp_system_MsgDgnssStatus.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_system_MsgGnssTimeOffset.cc
+++ b/c/test/cpp/auto_check_sbp_system_MsgGnssTimeOffset.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_system_MsgGroupMeta.cc
+++ b/c/test/cpp/auto_check_sbp_system_MsgGroupMeta.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_system_MsgHeartbeat.cc
+++ b/c/test/cpp/auto_check_sbp_system_MsgHeartbeat.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_system_MsgInsStatus.cc
+++ b/c/test/cpp/auto_check_sbp_system_MsgInsStatus.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_system_MsgInsUpdates.cc
+++ b/c/test/cpp/auto_check_sbp_system_MsgInsUpdates.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_system_MsgPpsTime.cc
+++ b/c/test/cpp/auto_check_sbp_system_MsgPpsTime.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_system_MsgSensorAidEvent.cc
+++ b/c/test/cpp/auto_check_sbp_system_MsgSensorAidEvent.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_system_MsgStartup.cc
+++ b/c/test/cpp/auto_check_sbp_system_MsgStartup.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_system_MsgStatusJournal.cc
+++ b/c/test/cpp/auto_check_sbp_system_MsgStatusJournal.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_system_MsgStatusReport.cc
+++ b/c/test/cpp/auto_check_sbp_system_MsgStatusReport.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_system_system_structs.cc
+++ b/c/test/cpp/auto_check_sbp_system_system_structs.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_telemetry_MsgTelSv.cc
+++ b/c/test/cpp/auto_check_sbp_telemetry_MsgTelSv.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_telemetry_acquisition_structs.cc
+++ b/c/test/cpp/auto_check_sbp_telemetry_acquisition_structs.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_telemetry_telemetry_structs.cc
+++ b/c/test/cpp/auto_check_sbp_telemetry_telemetry_structs.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_tracking_MsgMeasurementState.cc
+++ b/c/test/cpp/auto_check_sbp_tracking_MsgMeasurementState.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_tracking_MsgTrackingIq.cc
+++ b/c/test/cpp/auto_check_sbp_tracking_MsgTrackingIq.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_tracking_MsgTrackingIqDepA.cc
+++ b/c/test/cpp/auto_check_sbp_tracking_MsgTrackingIqDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_tracking_MsgTrackingIqDepB.cc
+++ b/c/test/cpp/auto_check_sbp_tracking_MsgTrackingIqDepB.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_tracking_MsgTrackingState.cc
+++ b/c/test/cpp/auto_check_sbp_tracking_MsgTrackingState.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_tracking_MsgTrackingStateDepB.cc
+++ b/c/test/cpp/auto_check_sbp_tracking_MsgTrackingStateDepB.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_tracking_MsgTrackingStateDetailedDep.cc
+++ b/c/test/cpp/auto_check_sbp_tracking_MsgTrackingStateDetailedDep.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_tracking_MsgTrackingStateDetailedDepA.cc
+++ b/c/test/cpp/auto_check_sbp_tracking_MsgTrackingStateDetailedDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_tracking_MsgtrackingStateDepA.cc
+++ b/c/test/cpp/auto_check_sbp_tracking_MsgtrackingStateDepA.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_tracking_tracking_structs.cc
+++ b/c/test/cpp/auto_check_sbp_tracking_tracking_structs.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_user_MsgUserData.cc
+++ b/c/test/cpp/auto_check_sbp_user_MsgUserData.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_vehicle_MsgOdometry.cc
+++ b/c/test/cpp/auto_check_sbp_vehicle_MsgOdometry.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/cpp/auto_check_sbp_vehicle_MsgWheeltick.cc
+++ b/c/test/cpp/auto_check_sbp_vehicle_MsgWheeltick.cc
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/string/CMakeLists.txt
+++ b/c/test/string/CMakeLists.txt
@@ -17,7 +17,8 @@ swift_add_test(test-libsbp-string
     ${PROJECT_SOURCE_DIR}/src/include
     ${PROJECT_SOURCE_DIR}/include
   LINK
-    sbp
-    gtest_main)
+    gtest_main
+    swiftnav::sbp
+)
 swift_set_language_standards(test-libsbp-string)
 swift_set_compile_options(test-libsbp-string)

--- a/generator/json2test.py
+++ b/generator/json2test.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/missing.py
+++ b/generator/missing.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/generator.py
+++ b/generator/sbpg/generator.py
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/specs/yaml2.py
+++ b/generator/sbpg/specs/yaml2.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/specs/yaml_schema.py
+++ b/generator/sbpg/specs/yaml_schema.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/specs/yaml_test_schema.py
+++ b/generator/sbpg/specs/yaml_test_schema.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/syntax.py
+++ b/generator/sbpg/syntax.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/c.py
+++ b/generator/sbpg/targets/c.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/common.py
+++ b/generator/sbpg/targets/common.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/haskell.py
+++ b/generator/sbpg/targets/haskell.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/java.py
+++ b/generator/sbpg/targets/java.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/javascript.py
+++ b/generator/sbpg/targets/javascript.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/jsonschema.py
+++ b/generator/sbpg/targets/jsonschema.py
@@ -3,7 +3,7 @@
 # Contact: Swift Engineering <dev@swiftnav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/kaitai.py
+++ b/generator/sbpg/targets/kaitai.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/latex.py
+++ b/generator/sbpg/targets/latex.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/protobuf.py
+++ b/generator/sbpg/targets/protobuf.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/python.py
+++ b/generator/sbpg/targets/python.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/resources/MessageTable.java.j2
+++ b/generator/sbpg/targets/resources/MessageTable.java.j2
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/resources/MessageTest.java.j2
+++ b/generator/sbpg/targets/resources/MessageTest.java.j2
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/resources/c/include/libsbp/cpp/message_traits_template.h
+++ b/generator/sbpg/targets/resources/c/include/libsbp/cpp/message_traits_template.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/resources/c/include/libsbp/package/sbp_messages_template.h
+++ b/generator/sbpg/targets/resources/c/include/libsbp/package/sbp_messages_template.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/resources/c/include/libsbp/sbp_messages_macros_template.h
+++ b/generator/sbpg/targets/resources/c/include/libsbp/sbp_messages_macros_template.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/resources/c/include/libsbp/sbp_msg_template.h
+++ b/generator/sbpg/targets/resources/c/include/libsbp/sbp_msg_template.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/resources/c/include/libsbp/sbp_msg_type_template.h
+++ b/generator/sbpg/targets/resources/c/include/libsbp/sbp_msg_type_template.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/resources/c/include/libsbp/sbp_package_template.h
+++ b/generator/sbpg/targets/resources/c/include/libsbp/sbp_package_template.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/resources/c/include/libsbp/sbp_version_template.h
+++ b/generator/sbpg/targets/resources/c/include/libsbp/sbp_version_template.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/resources/c/src/sbp_messages_private_template.h
+++ b/generator/sbpg/targets/resources/c/src/sbp_messages_private_template.h
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/resources/c/test/sbp_c_main.c.j2
+++ b/generator/sbpg/targets/resources/c/test/sbp_c_main.c.j2
@@ -3,7 +3,7 @@
  * Contact: Swift Navigation <dev@swift-nav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/resources/c/test/sbp_c_suites.h.j2
+++ b/generator/sbpg/targets/resources/c/test/sbp_c_suites.h.j2
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/resources/c/test/sbp_c_test.c.j2
+++ b/generator/sbpg/targets/resources/c/test/sbp_c_test.c.j2
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/resources/c/test/sbp_cpp_test.cc.j2
+++ b/generator/sbpg/targets/resources/c/test/sbp_cpp_test.cc.j2
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/resources/kaitai/main.ksy.j2
+++ b/generator/sbpg/targets/resources/kaitai/main.ksy.j2
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/resources/kaitai/table_perl.pm.j2
+++ b/generator/sbpg/targets/resources/kaitai/table_perl.pm.j2
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/resources/kaitai/table_python.py.j2
+++ b/generator/sbpg/targets/resources/kaitai/table_python.py.j2
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/resources/kaitai/test_perl.t.j2
+++ b/generator/sbpg/targets/resources/kaitai/test_perl.t.j2
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/resources/kaitai/test_python.py.j2
+++ b/generator/sbpg/targets/resources/kaitai/test_python.py.j2
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/resources/kaitai/types.ksy.j2
+++ b/generator/sbpg/targets/resources/kaitai/types.ksy.j2
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/resources/message_template.jsonschema.j2
+++ b/generator/sbpg/targets/resources/message_template.jsonschema.j2
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/generator/sbpg/targets/resources/message_template.proto.j2
+++ b/generator/sbpg/targets/resources/message_template.proto.j2
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/resources/rust/sbp_messages_mod.rs
+++ b/generator/sbpg/targets/resources/rust/sbp_messages_mod.rs
@@ -2,7 +2,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/resources/rust/sbp_messages_template.rs
+++ b/generator/sbpg/targets/resources/rust/sbp_messages_template.rs
@@ -2,7 +2,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/resources/rust/test/sbp_tests_main_template.rs
+++ b/generator/sbpg/targets/resources/rust/test/sbp_tests_main_template.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/resources/rust/test/sbp_tests_template.rs
+++ b/generator/sbpg/targets/resources/rust/test/sbp_tests_template.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/resources/sbp_construct_template.py.j2
+++ b/generator/sbpg/targets/resources/sbp_construct_template.py.j2
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/resources/sbp_java.java.j2
+++ b/generator/sbpg/targets/resources/sbp_java.java.j2
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/rust.py
+++ b/generator/sbpg/targets/rust.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/templating.py
+++ b/generator/sbpg/targets/templating.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/test_c.py
+++ b/generator/sbpg/targets/test_c.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/test_java.py
+++ b/generator/sbpg/targets/test_java.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/test_kaitai_perl.py
+++ b/generator/sbpg/targets/test_kaitai_perl.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/test_kaitai_python.py
+++ b/generator/sbpg/targets/test_kaitai_python.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/targets/test_rust.py
+++ b/generator/sbpg/targets/test_rust.py
@@ -3,7 +3,7 @@
 # Contact: Swift NAvigation <dev@swiftnav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/test_structs.py
+++ b/generator/sbpg/test_structs.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/generator/sbpg/utils.py
+++ b/generator/sbpg/utils.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -82,7 +82,7 @@ spotless {
                   ' * Contact: https://support.swiftnav.com\n' +
                   ' *\n' +
                   ' * This source is subject to the license found in the file \'LICENSE\' which must\n' +
-                  ' * be be distributed together with this source. All other rights reserved.\n' +
+                  ' * be distributed together with this source. All other rights reserved.\n' +
                   ' *\n' +
                   ' * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,\n' +
                   ' * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED\n' +

--- a/java/src/com/swiftnav/sbp/SBPBinaryException.java
+++ b/java/src/com/swiftnav/sbp/SBPBinaryException.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/SBPMessage.java
+++ b/java/src/com/swiftnav/sbp/SBPMessage.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/SBPStruct.java
+++ b/java/src/com/swiftnav/sbp/SBPStruct.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/acquisition/AcqSvProfile.java
+++ b/java/src/com/swiftnav/sbp/acquisition/AcqSvProfile.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/acquisition/AcqSvProfileDep.java
+++ b/java/src/com/swiftnav/sbp/acquisition/AcqSvProfileDep.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/acquisition/MsgAcqResult.java
+++ b/java/src/com/swiftnav/sbp/acquisition/MsgAcqResult.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/acquisition/MsgAcqResultDepA.java
+++ b/java/src/com/swiftnav/sbp/acquisition/MsgAcqResultDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/acquisition/MsgAcqResultDepB.java
+++ b/java/src/com/swiftnav/sbp/acquisition/MsgAcqResultDepB.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/acquisition/MsgAcqResultDepC.java
+++ b/java/src/com/swiftnav/sbp/acquisition/MsgAcqResultDepC.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/acquisition/MsgAcqSvProfile.java
+++ b/java/src/com/swiftnav/sbp/acquisition/MsgAcqSvProfile.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/acquisition/MsgAcqSvProfileDep.java
+++ b/java/src/com/swiftnav/sbp/acquisition/MsgAcqSvProfileDep.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/bootload/MsgBootloaderHandshakeDepA.java
+++ b/java/src/com/swiftnav/sbp/bootload/MsgBootloaderHandshakeDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/bootload/MsgBootloaderHandshakeReq.java
+++ b/java/src/com/swiftnav/sbp/bootload/MsgBootloaderHandshakeReq.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/bootload/MsgBootloaderHandshakeResp.java
+++ b/java/src/com/swiftnav/sbp/bootload/MsgBootloaderHandshakeResp.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/bootload/MsgBootloaderJumpToApp.java
+++ b/java/src/com/swiftnav/sbp/bootload/MsgBootloaderJumpToApp.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/bootload/MsgNapDeviceDnaReq.java
+++ b/java/src/com/swiftnav/sbp/bootload/MsgNapDeviceDnaReq.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/bootload/MsgNapDeviceDnaResp.java
+++ b/java/src/com/swiftnav/sbp/bootload/MsgNapDeviceDnaResp.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/client/CRC16.java
+++ b/java/src/com/swiftnav/sbp/client/CRC16.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/client/MessageTable.java
+++ b/java/src/com/swiftnav/sbp/client/MessageTable.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/client/SBPCallback.java
+++ b/java/src/com/swiftnav/sbp/client/SBPCallback.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/client/SBPDriver.java
+++ b/java/src/com/swiftnav/sbp/client/SBPDriver.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/client/SBPForwarder.java
+++ b/java/src/com/swiftnav/sbp/client/SBPForwarder.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/client/SBPFramer.java
+++ b/java/src/com/swiftnav/sbp/client/SBPFramer.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/client/SBPHandler.java
+++ b/java/src/com/swiftnav/sbp/client/SBPHandler.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/client/SBPIterable.java
+++ b/java/src/com/swiftnav/sbp/client/SBPIterable.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/client/SBPSender.java
+++ b/java/src/com/swiftnav/sbp/client/SBPSender.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/drivers/HexStreamConnection.java
+++ b/java/src/com/swiftnav/sbp/drivers/HexStreamConnection.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/drivers/SBPDriverHTTP.java
+++ b/java/src/com/swiftnav/sbp/drivers/SBPDriverHTTP.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/drivers/SBPDriverJSSC.java
+++ b/java/src/com/swiftnav/sbp/drivers/SBPDriverJSSC.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/drivers/SBPDriverStream.java
+++ b/java/src/com/swiftnav/sbp/drivers/SBPDriverStream.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/drivers/SBPDriverTCP.java
+++ b/java/src/com/swiftnav/sbp/drivers/SBPDriverTCP.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/drivers/SBPDriverUDP.java
+++ b/java/src/com/swiftnav/sbp/drivers/SBPDriverUDP.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ext_events/MsgExtEvent.java
+++ b/java/src/com/swiftnav/sbp/ext_events/MsgExtEvent.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/file_io/MsgFileioConfigReq.java
+++ b/java/src/com/swiftnav/sbp/file_io/MsgFileioConfigReq.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/file_io/MsgFileioConfigResp.java
+++ b/java/src/com/swiftnav/sbp/file_io/MsgFileioConfigResp.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/file_io/MsgFileioReadDirReq.java
+++ b/java/src/com/swiftnav/sbp/file_io/MsgFileioReadDirReq.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/file_io/MsgFileioReadDirResp.java
+++ b/java/src/com/swiftnav/sbp/file_io/MsgFileioReadDirResp.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/file_io/MsgFileioReadReq.java
+++ b/java/src/com/swiftnav/sbp/file_io/MsgFileioReadReq.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/file_io/MsgFileioReadResp.java
+++ b/java/src/com/swiftnav/sbp/file_io/MsgFileioReadResp.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/file_io/MsgFileioRemove.java
+++ b/java/src/com/swiftnav/sbp/file_io/MsgFileioRemove.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/file_io/MsgFileioWriteReq.java
+++ b/java/src/com/swiftnav/sbp/file_io/MsgFileioWriteReq.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/file_io/MsgFileioWriteResp.java
+++ b/java/src/com/swiftnav/sbp/file_io/MsgFileioWriteResp.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/flash/MsgFlashDone.java
+++ b/java/src/com/swiftnav/sbp/flash/MsgFlashDone.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/flash/MsgFlashErase.java
+++ b/java/src/com/swiftnav/sbp/flash/MsgFlashErase.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/flash/MsgFlashProgram.java
+++ b/java/src/com/swiftnav/sbp/flash/MsgFlashProgram.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/flash/MsgFlashReadReq.java
+++ b/java/src/com/swiftnav/sbp/flash/MsgFlashReadReq.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/flash/MsgFlashReadResp.java
+++ b/java/src/com/swiftnav/sbp/flash/MsgFlashReadResp.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/flash/MsgM25FlashWriteStatus.java
+++ b/java/src/com/swiftnav/sbp/flash/MsgM25FlashWriteStatus.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/flash/MsgStmFlashLockSector.java
+++ b/java/src/com/swiftnav/sbp/flash/MsgStmFlashLockSector.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/flash/MsgStmFlashUnlockSector.java
+++ b/java/src/com/swiftnav/sbp/flash/MsgStmFlashUnlockSector.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/flash/MsgStmUniqueIdReq.java
+++ b/java/src/com/swiftnav/sbp/flash/MsgStmUniqueIdReq.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/flash/MsgStmUniqueIdResp.java
+++ b/java/src/com/swiftnav/sbp/flash/MsgStmUniqueIdResp.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/gnss/CarrierPhase.java
+++ b/java/src/com/swiftnav/sbp/gnss/CarrierPhase.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/gnss/GPSTime.java
+++ b/java/src/com/swiftnav/sbp/gnss/GPSTime.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/gnss/GPSTimeDep.java
+++ b/java/src/com/swiftnav/sbp/gnss/GPSTimeDep.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/gnss/GPSTimeSec.java
+++ b/java/src/com/swiftnav/sbp/gnss/GPSTimeSec.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/gnss/GnssSignal.java
+++ b/java/src/com/swiftnav/sbp/gnss/GnssSignal.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/gnss/GnssSignalDep.java
+++ b/java/src/com/swiftnav/sbp/gnss/GnssSignalDep.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/gnss/SvId.java
+++ b/java/src/com/swiftnav/sbp/gnss/SvId.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/imu/MsgImuAux.java
+++ b/java/src/com/swiftnav/sbp/imu/MsgImuAux.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/imu/MsgImuRaw.java
+++ b/java/src/com/swiftnav/sbp/imu/MsgImuRaw.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/integrity/IntegritySSRHeader.java
+++ b/java/src/com/swiftnav/sbp/integrity/IntegritySSRHeader.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/integrity/MsgAcknowledge.java
+++ b/java/src/com/swiftnav/sbp/integrity/MsgAcknowledge.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/integrity/MsgSsrFlagHighLevel.java
+++ b/java/src/com/swiftnav/sbp/integrity/MsgSsrFlagHighLevel.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/integrity/MsgSsrFlagIonoGridPointSatLos.java
+++ b/java/src/com/swiftnav/sbp/integrity/MsgSsrFlagIonoGridPointSatLos.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/integrity/MsgSsrFlagIonoGridPoints.java
+++ b/java/src/com/swiftnav/sbp/integrity/MsgSsrFlagIonoGridPoints.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/integrity/MsgSsrFlagIonoTileSatLos.java
+++ b/java/src/com/swiftnav/sbp/integrity/MsgSsrFlagIonoTileSatLos.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/integrity/MsgSsrFlagSatellites.java
+++ b/java/src/com/swiftnav/sbp/integrity/MsgSsrFlagSatellites.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/integrity/MsgSsrFlagTropoGridPoints.java
+++ b/java/src/com/swiftnav/sbp/integrity/MsgSsrFlagTropoGridPoints.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/linux/MsgLinuxCpuState.java
+++ b/java/src/com/swiftnav/sbp/linux/MsgLinuxCpuState.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/linux/MsgLinuxCpuStateDepA.java
+++ b/java/src/com/swiftnav/sbp/linux/MsgLinuxCpuStateDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/linux/MsgLinuxMemState.java
+++ b/java/src/com/swiftnav/sbp/linux/MsgLinuxMemState.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/linux/MsgLinuxMemStateDepA.java
+++ b/java/src/com/swiftnav/sbp/linux/MsgLinuxMemStateDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/linux/MsgLinuxProcessFdCount.java
+++ b/java/src/com/swiftnav/sbp/linux/MsgLinuxProcessFdCount.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/linux/MsgLinuxProcessFdSummary.java
+++ b/java/src/com/swiftnav/sbp/linux/MsgLinuxProcessFdSummary.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/linux/MsgLinuxProcessSocketCounts.java
+++ b/java/src/com/swiftnav/sbp/linux/MsgLinuxProcessSocketCounts.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/linux/MsgLinuxProcessSocketQueues.java
+++ b/java/src/com/swiftnav/sbp/linux/MsgLinuxProcessSocketQueues.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/linux/MsgLinuxSocketUsage.java
+++ b/java/src/com/swiftnav/sbp/linux/MsgLinuxSocketUsage.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/linux/MsgLinuxSysState.java
+++ b/java/src/com/swiftnav/sbp/linux/MsgLinuxSysState.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/linux/MsgLinuxSysStateDepA.java
+++ b/java/src/com/swiftnav/sbp/linux/MsgLinuxSysStateDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/loggers/JSONLogger.java
+++ b/java/src/com/swiftnav/sbp/loggers/JSONLogger.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/logging/MsgFwd.java
+++ b/java/src/com/swiftnav/sbp/logging/MsgFwd.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/logging/MsgLog.java
+++ b/java/src/com/swiftnav/sbp/logging/MsgLog.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/logging/MsgPrintDep.java
+++ b/java/src/com/swiftnav/sbp/logging/MsgPrintDep.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/mag/MsgMagRaw.java
+++ b/java/src/com/swiftnav/sbp/mag/MsgMagRaw.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/EstimatedHorizontalErrorEllipse.java
+++ b/java/src/com/swiftnav/sbp/navigation/EstimatedHorizontalErrorEllipse.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgAgeCorrections.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgAgeCorrections.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgBaselineECEF.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgBaselineECEF.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgBaselineECEFDepA.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgBaselineECEFDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgBaselineHeading.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgBaselineHeading.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgBaselineHeadingDepA.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgBaselineHeadingDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgBaselineNED.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgBaselineNED.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgBaselineNEDDepA.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgBaselineNEDDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgDops.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgDops.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgDopsDepA.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgDopsDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgGPSTime.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgGPSTime.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgGPSTimeDepA.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgGPSTimeDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgGPSTimeGnss.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgGPSTimeGnss.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgPosECEF.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgPosECEF.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgPosECEFCov.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgPosECEFCov.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgPosECEFCovGnss.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgPosECEFCovGnss.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgPosECEFDepA.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgPosECEFDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgPosECEFGnss.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgPosECEFGnss.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgPosLLH.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgPosLLH.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgPosLLHAcc.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgPosLLHAcc.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgPosLLHCov.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgPosLLHCov.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgPosLLHCovGnss.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgPosLLHCovGnss.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgPosLLHDepA.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgPosLLHDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgPosLLHGnss.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgPosLLHGnss.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgPoseRelative.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgPoseRelative.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgProtectionLevel.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgProtectionLevel.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgProtectionLevelDepA.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgProtectionLevelDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgReferenceFrameParam.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgReferenceFrameParam.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgUtcLeapSecond.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgUtcLeapSecond.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgUtcTime.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgUtcTime.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgUtcTimeGnss.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgUtcTimeGnss.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgVelBody.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgVelBody.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgVelCog.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgVelCog.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgVelECEF.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgVelECEF.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgVelECEFCov.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgVelECEFCov.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgVelECEFCovGnss.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgVelECEFCovGnss.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgVelECEFDepA.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgVelECEFDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgVelECEFGnss.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgVelECEFGnss.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgVelNED.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgVelNED.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgVelNEDCov.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgVelNEDCov.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgVelNEDCovGnss.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgVelNEDCovGnss.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgVelNEDDepA.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgVelNEDDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgVelNEDGnss.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgVelNEDGnss.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/navigation/MsgVelUserFrame.java
+++ b/java/src/com/swiftnav/sbp/navigation/MsgVelUserFrame.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ndb/MsgNdbEvent.java
+++ b/java/src/com/swiftnav/sbp/ndb/MsgNdbEvent.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/AlmanacCommonContent.java
+++ b/java/src/com/swiftnav/sbp/observation/AlmanacCommonContent.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/AlmanacCommonContentDep.java
+++ b/java/src/com/swiftnav/sbp/observation/AlmanacCommonContentDep.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/CarrierPhaseDepA.java
+++ b/java/src/com/swiftnav/sbp/observation/CarrierPhaseDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/Doppler.java
+++ b/java/src/com/swiftnav/sbp/observation/Doppler.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/EphemerisCommonContent.java
+++ b/java/src/com/swiftnav/sbp/observation/EphemerisCommonContent.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/EphemerisCommonContentDepA.java
+++ b/java/src/com/swiftnav/sbp/observation/EphemerisCommonContentDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/EphemerisCommonContentDepB.java
+++ b/java/src/com/swiftnav/sbp/observation/EphemerisCommonContentDepB.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/GnssCapb.java
+++ b/java/src/com/swiftnav/sbp/observation/GnssCapb.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgAlmanacGPS.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgAlmanacGPS.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgAlmanacGPSDep.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgAlmanacGPSDep.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgAlmanacGlo.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgAlmanacGlo.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgAlmanacGloDep.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgAlmanacGloDep.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgBasePosECEF.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgBasePosECEF.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgBasePosLLH.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgBasePosLLH.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgEphemerisBds.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgEphemerisBds.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgEphemerisDepA.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgEphemerisDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgEphemerisDepB.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgEphemerisDepB.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgEphemerisDepC.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgEphemerisDepC.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgEphemerisDepD.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgEphemerisDepD.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgEphemerisGPS.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgEphemerisGPS.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgEphemerisGPSDepE.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgEphemerisGPSDepE.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgEphemerisGPSDepF.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgEphemerisGPSDepF.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgEphemerisGal.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgEphemerisGal.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgEphemerisGalDepA.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgEphemerisGalDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgEphemerisGlo.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgEphemerisGlo.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgEphemerisGloDepA.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgEphemerisGloDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgEphemerisGloDepB.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgEphemerisGloDepB.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgEphemerisGloDepC.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgEphemerisGloDepC.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgEphemerisGloDepD.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgEphemerisGloDepD.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgEphemerisQzss.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgEphemerisQzss.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgEphemerisSbas.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgEphemerisSbas.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgEphemerisSbasDepA.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgEphemerisSbasDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgEphemerisSbasDepB.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgEphemerisSbasDepB.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgGloBiases.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgGloBiases.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgGnssCapb.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgGnssCapb.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgGroupDelay.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgGroupDelay.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgGroupDelayDepA.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgGroupDelayDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgGroupDelayDepB.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgGroupDelayDepB.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgIono.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgIono.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgObs.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgObs.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgObsDepA.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgObsDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgObsDepB.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgObsDepB.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgObsDepC.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgObsDepC.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgOsr.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgOsr.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgSvAzEl.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgSvAzEl.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgSvConfigurationGPS.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgSvConfigurationGPS.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/MsgSvConfigurationGPSDep.java
+++ b/java/src/com/swiftnav/sbp/observation/MsgSvConfigurationGPSDep.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/ObservationHeader.java
+++ b/java/src/com/swiftnav/sbp/observation/ObservationHeader.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/ObservationHeaderDep.java
+++ b/java/src/com/swiftnav/sbp/observation/ObservationHeaderDep.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/PackedObsContent.java
+++ b/java/src/com/swiftnav/sbp/observation/PackedObsContent.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/PackedObsContentDepA.java
+++ b/java/src/com/swiftnav/sbp/observation/PackedObsContentDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/PackedObsContentDepB.java
+++ b/java/src/com/swiftnav/sbp/observation/PackedObsContentDepB.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/PackedObsContentDepC.java
+++ b/java/src/com/swiftnav/sbp/observation/PackedObsContentDepC.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/PackedOsrContent.java
+++ b/java/src/com/swiftnav/sbp/observation/PackedOsrContent.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/SbpMsgGnssCapb.java
+++ b/java/src/com/swiftnav/sbp/observation/SbpMsgGnssCapb.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/observation/SvAzEl.java
+++ b/java/src/com/swiftnav/sbp/observation/SvAzEl.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/orientation/MsgAngularRate.java
+++ b/java/src/com/swiftnav/sbp/orientation/MsgAngularRate.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/orientation/MsgBaselineHeading.java
+++ b/java/src/com/swiftnav/sbp/orientation/MsgBaselineHeading.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/orientation/MsgOrientEuler.java
+++ b/java/src/com/swiftnav/sbp/orientation/MsgOrientEuler.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/orientation/MsgOrientQuat.java
+++ b/java/src/com/swiftnav/sbp/orientation/MsgOrientQuat.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/piksi/Latency.java
+++ b/java/src/com/swiftnav/sbp/piksi/Latency.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/piksi/MsgAlmanac.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgAlmanac.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/piksi/MsgCellModemStatus.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgCellModemStatus.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/piksi/MsgCommandOutput.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgCommandOutput.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/piksi/MsgCommandReq.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgCommandReq.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/piksi/MsgCommandResp.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgCommandResp.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/piksi/MsgCwResults.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgCwResults.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/piksi/MsgCwStart.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgCwStart.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/piksi/MsgDeviceMonitor.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgDeviceMonitor.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/piksi/MsgFrontEndGain.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgFrontEndGain.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/piksi/MsgIarState.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgIarState.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/piksi/MsgInitBaseDep.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgInitBaseDep.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/piksi/MsgMaskSatellite.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgMaskSatellite.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/piksi/MsgMaskSatelliteDep.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgMaskSatelliteDep.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/piksi/MsgNetworkBandwidthUsage.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgNetworkBandwidthUsage.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/piksi/MsgNetworkStateReq.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgNetworkStateReq.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/piksi/MsgNetworkStateResp.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgNetworkStateResp.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/piksi/MsgReset.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgReset.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/piksi/MsgResetDep.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgResetDep.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/piksi/MsgResetFilters.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgResetFilters.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/piksi/MsgSetTime.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgSetTime.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/piksi/MsgSpecan.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgSpecan.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/piksi/MsgSpecanDep.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgSpecanDep.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/piksi/MsgThreadState.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgThreadState.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/piksi/MsgUartState.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgUartState.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/piksi/MsgUartStateDepa.java
+++ b/java/src/com/swiftnav/sbp/piksi/MsgUartStateDepa.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/piksi/NetworkUsage.java
+++ b/java/src/com/swiftnav/sbp/piksi/NetworkUsage.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/piksi/Period.java
+++ b/java/src/com/swiftnav/sbp/piksi/Period.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/piksi/UARTChannel.java
+++ b/java/src/com/swiftnav/sbp/piksi/UARTChannel.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/profiling/MsgMeasurementPoint.java
+++ b/java/src/com/swiftnav/sbp/profiling/MsgMeasurementPoint.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/profiling/MsgProfilingResourceCounter.java
+++ b/java/src/com/swiftnav/sbp/profiling/MsgProfilingResourceCounter.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/profiling/MsgProfilingSystemInfo.java
+++ b/java/src/com/swiftnav/sbp/profiling/MsgProfilingSystemInfo.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/profiling/MsgProfilingThreadInfo.java
+++ b/java/src/com/swiftnav/sbp/profiling/MsgProfilingThreadInfo.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/profiling/ResourceBucket.java
+++ b/java/src/com/swiftnav/sbp/profiling/ResourceBucket.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/sbas/MsgSbasRaw.java
+++ b/java/src/com/swiftnav/sbp/sbas/MsgSbasRaw.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/settings/MsgSettingsReadByIndexDone.java
+++ b/java/src/com/swiftnav/sbp/settings/MsgSettingsReadByIndexDone.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/settings/MsgSettingsReadByIndexReq.java
+++ b/java/src/com/swiftnav/sbp/settings/MsgSettingsReadByIndexReq.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/settings/MsgSettingsReadByIndexResp.java
+++ b/java/src/com/swiftnav/sbp/settings/MsgSettingsReadByIndexResp.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/settings/MsgSettingsReadReq.java
+++ b/java/src/com/swiftnav/sbp/settings/MsgSettingsReadReq.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/settings/MsgSettingsReadResp.java
+++ b/java/src/com/swiftnav/sbp/settings/MsgSettingsReadResp.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/settings/MsgSettingsRegister.java
+++ b/java/src/com/swiftnav/sbp/settings/MsgSettingsRegister.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/settings/MsgSettingsRegisterResp.java
+++ b/java/src/com/swiftnav/sbp/settings/MsgSettingsRegisterResp.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/settings/MsgSettingsSave.java
+++ b/java/src/com/swiftnav/sbp/settings/MsgSettingsSave.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/settings/MsgSettingsWrite.java
+++ b/java/src/com/swiftnav/sbp/settings/MsgSettingsWrite.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/settings/MsgSettingsWriteResp.java
+++ b/java/src/com/swiftnav/sbp/settings/MsgSettingsWriteResp.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/signing/ECDSASignature.java
+++ b/java/src/com/swiftnav/sbp/signing/ECDSASignature.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/signing/MsgCertificateChain.java
+++ b/java/src/com/swiftnav/sbp/signing/MsgCertificateChain.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/signing/MsgCertificateChainDep.java
+++ b/java/src/com/swiftnav/sbp/signing/MsgCertificateChainDep.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/signing/MsgEcdsaCertificate.java
+++ b/java/src/com/swiftnav/sbp/signing/MsgEcdsaCertificate.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/signing/MsgEcdsaSignature.java
+++ b/java/src/com/swiftnav/sbp/signing/MsgEcdsaSignature.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/signing/MsgEcdsaSignatureDepA.java
+++ b/java/src/com/swiftnav/sbp/signing/MsgEcdsaSignatureDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/signing/MsgEcdsaSignatureDepB.java
+++ b/java/src/com/swiftnav/sbp/signing/MsgEcdsaSignatureDepB.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/signing/MsgEd25519CertificateDep.java
+++ b/java/src/com/swiftnav/sbp/signing/MsgEd25519CertificateDep.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/signing/MsgEd25519SignatureDepA.java
+++ b/java/src/com/swiftnav/sbp/signing/MsgEd25519SignatureDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/signing/MsgEd25519SignatureDepB.java
+++ b/java/src/com/swiftnav/sbp/signing/MsgEd25519SignatureDepB.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/signing/UtcTime.java
+++ b/java/src/com/swiftnav/sbp/signing/UtcTime.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/solution_meta/GNSSInputType.java
+++ b/java/src/com/swiftnav/sbp/solution_meta/GNSSInputType.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/solution_meta/IMUInputType.java
+++ b/java/src/com/swiftnav/sbp/solution_meta/IMUInputType.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/solution_meta/MsgSolnMeta.java
+++ b/java/src/com/swiftnav/sbp/solution_meta/MsgSolnMeta.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/solution_meta/MsgSolnMetaDepA.java
+++ b/java/src/com/swiftnav/sbp/solution_meta/MsgSolnMetaDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/solution_meta/OdoInputType.java
+++ b/java/src/com/swiftnav/sbp/solution_meta/OdoInputType.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/solution_meta/SolutionInputType.java
+++ b/java/src/com/swiftnav/sbp/solution_meta/SolutionInputType.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/BoundsHeader.java
+++ b/java/src/com/swiftnav/sbp/ssr/BoundsHeader.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/CodeBiasesContent.java
+++ b/java/src/com/swiftnav/sbp/ssr/CodeBiasesContent.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/CodePhaseBiasesSatSig.java
+++ b/java/src/com/swiftnav/sbp/ssr/CodePhaseBiasesSatSig.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/GridDefinitionHeader.java
+++ b/java/src/com/swiftnav/sbp/ssr/GridDefinitionHeader.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/GridDefinitionHeaderDepA.java
+++ b/java/src/com/swiftnav/sbp/ssr/GridDefinitionHeaderDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/GridElement.java
+++ b/java/src/com/swiftnav/sbp/ssr/GridElement.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/GridElementNoStd.java
+++ b/java/src/com/swiftnav/sbp/ssr/GridElementNoStd.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/GriddedCorrectionHeader.java
+++ b/java/src/com/swiftnav/sbp/ssr/GriddedCorrectionHeader.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/GriddedCorrectionHeaderDepA.java
+++ b/java/src/com/swiftnav/sbp/ssr/GriddedCorrectionHeaderDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/MsgSsrCodeBiases.java
+++ b/java/src/com/swiftnav/sbp/ssr/MsgSsrCodeBiases.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/MsgSsrCodePhaseBiasesBounds.java
+++ b/java/src/com/swiftnav/sbp/ssr/MsgSsrCodePhaseBiasesBounds.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/MsgSsrGridDefinition.java
+++ b/java/src/com/swiftnav/sbp/ssr/MsgSsrGridDefinition.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/MsgSsrGridDefinitionDepA.java
+++ b/java/src/com/swiftnav/sbp/ssr/MsgSsrGridDefinitionDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/MsgSsrGriddedCorrection.java
+++ b/java/src/com/swiftnav/sbp/ssr/MsgSsrGriddedCorrection.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/MsgSsrGriddedCorrectionBounds.java
+++ b/java/src/com/swiftnav/sbp/ssr/MsgSsrGriddedCorrectionBounds.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/MsgSsrGriddedCorrectionDepA.java
+++ b/java/src/com/swiftnav/sbp/ssr/MsgSsrGriddedCorrectionDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/MsgSsrGriddedCorrectionNoStd.java
+++ b/java/src/com/swiftnav/sbp/ssr/MsgSsrGriddedCorrectionNoStd.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/MsgSsrGriddedCorrectionNoStdDepA.java
+++ b/java/src/com/swiftnav/sbp/ssr/MsgSsrGriddedCorrectionNoStdDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/MsgSsrOrbitClock.java
+++ b/java/src/com/swiftnav/sbp/ssr/MsgSsrOrbitClock.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/MsgSsrOrbitClockBounds.java
+++ b/java/src/com/swiftnav/sbp/ssr/MsgSsrOrbitClockBounds.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/MsgSsrOrbitClockBoundsDegradation.java
+++ b/java/src/com/swiftnav/sbp/ssr/MsgSsrOrbitClockBoundsDegradation.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/MsgSsrOrbitClockDepA.java
+++ b/java/src/com/swiftnav/sbp/ssr/MsgSsrOrbitClockDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/MsgSsrPhaseBiases.java
+++ b/java/src/com/swiftnav/sbp/ssr/MsgSsrPhaseBiases.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/MsgSsrSatelliteApc.java
+++ b/java/src/com/swiftnav/sbp/ssr/MsgSsrSatelliteApc.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/MsgSsrSatelliteApcDep.java
+++ b/java/src/com/swiftnav/sbp/ssr/MsgSsrSatelliteApcDep.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/MsgSsrStecCorrection.java
+++ b/java/src/com/swiftnav/sbp/ssr/MsgSsrStecCorrection.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/MsgSsrStecCorrectionDep.java
+++ b/java/src/com/swiftnav/sbp/ssr/MsgSsrStecCorrectionDep.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/MsgSsrStecCorrectionDepA.java
+++ b/java/src/com/swiftnav/sbp/ssr/MsgSsrStecCorrectionDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/MsgSsrTileDefinition.java
+++ b/java/src/com/swiftnav/sbp/ssr/MsgSsrTileDefinition.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/MsgSsrTileDefinitionDepA.java
+++ b/java/src/com/swiftnav/sbp/ssr/MsgSsrTileDefinitionDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/MsgSsrTileDefinitionDepB.java
+++ b/java/src/com/swiftnav/sbp/ssr/MsgSsrTileDefinitionDepB.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/OrbitClockBound.java
+++ b/java/src/com/swiftnav/sbp/ssr/OrbitClockBound.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/OrbitClockBoundDegradation.java
+++ b/java/src/com/swiftnav/sbp/ssr/OrbitClockBoundDegradation.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/PhaseBiasesContent.java
+++ b/java/src/com/swiftnav/sbp/ssr/PhaseBiasesContent.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/STECHeader.java
+++ b/java/src/com/swiftnav/sbp/ssr/STECHeader.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/STECHeaderDepA.java
+++ b/java/src/com/swiftnav/sbp/ssr/STECHeaderDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/STECResidual.java
+++ b/java/src/com/swiftnav/sbp/ssr/STECResidual.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/STECResidualNoStd.java
+++ b/java/src/com/swiftnav/sbp/ssr/STECResidualNoStd.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/STECSatElement.java
+++ b/java/src/com/swiftnav/sbp/ssr/STECSatElement.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/STECSatElementIntegrity.java
+++ b/java/src/com/swiftnav/sbp/ssr/STECSatElementIntegrity.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/SatelliteAPC.java
+++ b/java/src/com/swiftnav/sbp/ssr/SatelliteAPC.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/TroposphericDelayCorrection.java
+++ b/java/src/com/swiftnav/sbp/ssr/TroposphericDelayCorrection.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/ssr/TroposphericDelayCorrectionNoStd.java
+++ b/java/src/com/swiftnav/sbp/ssr/TroposphericDelayCorrectionNoStd.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/system/MsgCsacTelemetry.java
+++ b/java/src/com/swiftnav/sbp/system/MsgCsacTelemetry.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/system/MsgCsacTelemetryLabels.java
+++ b/java/src/com/swiftnav/sbp/system/MsgCsacTelemetryLabels.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/system/MsgDgnssStatus.java
+++ b/java/src/com/swiftnav/sbp/system/MsgDgnssStatus.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/system/MsgGnssTimeOffset.java
+++ b/java/src/com/swiftnav/sbp/system/MsgGnssTimeOffset.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/system/MsgGroupMeta.java
+++ b/java/src/com/swiftnav/sbp/system/MsgGroupMeta.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/system/MsgHeartbeat.java
+++ b/java/src/com/swiftnav/sbp/system/MsgHeartbeat.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/system/MsgInsStatus.java
+++ b/java/src/com/swiftnav/sbp/system/MsgInsStatus.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/system/MsgInsUpdates.java
+++ b/java/src/com/swiftnav/sbp/system/MsgInsUpdates.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/system/MsgPpsTime.java
+++ b/java/src/com/swiftnav/sbp/system/MsgPpsTime.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/system/MsgSensorAidEvent.java
+++ b/java/src/com/swiftnav/sbp/system/MsgSensorAidEvent.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/system/MsgStartup.java
+++ b/java/src/com/swiftnav/sbp/system/MsgStartup.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/system/MsgStatusJournal.java
+++ b/java/src/com/swiftnav/sbp/system/MsgStatusJournal.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/system/MsgStatusReport.java
+++ b/java/src/com/swiftnav/sbp/system/MsgStatusReport.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/system/StatusJournalItem.java
+++ b/java/src/com/swiftnav/sbp/system/StatusJournalItem.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/system/SubSystemReport.java
+++ b/java/src/com/swiftnav/sbp/system/SubSystemReport.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/telemetry/MsgTelSv.java
+++ b/java/src/com/swiftnav/sbp/telemetry/MsgTelSv.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/telemetry/TelemetrySV.java
+++ b/java/src/com/swiftnav/sbp/telemetry/TelemetrySV.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/tracking/MeasurementState.java
+++ b/java/src/com/swiftnav/sbp/tracking/MeasurementState.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/tracking/MsgMeasurementState.java
+++ b/java/src/com/swiftnav/sbp/tracking/MsgMeasurementState.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/tracking/MsgTrackingIq.java
+++ b/java/src/com/swiftnav/sbp/tracking/MsgTrackingIq.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/tracking/MsgTrackingIqDep.java
+++ b/java/src/com/swiftnav/sbp/tracking/MsgTrackingIqDep.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/tracking/MsgTrackingIqDepA.java
+++ b/java/src/com/swiftnav/sbp/tracking/MsgTrackingIqDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/tracking/MsgTrackingIqDepB.java
+++ b/java/src/com/swiftnav/sbp/tracking/MsgTrackingIqDepB.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/tracking/MsgTrackingState.java
+++ b/java/src/com/swiftnav/sbp/tracking/MsgTrackingState.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/tracking/MsgTrackingStateDepA.java
+++ b/java/src/com/swiftnav/sbp/tracking/MsgTrackingStateDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/tracking/MsgTrackingStateDepB.java
+++ b/java/src/com/swiftnav/sbp/tracking/MsgTrackingStateDepB.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/tracking/MsgTrackingStateDetailed.java
+++ b/java/src/com/swiftnav/sbp/tracking/MsgTrackingStateDetailed.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/tracking/MsgTrackingStateDetailedDep.java
+++ b/java/src/com/swiftnav/sbp/tracking/MsgTrackingStateDetailedDep.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/tracking/MsgTrackingStateDetailedDepA.java
+++ b/java/src/com/swiftnav/sbp/tracking/MsgTrackingStateDetailedDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/tracking/TrackingChannelCorrelation.java
+++ b/java/src/com/swiftnav/sbp/tracking/TrackingChannelCorrelation.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/tracking/TrackingChannelCorrelationDep.java
+++ b/java/src/com/swiftnav/sbp/tracking/TrackingChannelCorrelationDep.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/tracking/TrackingChannelState.java
+++ b/java/src/com/swiftnav/sbp/tracking/TrackingChannelState.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/tracking/TrackingChannelStateDepA.java
+++ b/java/src/com/swiftnav/sbp/tracking/TrackingChannelStateDepA.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/tracking/TrackingChannelStateDepB.java
+++ b/java/src/com/swiftnav/sbp/tracking/TrackingChannelStateDepB.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/user/MsgUserData.java
+++ b/java/src/com/swiftnav/sbp/user/MsgUserData.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/vehicle/MsgOdometry.java
+++ b/java/src/com/swiftnav/sbp/vehicle/MsgOdometry.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/src/com/swiftnav/sbp/vehicle/MsgWheeltick.java
+++ b/java/src/com/swiftnav/sbp/vehicle/MsgWheeltick.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_acquisition_MsgAcqResultDepATest.java
+++ b/java/test/auto_check_sbp_acquisition_MsgAcqResultDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_acquisition_MsgAcqResultDepBTest.java
+++ b/java/test/auto_check_sbp_acquisition_MsgAcqResultDepBTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_acquisition_MsgAcqResultDepCTest.java
+++ b/java/test/auto_check_sbp_acquisition_MsgAcqResultDepCTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_acquisition_MsgAcqResultTest.java
+++ b/java/test/auto_check_sbp_acquisition_MsgAcqResultTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_acquisition_MsgAcqSvProfileDepTest.java
+++ b/java/test/auto_check_sbp_acquisition_MsgAcqSvProfileDepTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_acquisition_MsgAcqSvProfileTest.java
+++ b/java/test/auto_check_sbp_acquisition_MsgAcqSvProfileTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_bootload_MsgBootloaderHandshakeReqTest.java
+++ b/java/test/auto_check_sbp_bootload_MsgBootloaderHandshakeReqTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_bootload_MsgBootloaderHandshakeRespTest.java
+++ b/java/test/auto_check_sbp_bootload_MsgBootloaderHandshakeRespTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_bootload_MsgBootloaderJumptoAppTest.java
+++ b/java/test/auto_check_sbp_bootload_MsgBootloaderJumptoAppTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_bootload_MsgNapDeviceDnaReqTest.java
+++ b/java/test/auto_check_sbp_bootload_MsgNapDeviceDnaReqTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_bootload_MsgNapDeviceDnaRespTest.java
+++ b/java/test/auto_check_sbp_bootload_MsgNapDeviceDnaRespTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_ext_events_MsgExtEventTest.java
+++ b/java/test/auto_check_sbp_ext_events_MsgExtEventTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_file_io_MsgFileioConfigReqTest.java
+++ b/java/test/auto_check_sbp_file_io_MsgFileioConfigReqTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_file_io_MsgFileioConfigRespTest.java
+++ b/java/test/auto_check_sbp_file_io_MsgFileioConfigRespTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_file_io_MsgFileioReadDirReqTest.java
+++ b/java/test/auto_check_sbp_file_io_MsgFileioReadDirReqTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_file_io_MsgFileioReadDirRespTest.java
+++ b/java/test/auto_check_sbp_file_io_MsgFileioReadDirRespTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_file_io_MsgFileioReadReqTest.java
+++ b/java/test/auto_check_sbp_file_io_MsgFileioReadReqTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_file_io_MsgFileioReadRespTest.java
+++ b/java/test/auto_check_sbp_file_io_MsgFileioReadRespTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_file_io_MsgFileioRemoveTest.java
+++ b/java/test/auto_check_sbp_file_io_MsgFileioRemoveTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_file_io_MsgFileioWriteRespTest.java
+++ b/java/test/auto_check_sbp_file_io_MsgFileioWriteRespTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_flash_MsgFlashDoneTest.java
+++ b/java/test/auto_check_sbp_flash_MsgFlashDoneTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_flash_MsgFlashEraseTest.java
+++ b/java/test/auto_check_sbp_flash_MsgFlashEraseTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_flash_MsgFlashProgramTest.java
+++ b/java/test/auto_check_sbp_flash_MsgFlashProgramTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_flash_MsgFlashReadReqTest.java
+++ b/java/test/auto_check_sbp_flash_MsgFlashReadReqTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_flash_MsgFlashReadRespTest.java
+++ b/java/test/auto_check_sbp_flash_MsgFlashReadRespTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_flash_MsgM25FlashWriteStatusTest.java
+++ b/java/test/auto_check_sbp_flash_MsgM25FlashWriteStatusTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_flash_MsgStmFlashLockSectorTest.java
+++ b/java/test/auto_check_sbp_flash_MsgStmFlashLockSectorTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_flash_MsgStmFlashUnlockSectorTest.java
+++ b/java/test/auto_check_sbp_flash_MsgStmFlashUnlockSectorTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_flash_MsgStmUniqueIdReqTest.java
+++ b/java/test/auto_check_sbp_flash_MsgStmUniqueIdReqTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_flash_MsgStmUniqueIdRespTest.java
+++ b/java/test/auto_check_sbp_flash_MsgStmUniqueIdRespTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_gnss_gnss_structsTest.java
+++ b/java/test/auto_check_sbp_gnss_gnss_structsTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_imu_MsgImuAuxTest.java
+++ b/java/test/auto_check_sbp_imu_MsgImuAuxTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_imu_MsgImuRawTest.java
+++ b/java/test/auto_check_sbp_imu_MsgImuRawTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_integrity_MsgAcknowledgeTest.java
+++ b/java/test/auto_check_sbp_integrity_MsgAcknowledgeTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_integrity_MsgSsrFlagHighLevelTest.java
+++ b/java/test/auto_check_sbp_integrity_MsgSsrFlagHighLevelTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_integrity_MsgSsrFlagIonoGridPointSatLosTest.java
+++ b/java/test/auto_check_sbp_integrity_MsgSsrFlagIonoGridPointSatLosTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_integrity_MsgSsrFlagIonoGridPointsTest.java
+++ b/java/test/auto_check_sbp_integrity_MsgSsrFlagIonoGridPointsTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_integrity_MsgSsrFlagIonoTileSatLosTest.java
+++ b/java/test/auto_check_sbp_integrity_MsgSsrFlagIonoTileSatLosTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_integrity_MsgSsrFlagSatellitesTest.java
+++ b/java/test/auto_check_sbp_integrity_MsgSsrFlagSatellitesTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_integrity_MsgSsrFlagTropoGridPointsTest.java
+++ b/java/test/auto_check_sbp_integrity_MsgSsrFlagTropoGridPointsTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_integrity_integrity_structsTest.java
+++ b/java/test/auto_check_sbp_integrity_integrity_structsTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_linux_MsgLinuxCpuStateDepATest.java
+++ b/java/test/auto_check_sbp_linux_MsgLinuxCpuStateDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_linux_MsgLinuxCpuStateTest.java
+++ b/java/test/auto_check_sbp_linux_MsgLinuxCpuStateTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_linux_MsgLinuxMemStateDepATest.java
+++ b/java/test/auto_check_sbp_linux_MsgLinuxMemStateDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_linux_MsgLinuxMemStateTest.java
+++ b/java/test/auto_check_sbp_linux_MsgLinuxMemStateTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_linux_MsgLinuxProcessFdCountTest.java
+++ b/java/test/auto_check_sbp_linux_MsgLinuxProcessFdCountTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_linux_MsgLinuxProcessFdSummaryTest.java
+++ b/java/test/auto_check_sbp_linux_MsgLinuxProcessFdSummaryTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_linux_MsgLinuxProcessSocketCountsTest.java
+++ b/java/test/auto_check_sbp_linux_MsgLinuxProcessSocketCountsTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_linux_MsgLinuxProcessSocketQueuesTest.java
+++ b/java/test/auto_check_sbp_linux_MsgLinuxProcessSocketQueuesTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_linux_MsgLinuxSocketUsageTest.java
+++ b/java/test/auto_check_sbp_linux_MsgLinuxSocketUsageTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_linux_MsgLinuxSysStateDepATest.java
+++ b/java/test/auto_check_sbp_linux_MsgLinuxSysStateDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_linux_MsgLinuxSysStateTest.java
+++ b/java/test/auto_check_sbp_linux_MsgLinuxSysStateTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_logging_MsgFwdTest.java
+++ b/java/test/auto_check_sbp_logging_MsgFwdTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_logging_MsgLogTest.java
+++ b/java/test/auto_check_sbp_logging_MsgLogTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_logging_MsgPrintDepTest.java
+++ b/java/test/auto_check_sbp_logging_MsgPrintDepTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_mag_MsgMagRawTest.java
+++ b/java/test/auto_check_sbp_mag_MsgMagRawTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgAgeCorrectionsTest.java
+++ b/java/test/auto_check_sbp_navigation_MsgAgeCorrectionsTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgBaselineECEFDepATest.java
+++ b/java/test/auto_check_sbp_navigation_MsgBaselineECEFDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgBaselineECEFTest.java
+++ b/java/test/auto_check_sbp_navigation_MsgBaselineECEFTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgBaselineHeadingDepATest.java
+++ b/java/test/auto_check_sbp_navigation_MsgBaselineHeadingDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgBaselineNEDDepATest.java
+++ b/java/test/auto_check_sbp_navigation_MsgBaselineNEDDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgBaselineNEDTest.java
+++ b/java/test/auto_check_sbp_navigation_MsgBaselineNEDTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgDopsDepATest.java
+++ b/java/test/auto_check_sbp_navigation_MsgDopsDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgDopsTest.java
+++ b/java/test/auto_check_sbp_navigation_MsgDopsTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgGPSTimeDepATest.java
+++ b/java/test/auto_check_sbp_navigation_MsgGPSTimeDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgGPSTimeGNSSTest.java
+++ b/java/test/auto_check_sbp_navigation_MsgGPSTimeGNSSTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgGPSTimeTest.java
+++ b/java/test/auto_check_sbp_navigation_MsgGPSTimeTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgPosECEFCovGNSSTest.java
+++ b/java/test/auto_check_sbp_navigation_MsgPosECEFCovGNSSTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgPosECEFCovTest.java
+++ b/java/test/auto_check_sbp_navigation_MsgPosECEFCovTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgPosECEFDepATest.java
+++ b/java/test/auto_check_sbp_navigation_MsgPosECEFDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgPosECEFGNSSTest.java
+++ b/java/test/auto_check_sbp_navigation_MsgPosECEFGNSSTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgPosECEFTest.java
+++ b/java/test/auto_check_sbp_navigation_MsgPosECEFTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgPosLLHCovTest.java
+++ b/java/test/auto_check_sbp_navigation_MsgPosLLHCovTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgPosLLHDepATest.java
+++ b/java/test/auto_check_sbp_navigation_MsgPosLLHDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgPosLLHTest.java
+++ b/java/test/auto_check_sbp_navigation_MsgPosLLHTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgPosLlhAccTest.java
+++ b/java/test/auto_check_sbp_navigation_MsgPosLlhAccTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgPosLlhCovGnssTest.java
+++ b/java/test/auto_check_sbp_navigation_MsgPosLlhCovGnssTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgPosLlhGnssTest.java
+++ b/java/test/auto_check_sbp_navigation_MsgPosLlhGnssTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgPoseRelativeTest.java
+++ b/java/test/auto_check_sbp_navigation_MsgPoseRelativeTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgProtectionLevelDepATest.java
+++ b/java/test/auto_check_sbp_navigation_MsgProtectionLevelDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgProtectionLevelTest.java
+++ b/java/test/auto_check_sbp_navigation_MsgProtectionLevelTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgReferenceFrameParamTest.java
+++ b/java/test/auto_check_sbp_navigation_MsgReferenceFrameParamTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgUTCLeapSecondTest.java
+++ b/java/test/auto_check_sbp_navigation_MsgUTCLeapSecondTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgUTCTimeGNSSTest.java
+++ b/java/test/auto_check_sbp_navigation_MsgUTCTimeGNSSTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgUTCTimeTest.java
+++ b/java/test/auto_check_sbp_navigation_MsgUTCTimeTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgVelBodyTest.java
+++ b/java/test/auto_check_sbp_navigation_MsgVelBodyTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgVelCogTest.java
+++ b/java/test/auto_check_sbp_navigation_MsgVelCogTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgVelECEFCovTest.java
+++ b/java/test/auto_check_sbp_navigation_MsgVelECEFCovTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgVelECEFDepATest.java
+++ b/java/test/auto_check_sbp_navigation_MsgVelECEFDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgVelECEFTest.java
+++ b/java/test/auto_check_sbp_navigation_MsgVelECEFTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgVelEcefCovGnssTest.java
+++ b/java/test/auto_check_sbp_navigation_MsgVelEcefCovGnssTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgVelEcefGnssTest.java
+++ b/java/test/auto_check_sbp_navigation_MsgVelEcefGnssTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgVelNEDCOVTest.java
+++ b/java/test/auto_check_sbp_navigation_MsgVelNEDCOVTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgVelNEDDepATest.java
+++ b/java/test/auto_check_sbp_navigation_MsgVelNEDDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgVelNEDTest.java
+++ b/java/test/auto_check_sbp_navigation_MsgVelNEDTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgVelNedCovGnssTest.java
+++ b/java/test/auto_check_sbp_navigation_MsgVelNedCovGnssTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_MsgVelNedGnssTest.java
+++ b/java/test/auto_check_sbp_navigation_MsgVelNedGnssTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_navigation_navigation_structsTest.java
+++ b/java/test/auto_check_sbp_navigation_navigation_structsTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_ndb_MsgNdbEventTest.java
+++ b/java/test/auto_check_sbp_ndb_MsgNdbEventTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgAlmanacGLODepTest.java
+++ b/java/test/auto_check_sbp_observation_MsgAlmanacGLODepTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgAlmanacGLOTest.java
+++ b/java/test/auto_check_sbp_observation_MsgAlmanacGLOTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgAlmanacGPSDepTest.java
+++ b/java/test/auto_check_sbp_observation_MsgAlmanacGPSDepTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgAlmanacGPSTest.java
+++ b/java/test/auto_check_sbp_observation_MsgAlmanacGPSTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgBasePosEcefTest.java
+++ b/java/test/auto_check_sbp_observation_MsgBasePosEcefTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgBasePosLLHTest.java
+++ b/java/test/auto_check_sbp_observation_MsgBasePosLLHTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgEphemerisBdsTest.java
+++ b/java/test/auto_check_sbp_observation_MsgEphemerisBdsTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgEphemerisDepATest.java
+++ b/java/test/auto_check_sbp_observation_MsgEphemerisDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgEphemerisDepCTest.java
+++ b/java/test/auto_check_sbp_observation_MsgEphemerisDepCTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgEphemerisDepDTest.java
+++ b/java/test/auto_check_sbp_observation_MsgEphemerisDepDTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgEphemerisGLODepATest.java
+++ b/java/test/auto_check_sbp_observation_MsgEphemerisGLODepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgEphemerisGLODepBTest.java
+++ b/java/test/auto_check_sbp_observation_MsgEphemerisGLODepBTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgEphemerisGLODepCTest.java
+++ b/java/test/auto_check_sbp_observation_MsgEphemerisGLODepCTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgEphemerisGLODepDTest.java
+++ b/java/test/auto_check_sbp_observation_MsgEphemerisGLODepDTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgEphemerisGLOTest.java
+++ b/java/test/auto_check_sbp_observation_MsgEphemerisGLOTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgEphemerisGPSDepETest.java
+++ b/java/test/auto_check_sbp_observation_MsgEphemerisGPSDepETest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgEphemerisGPSDepFTest.java
+++ b/java/test/auto_check_sbp_observation_MsgEphemerisGPSDepFTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgEphemerisGPSTest.java
+++ b/java/test/auto_check_sbp_observation_MsgEphemerisGPSTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgEphemerisGalDepATest.java
+++ b/java/test/auto_check_sbp_observation_MsgEphemerisGalDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgEphemerisGalTest.java
+++ b/java/test/auto_check_sbp_observation_MsgEphemerisGalTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgEphemerisSbasDepATest.java
+++ b/java/test/auto_check_sbp_observation_MsgEphemerisSbasDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgEphemerisSbasDepBTest.java
+++ b/java/test/auto_check_sbp_observation_MsgEphemerisSbasDepBTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgEphemerisSbasTest.java
+++ b/java/test/auto_check_sbp_observation_MsgEphemerisSbasTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgGloBiasesTest.java
+++ b/java/test/auto_check_sbp_observation_MsgGloBiasesTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgGnssCapbTest.java
+++ b/java/test/auto_check_sbp_observation_MsgGnssCapbTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgGroupDelayDepATest.java
+++ b/java/test/auto_check_sbp_observation_MsgGroupDelayDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgGroupDelayDepBTest.java
+++ b/java/test/auto_check_sbp_observation_MsgGroupDelayDepBTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgGroupDelayTest.java
+++ b/java/test/auto_check_sbp_observation_MsgGroupDelayTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgIonoTest.java
+++ b/java/test/auto_check_sbp_observation_MsgIonoTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgObsDepBTest.java
+++ b/java/test/auto_check_sbp_observation_MsgObsDepBTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgObsDepCTest.java
+++ b/java/test/auto_check_sbp_observation_MsgObsDepCTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgObsTest.java
+++ b/java/test/auto_check_sbp_observation_MsgObsTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgOsrTest.java
+++ b/java/test/auto_check_sbp_observation_MsgOsrTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgSvAzElTest.java
+++ b/java/test/auto_check_sbp_observation_MsgSvAzElTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_MsgSvConfigurationGpsDepTest.java
+++ b/java/test/auto_check_sbp_observation_MsgSvConfigurationGpsDepTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_msgEphemerisDepBTest.java
+++ b/java/test/auto_check_sbp_observation_msgEphemerisDepBTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_msgEphemerisQzssTest.java
+++ b/java/test/auto_check_sbp_observation_msgEphemerisQzssTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_msgObsDepATest.java
+++ b/java/test/auto_check_sbp_observation_msgObsDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_observation_observation_structsTest.java
+++ b/java/test/auto_check_sbp_observation_observation_structsTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_orientation_MsgAngularRateTest.java
+++ b/java/test/auto_check_sbp_orientation_MsgAngularRateTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_orientation_MsgBaselineHeadingTest.java
+++ b/java/test/auto_check_sbp_orientation_MsgBaselineHeadingTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_orientation_MsgOrientEulerTest.java
+++ b/java/test/auto_check_sbp_orientation_MsgOrientEulerTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_orientation_MsgOrientQuatTest.java
+++ b/java/test/auto_check_sbp_orientation_MsgOrientQuatTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_piksi_MsgAlmanacTest.java
+++ b/java/test/auto_check_sbp_piksi_MsgAlmanacTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_piksi_MsgCellModemStatusTest.java
+++ b/java/test/auto_check_sbp_piksi_MsgCellModemStatusTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_piksi_MsgCommandOutputTest.java
+++ b/java/test/auto_check_sbp_piksi_MsgCommandOutputTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_piksi_MsgCommandReqTest.java
+++ b/java/test/auto_check_sbp_piksi_MsgCommandReqTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_piksi_MsgCommandRespTest.java
+++ b/java/test/auto_check_sbp_piksi_MsgCommandRespTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_piksi_MsgCwResultsTest.java
+++ b/java/test/auto_check_sbp_piksi_MsgCwResultsTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_piksi_MsgCwStartTest.java
+++ b/java/test/auto_check_sbp_piksi_MsgCwStartTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_piksi_MsgDeviceMonitorTest.java
+++ b/java/test/auto_check_sbp_piksi_MsgDeviceMonitorTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_piksi_MsgFrontEndGainTest.java
+++ b/java/test/auto_check_sbp_piksi_MsgFrontEndGainTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_piksi_MsgIarStateTest.java
+++ b/java/test/auto_check_sbp_piksi_MsgIarStateTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_piksi_MsgInitBaseDepTest.java
+++ b/java/test/auto_check_sbp_piksi_MsgInitBaseDepTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_piksi_MsgMaskSatelliteDepTest.java
+++ b/java/test/auto_check_sbp_piksi_MsgMaskSatelliteDepTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_piksi_MsgMaskSatelliteTest.java
+++ b/java/test/auto_check_sbp_piksi_MsgMaskSatelliteTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_piksi_MsgNetworkBandwidthUsageTest.java
+++ b/java/test/auto_check_sbp_piksi_MsgNetworkBandwidthUsageTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_piksi_MsgNetworkStateReqTest.java
+++ b/java/test/auto_check_sbp_piksi_MsgNetworkStateReqTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_piksi_MsgNetworkStateRespTest.java
+++ b/java/test/auto_check_sbp_piksi_MsgNetworkStateRespTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_piksi_MsgResetDepTest.java
+++ b/java/test/auto_check_sbp_piksi_MsgResetDepTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_piksi_MsgResetFiltersTest.java
+++ b/java/test/auto_check_sbp_piksi_MsgResetFiltersTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_piksi_MsgResetTest.java
+++ b/java/test/auto_check_sbp_piksi_MsgResetTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_piksi_MsgSetTimeTest.java
+++ b/java/test/auto_check_sbp_piksi_MsgSetTimeTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_piksi_MsgSpecanDepTest.java
+++ b/java/test/auto_check_sbp_piksi_MsgSpecanDepTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_piksi_MsgSpecanTest.java
+++ b/java/test/auto_check_sbp_piksi_MsgSpecanTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_piksi_MsgThreadStateTest.java
+++ b/java/test/auto_check_sbp_piksi_MsgThreadStateTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_piksi_MsgUartStateDepATest.java
+++ b/java/test/auto_check_sbp_piksi_MsgUartStateDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_piksi_MsgUartStateTest.java
+++ b/java/test/auto_check_sbp_piksi_MsgUartStateTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_piksi_piksi_structsTest.java
+++ b/java/test/auto_check_sbp_piksi_piksi_structsTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_profiling_MsgMeasurementPointTest.java
+++ b/java/test/auto_check_sbp_profiling_MsgMeasurementPointTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_profiling_MsgProfilingResourceCounterTest.java
+++ b/java/test/auto_check_sbp_profiling_MsgProfilingResourceCounterTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_profiling_MsgProfilingSystemInfoTest.java
+++ b/java/test/auto_check_sbp_profiling_MsgProfilingSystemInfoTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_profiling_MsgProfilingThreadInfoTest.java
+++ b/java/test/auto_check_sbp_profiling_MsgProfilingThreadInfoTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_sbas_MsgSbasRawTest.java
+++ b/java/test/auto_check_sbp_sbas_MsgSbasRawTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_settings_MsgSettingsReadByIndexDoneTest.java
+++ b/java/test/auto_check_sbp_settings_MsgSettingsReadByIndexDoneTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_settings_MsgSettingsReadByIndexReqTest.java
+++ b/java/test/auto_check_sbp_settings_MsgSettingsReadByIndexReqTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_settings_MsgSettingsReadByIndexRespTest.java
+++ b/java/test/auto_check_sbp_settings_MsgSettingsReadByIndexRespTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_settings_MsgSettingsReadReqTest.java
+++ b/java/test/auto_check_sbp_settings_MsgSettingsReadReqTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_settings_MsgSettingsReadRespTest.java
+++ b/java/test/auto_check_sbp_settings_MsgSettingsReadRespTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_settings_MsgSettingsRegisterRespTest.java
+++ b/java/test/auto_check_sbp_settings_MsgSettingsRegisterRespTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_settings_MsgSettingsRegisterTest.java
+++ b/java/test/auto_check_sbp_settings_MsgSettingsRegisterTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_settings_MsgSettingsSaveTest.java
+++ b/java/test/auto_check_sbp_settings_MsgSettingsSaveTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_settings_MsgSettingsWriteRespTest.java
+++ b/java/test/auto_check_sbp_settings_MsgSettingsWriteRespTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_settings_MsgSettingsWriteTest.java
+++ b/java/test/auto_check_sbp_settings_MsgSettingsWriteTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_signing_MsgCertificateChainDepTest.java
+++ b/java/test/auto_check_sbp_signing_MsgCertificateChainDepTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_signing_MsgCertificateChainTest.java
+++ b/java/test/auto_check_sbp_signing_MsgCertificateChainTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_signing_MsgEcdsaCertificateTest.java
+++ b/java/test/auto_check_sbp_signing_MsgEcdsaCertificateTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_signing_MsgEcdsaSignatureDepATest.java
+++ b/java/test/auto_check_sbp_signing_MsgEcdsaSignatureDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_signing_MsgEcdsaSignatureDepBTest.java
+++ b/java/test/auto_check_sbp_signing_MsgEcdsaSignatureDepBTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_signing_MsgEcdsaSignatureTest.java
+++ b/java/test/auto_check_sbp_signing_MsgEcdsaSignatureTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_signing_MsgEd25519CertificateDepTest.java
+++ b/java/test/auto_check_sbp_signing_MsgEd25519CertificateDepTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_signing_MsgEd25519SignatureDepATest.java
+++ b/java/test/auto_check_sbp_signing_MsgEd25519SignatureDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_signing_MsgEd25519SignatureDepBTest.java
+++ b/java/test/auto_check_sbp_signing_MsgEd25519SignatureDepBTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_signing_signing_structsTest.java
+++ b/java/test/auto_check_sbp_signing_signing_structsTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_soln_meta_soln_meta_structsTest.java
+++ b/java/test/auto_check_sbp_soln_meta_soln_meta_structsTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_solution_meta_MsgSolnMetaDepATest.java
+++ b/java/test/auto_check_sbp_solution_meta_MsgSolnMetaDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_solution_meta_MsgSolnMetaTest.java
+++ b/java/test/auto_check_sbp_solution_meta_MsgSolnMetaTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_ssr_MsgSsrCodeBiasesTest.java
+++ b/java/test/auto_check_sbp_ssr_MsgSsrCodeBiasesTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_ssr_MsgSsrCodePhaseBiasesBoundsTest.java
+++ b/java/test/auto_check_sbp_ssr_MsgSsrCodePhaseBiasesBoundsTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_ssr_MsgSsrGridDefinitionDepATest.java
+++ b/java/test/auto_check_sbp_ssr_MsgSsrGridDefinitionDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_ssr_MsgSsrGriddedCorrectionBoundsTest.java
+++ b/java/test/auto_check_sbp_ssr_MsgSsrGriddedCorrectionBoundsTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_ssr_MsgSsrGriddedCorrectionDepATest.java
+++ b/java/test/auto_check_sbp_ssr_MsgSsrGriddedCorrectionDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_ssr_MsgSsrGriddedCorrectionNoStdDepATest.java
+++ b/java/test/auto_check_sbp_ssr_MsgSsrGriddedCorrectionNoStdDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_ssr_MsgSsrGriddedCorrectionTest.java
+++ b/java/test/auto_check_sbp_ssr_MsgSsrGriddedCorrectionTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_ssr_MsgSsrOrbitClockBoundsDegradationTest.java
+++ b/java/test/auto_check_sbp_ssr_MsgSsrOrbitClockBoundsDegradationTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_ssr_MsgSsrOrbitClockBoundsTest.java
+++ b/java/test/auto_check_sbp_ssr_MsgSsrOrbitClockBoundsTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_ssr_MsgSsrOrbitClockDepATest.java
+++ b/java/test/auto_check_sbp_ssr_MsgSsrOrbitClockDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_ssr_MsgSsrOrbitClockTest.java
+++ b/java/test/auto_check_sbp_ssr_MsgSsrOrbitClockTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_ssr_MsgSsrPhaseBiasesTest.java
+++ b/java/test/auto_check_sbp_ssr_MsgSsrPhaseBiasesTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_ssr_MsgSsrSatelliteApcDepATest.java
+++ b/java/test/auto_check_sbp_ssr_MsgSsrSatelliteApcDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_ssr_MsgSsrSatelliteApcTest.java
+++ b/java/test/auto_check_sbp_ssr_MsgSsrSatelliteApcTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_ssr_MsgSsrStecCorrectionDepATest.java
+++ b/java/test/auto_check_sbp_ssr_MsgSsrStecCorrectionDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_ssr_MsgSsrStecCorrectionDepTest.java
+++ b/java/test/auto_check_sbp_ssr_MsgSsrStecCorrectionDepTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_ssr_MsgSsrStecCorrectionTest.java
+++ b/java/test/auto_check_sbp_ssr_MsgSsrStecCorrectionTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_ssr_MsgSsrTileDefinitionDepATest.java
+++ b/java/test/auto_check_sbp_ssr_MsgSsrTileDefinitionDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_ssr_MsgSsrTileDefinitionDepBTest.java
+++ b/java/test/auto_check_sbp_ssr_MsgSsrTileDefinitionDepBTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_ssr_MsgSsrTileDefinitionTest.java
+++ b/java/test/auto_check_sbp_ssr_MsgSsrTileDefinitionTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_ssr_ssr_structsTest.java
+++ b/java/test/auto_check_sbp_ssr_ssr_structsTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_system_MsgCsacTelemetryLabelsTest.java
+++ b/java/test/auto_check_sbp_system_MsgCsacTelemetryLabelsTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_system_MsgCsacTelemetryTest.java
+++ b/java/test/auto_check_sbp_system_MsgCsacTelemetryTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_system_MsgDgnssStatusTest.java
+++ b/java/test/auto_check_sbp_system_MsgDgnssStatusTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_system_MsgGnssTimeOffsetTest.java
+++ b/java/test/auto_check_sbp_system_MsgGnssTimeOffsetTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_system_MsgGroupMetaTest.java
+++ b/java/test/auto_check_sbp_system_MsgGroupMetaTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_system_MsgHeartbeatTest.java
+++ b/java/test/auto_check_sbp_system_MsgHeartbeatTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_system_MsgInsStatusTest.java
+++ b/java/test/auto_check_sbp_system_MsgInsStatusTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_system_MsgInsUpdatesTest.java
+++ b/java/test/auto_check_sbp_system_MsgInsUpdatesTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_system_MsgPpsTimeTest.java
+++ b/java/test/auto_check_sbp_system_MsgPpsTimeTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_system_MsgSensorAidEventTest.java
+++ b/java/test/auto_check_sbp_system_MsgSensorAidEventTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_system_MsgStartupTest.java
+++ b/java/test/auto_check_sbp_system_MsgStartupTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_system_MsgStatusJournalTest.java
+++ b/java/test/auto_check_sbp_system_MsgStatusJournalTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_system_MsgStatusReportTest.java
+++ b/java/test/auto_check_sbp_system_MsgStatusReportTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_system_system_structsTest.java
+++ b/java/test/auto_check_sbp_system_system_structsTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_telemetry_MsgTelSvTest.java
+++ b/java/test/auto_check_sbp_telemetry_MsgTelSvTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_telemetry_acquisition_structsTest.java
+++ b/java/test/auto_check_sbp_telemetry_acquisition_structsTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_telemetry_telemetry_structsTest.java
+++ b/java/test/auto_check_sbp_telemetry_telemetry_structsTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_tracking_MsgMeasurementStateTest.java
+++ b/java/test/auto_check_sbp_tracking_MsgMeasurementStateTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_tracking_MsgTrackingIqDepATest.java
+++ b/java/test/auto_check_sbp_tracking_MsgTrackingIqDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_tracking_MsgTrackingIqDepBTest.java
+++ b/java/test/auto_check_sbp_tracking_MsgTrackingIqDepBTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_tracking_MsgTrackingIqTest.java
+++ b/java/test/auto_check_sbp_tracking_MsgTrackingIqTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_tracking_MsgTrackingStateDepBTest.java
+++ b/java/test/auto_check_sbp_tracking_MsgTrackingStateDepBTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_tracking_MsgTrackingStateDetailedDepATest.java
+++ b/java/test/auto_check_sbp_tracking_MsgTrackingStateDetailedDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_tracking_MsgTrackingStateDetailedDepTest.java
+++ b/java/test/auto_check_sbp_tracking_MsgTrackingStateDetailedDepTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_tracking_MsgTrackingStateTest.java
+++ b/java/test/auto_check_sbp_tracking_MsgTrackingStateTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_tracking_MsgtrackingStateDepATest.java
+++ b/java/test/auto_check_sbp_tracking_MsgtrackingStateDepATest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_tracking_tracking_structsTest.java
+++ b/java/test/auto_check_sbp_tracking_tracking_structsTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_user_MsgUserDataTest.java
+++ b/java/test/auto_check_sbp_user_MsgUserDataTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_vehicle_MsgOdometryTest.java
+++ b/java/test/auto_check_sbp_vehicle_MsgOdometryTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/java/test/auto_check_sbp_vehicle_MsgWheeltickTest.java
+++ b/java/test/auto_check_sbp_vehicle_MsgWheeltickTest.java
@@ -2,7 +2,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/jsonschema/AcqSvProfile.json
+++ b/jsonschema/AcqSvProfile.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/AlmanacCommonContent.json
+++ b/jsonschema/AlmanacCommonContent.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/BoundsHeader.json
+++ b/jsonschema/BoundsHeader.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/CarrierPhase.json
+++ b/jsonschema/CarrierPhase.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/CodeBiasesContent.json
+++ b/jsonschema/CodeBiasesContent.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/CodePhaseBiasesSatSig.json
+++ b/jsonschema/CodePhaseBiasesSatSig.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/Doppler.json
+++ b/jsonschema/Doppler.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/ECDSASignature.json
+++ b/jsonschema/ECDSASignature.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/EphemerisCommonContent.json
+++ b/jsonschema/EphemerisCommonContent.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/EstimatedHorizontalErrorEllipse.json
+++ b/jsonschema/EstimatedHorizontalErrorEllipse.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/GNSSInputType.json
+++ b/jsonschema/GNSSInputType.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/GnssCapb.json
+++ b/jsonschema/GnssCapb.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/GnssSignal.json
+++ b/jsonschema/GnssSignal.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/GpsTime.json
+++ b/jsonschema/GpsTime.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/GpsTimeSec.json
+++ b/jsonschema/GpsTimeSec.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/GridElement.json
+++ b/jsonschema/GridElement.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/GridElementNoStd.json
+++ b/jsonschema/GridElementNoStd.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/GriddedCorrectionHeader.json
+++ b/jsonschema/GriddedCorrectionHeader.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/IMUInputType.json
+++ b/jsonschema/IMUInputType.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/IntegritySSRHeader.json
+++ b/jsonschema/IntegritySSRHeader.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/Latency.json
+++ b/jsonschema/Latency.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MeasurementState.json
+++ b/jsonschema/MeasurementState.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgAcknowledge.json
+++ b/jsonschema/MsgAcknowledge.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgAcqResult.json
+++ b/jsonschema/MsgAcqResult.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgAcqSvProfile.json
+++ b/jsonschema/MsgAcqSvProfile.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgAgeCorrections.json
+++ b/jsonschema/MsgAgeCorrections.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgAlmanac.json
+++ b/jsonschema/MsgAlmanac.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgAlmanacGPS.json
+++ b/jsonschema/MsgAlmanacGPS.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgAlmanacGlo.json
+++ b/jsonschema/MsgAlmanacGlo.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgAngularRate.json
+++ b/jsonschema/MsgAngularRate.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgBasePosECEF.json
+++ b/jsonschema/MsgBasePosECEF.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgBasePosLLH.json
+++ b/jsonschema/MsgBasePosLLH.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgBaselineECEF.json
+++ b/jsonschema/MsgBaselineECEF.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgBaselineHeading.json
+++ b/jsonschema/MsgBaselineHeading.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgBaselineNED.json
+++ b/jsonschema/MsgBaselineNED.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgBootloaderHandshakeReq.json
+++ b/jsonschema/MsgBootloaderHandshakeReq.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgBootloaderHandshakeResp.json
+++ b/jsonschema/MsgBootloaderHandshakeResp.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgBootloaderJumpToApp.json
+++ b/jsonschema/MsgBootloaderJumpToApp.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgCellModemStatus.json
+++ b/jsonschema/MsgCellModemStatus.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgCertificateChain.json
+++ b/jsonschema/MsgCertificateChain.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgCommandOutput.json
+++ b/jsonschema/MsgCommandOutput.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgCommandReq.json
+++ b/jsonschema/MsgCommandReq.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgCommandResp.json
+++ b/jsonschema/MsgCommandResp.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgCsacTelemetry.json
+++ b/jsonschema/MsgCsacTelemetry.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgCsacTelemetryLabels.json
+++ b/jsonschema/MsgCsacTelemetryLabels.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgCwResults.json
+++ b/jsonschema/MsgCwResults.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgCwStart.json
+++ b/jsonschema/MsgCwStart.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgDeviceMonitor.json
+++ b/jsonschema/MsgDeviceMonitor.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgDgnssStatus.json
+++ b/jsonschema/MsgDgnssStatus.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgDops.json
+++ b/jsonschema/MsgDops.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgEcdsaCertificate.json
+++ b/jsonschema/MsgEcdsaCertificate.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgEcdsaSignature.json
+++ b/jsonschema/MsgEcdsaSignature.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgEphemerisBds.json
+++ b/jsonschema/MsgEphemerisBds.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgEphemerisGPS.json
+++ b/jsonschema/MsgEphemerisGPS.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgEphemerisGal.json
+++ b/jsonschema/MsgEphemerisGal.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgEphemerisGlo.json
+++ b/jsonschema/MsgEphemerisGlo.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgEphemerisQzss.json
+++ b/jsonschema/MsgEphemerisQzss.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgEphemerisSbas.json
+++ b/jsonschema/MsgEphemerisSbas.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgExtEvent.json
+++ b/jsonschema/MsgExtEvent.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgFileioConfigReq.json
+++ b/jsonschema/MsgFileioConfigReq.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgFileioConfigResp.json
+++ b/jsonschema/MsgFileioConfigResp.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgFileioReadDirReq.json
+++ b/jsonschema/MsgFileioReadDirReq.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgFileioReadDirResp.json
+++ b/jsonschema/MsgFileioReadDirResp.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgFileioReadReq.json
+++ b/jsonschema/MsgFileioReadReq.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgFileioReadResp.json
+++ b/jsonschema/MsgFileioReadResp.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgFileioRemove.json
+++ b/jsonschema/MsgFileioRemove.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgFileioWriteReq.json
+++ b/jsonschema/MsgFileioWriteReq.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgFileioWriteResp.json
+++ b/jsonschema/MsgFileioWriteResp.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgFlashDone.json
+++ b/jsonschema/MsgFlashDone.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgFlashErase.json
+++ b/jsonschema/MsgFlashErase.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgFlashProgram.json
+++ b/jsonschema/MsgFlashProgram.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgFlashReadReq.json
+++ b/jsonschema/MsgFlashReadReq.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgFlashReadResp.json
+++ b/jsonschema/MsgFlashReadResp.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgFrontEndGain.json
+++ b/jsonschema/MsgFrontEndGain.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgFwd.json
+++ b/jsonschema/MsgFwd.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgGPSTime.json
+++ b/jsonschema/MsgGPSTime.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgGPSTimeGnss.json
+++ b/jsonschema/MsgGPSTimeGnss.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgGloBiases.json
+++ b/jsonschema/MsgGloBiases.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgGnssCapb.json
+++ b/jsonschema/MsgGnssCapb.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgGnssTimeOffset.json
+++ b/jsonschema/MsgGnssTimeOffset.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgGroupDelay.json
+++ b/jsonschema/MsgGroupDelay.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgGroupMeta.json
+++ b/jsonschema/MsgGroupMeta.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgHeartbeat.json
+++ b/jsonschema/MsgHeartbeat.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgIarState.json
+++ b/jsonschema/MsgIarState.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgImuAux.json
+++ b/jsonschema/MsgImuAux.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgImuRaw.json
+++ b/jsonschema/MsgImuRaw.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgInsStatus.json
+++ b/jsonschema/MsgInsStatus.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgInsUpdates.json
+++ b/jsonschema/MsgInsUpdates.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgIono.json
+++ b/jsonschema/MsgIono.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgLinuxCpuState.json
+++ b/jsonschema/MsgLinuxCpuState.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgLinuxMemState.json
+++ b/jsonschema/MsgLinuxMemState.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgLinuxProcessFdCount.json
+++ b/jsonschema/MsgLinuxProcessFdCount.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgLinuxProcessFdSummary.json
+++ b/jsonschema/MsgLinuxProcessFdSummary.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgLinuxProcessSocketCounts.json
+++ b/jsonschema/MsgLinuxProcessSocketCounts.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgLinuxProcessSocketQueues.json
+++ b/jsonschema/MsgLinuxProcessSocketQueues.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgLinuxSocketUsage.json
+++ b/jsonschema/MsgLinuxSocketUsage.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgLinuxSysState.json
+++ b/jsonschema/MsgLinuxSysState.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgLog.json
+++ b/jsonschema/MsgLog.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgM25FlashWriteStatus.json
+++ b/jsonschema/MsgM25FlashWriteStatus.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgMagRaw.json
+++ b/jsonschema/MsgMagRaw.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgMaskSatellite.json
+++ b/jsonschema/MsgMaskSatellite.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgMeasurementPoint.json
+++ b/jsonschema/MsgMeasurementPoint.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgMeasurementState.json
+++ b/jsonschema/MsgMeasurementState.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgNapDeviceDnaReq.json
+++ b/jsonschema/MsgNapDeviceDnaReq.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgNapDeviceDnaResp.json
+++ b/jsonschema/MsgNapDeviceDnaResp.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgNdbEvent.json
+++ b/jsonschema/MsgNdbEvent.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgNetworkBandwidthUsage.json
+++ b/jsonschema/MsgNetworkBandwidthUsage.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgNetworkStateReq.json
+++ b/jsonschema/MsgNetworkStateReq.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgNetworkStateResp.json
+++ b/jsonschema/MsgNetworkStateResp.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgObs.json
+++ b/jsonschema/MsgObs.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgOdometry.json
+++ b/jsonschema/MsgOdometry.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgOrientEuler.json
+++ b/jsonschema/MsgOrientEuler.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgOrientQuat.json
+++ b/jsonschema/MsgOrientQuat.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgOsr.json
+++ b/jsonschema/MsgOsr.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgPosECEF.json
+++ b/jsonschema/MsgPosECEF.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgPosECEFCov.json
+++ b/jsonschema/MsgPosECEFCov.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgPosECEFCovGnss.json
+++ b/jsonschema/MsgPosECEFCovGnss.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgPosECEFGnss.json
+++ b/jsonschema/MsgPosECEFGnss.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgPosLLH.json
+++ b/jsonschema/MsgPosLLH.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgPosLLHAcc.json
+++ b/jsonschema/MsgPosLLHAcc.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgPosLLHCov.json
+++ b/jsonschema/MsgPosLLHCov.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgPosLLHCovGnss.json
+++ b/jsonschema/MsgPosLLHCovGnss.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgPosLLHGnss.json
+++ b/jsonschema/MsgPosLLHGnss.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgPoseRelative.json
+++ b/jsonschema/MsgPoseRelative.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgPpsTime.json
+++ b/jsonschema/MsgPpsTime.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgProfilingResourceCounter.json
+++ b/jsonschema/MsgProfilingResourceCounter.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgProfilingSystemInfo.json
+++ b/jsonschema/MsgProfilingSystemInfo.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgProfilingThreadInfo.json
+++ b/jsonschema/MsgProfilingThreadInfo.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgProtectionLevel.json
+++ b/jsonschema/MsgProtectionLevel.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgReferenceFrameParam.json
+++ b/jsonschema/MsgReferenceFrameParam.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgReset.json
+++ b/jsonschema/MsgReset.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgResetFilters.json
+++ b/jsonschema/MsgResetFilters.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSbasRaw.json
+++ b/jsonschema/MsgSbasRaw.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSensorAidEvent.json
+++ b/jsonschema/MsgSensorAidEvent.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSetTime.json
+++ b/jsonschema/MsgSetTime.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSettingsReadByIndexDone.json
+++ b/jsonschema/MsgSettingsReadByIndexDone.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSettingsReadByIndexReq.json
+++ b/jsonschema/MsgSettingsReadByIndexReq.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSettingsReadByIndexResp.json
+++ b/jsonschema/MsgSettingsReadByIndexResp.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSettingsReadReq.json
+++ b/jsonschema/MsgSettingsReadReq.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSettingsReadResp.json
+++ b/jsonschema/MsgSettingsReadResp.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSettingsRegister.json
+++ b/jsonschema/MsgSettingsRegister.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSettingsRegisterResp.json
+++ b/jsonschema/MsgSettingsRegisterResp.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSettingsSave.json
+++ b/jsonschema/MsgSettingsSave.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSettingsWrite.json
+++ b/jsonschema/MsgSettingsWrite.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSettingsWriteResp.json
+++ b/jsonschema/MsgSettingsWriteResp.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSolnMeta.json
+++ b/jsonschema/MsgSolnMeta.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSpecan.json
+++ b/jsonschema/MsgSpecan.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSsrCodeBiases.json
+++ b/jsonschema/MsgSsrCodeBiases.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSsrCodePhaseBiasesBounds.json
+++ b/jsonschema/MsgSsrCodePhaseBiasesBounds.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSsrFlagHighLevel.json
+++ b/jsonschema/MsgSsrFlagHighLevel.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSsrFlagIonoGridPointSatLos.json
+++ b/jsonschema/MsgSsrFlagIonoGridPointSatLos.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSsrFlagIonoGridPoints.json
+++ b/jsonschema/MsgSsrFlagIonoGridPoints.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSsrFlagIonoTileSatLos.json
+++ b/jsonschema/MsgSsrFlagIonoTileSatLos.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSsrFlagSatellites.json
+++ b/jsonschema/MsgSsrFlagSatellites.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSsrFlagTropoGridPoints.json
+++ b/jsonschema/MsgSsrFlagTropoGridPoints.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSsrGriddedCorrection.json
+++ b/jsonschema/MsgSsrGriddedCorrection.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSsrGriddedCorrectionBounds.json
+++ b/jsonschema/MsgSsrGriddedCorrectionBounds.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSsrOrbitClock.json
+++ b/jsonschema/MsgSsrOrbitClock.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSsrOrbitClockBounds.json
+++ b/jsonschema/MsgSsrOrbitClockBounds.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSsrOrbitClockBoundsDegradation.json
+++ b/jsonschema/MsgSsrOrbitClockBoundsDegradation.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSsrPhaseBiases.json
+++ b/jsonschema/MsgSsrPhaseBiases.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSsrSatelliteApc.json
+++ b/jsonschema/MsgSsrSatelliteApc.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSsrStecCorrection.json
+++ b/jsonschema/MsgSsrStecCorrection.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSsrTileDefinition.json
+++ b/jsonschema/MsgSsrTileDefinition.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgStartup.json
+++ b/jsonschema/MsgStartup.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgStatusJournal.json
+++ b/jsonschema/MsgStatusJournal.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgStatusReport.json
+++ b/jsonschema/MsgStatusReport.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgStmFlashLockSector.json
+++ b/jsonschema/MsgStmFlashLockSector.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgStmFlashUnlockSector.json
+++ b/jsonschema/MsgStmFlashUnlockSector.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgStmUniqueIdReq.json
+++ b/jsonschema/MsgStmUniqueIdReq.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgStmUniqueIdResp.json
+++ b/jsonschema/MsgStmUniqueIdResp.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgSvAzEl.json
+++ b/jsonschema/MsgSvAzEl.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgTelSv.json
+++ b/jsonschema/MsgTelSv.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgThreadState.json
+++ b/jsonschema/MsgThreadState.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgTrackingIq.json
+++ b/jsonschema/MsgTrackingIq.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgTrackingState.json
+++ b/jsonschema/MsgTrackingState.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgUartState.json
+++ b/jsonschema/MsgUartState.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgUserData.json
+++ b/jsonschema/MsgUserData.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgUtcLeapSecond.json
+++ b/jsonschema/MsgUtcLeapSecond.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgUtcTime.json
+++ b/jsonschema/MsgUtcTime.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgUtcTimeGnss.json
+++ b/jsonschema/MsgUtcTimeGnss.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgVelBody.json
+++ b/jsonschema/MsgVelBody.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgVelCog.json
+++ b/jsonschema/MsgVelCog.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgVelECEF.json
+++ b/jsonschema/MsgVelECEF.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgVelECEFCov.json
+++ b/jsonschema/MsgVelECEFCov.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgVelECEFCovGnss.json
+++ b/jsonschema/MsgVelECEFCovGnss.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgVelECEFGnss.json
+++ b/jsonschema/MsgVelECEFGnss.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgVelNED.json
+++ b/jsonschema/MsgVelNED.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgVelNEDCov.json
+++ b/jsonschema/MsgVelNEDCov.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgVelNEDCovGnss.json
+++ b/jsonschema/MsgVelNEDCovGnss.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgVelNEDGnss.json
+++ b/jsonschema/MsgVelNEDGnss.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/MsgWheeltick.json
+++ b/jsonschema/MsgWheeltick.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/NetworkUsage.json
+++ b/jsonschema/NetworkUsage.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/ObservationHeader.json
+++ b/jsonschema/ObservationHeader.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/OdoInputType.json
+++ b/jsonschema/OdoInputType.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/OrbitClockBound.json
+++ b/jsonschema/OrbitClockBound.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/OrbitClockBoundDegradation.json
+++ b/jsonschema/OrbitClockBoundDegradation.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/PackedObsContent.json
+++ b/jsonschema/PackedObsContent.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/PackedOsrContent.json
+++ b/jsonschema/PackedOsrContent.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/Period.json
+++ b/jsonschema/Period.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/PhaseBiasesContent.json
+++ b/jsonschema/PhaseBiasesContent.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/ResourceBucket.json
+++ b/jsonschema/ResourceBucket.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/STECHeader.json
+++ b/jsonschema/STECHeader.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/STECResidual.json
+++ b/jsonschema/STECResidual.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/STECResidualNoStd.json
+++ b/jsonschema/STECResidualNoStd.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/STECSatElement.json
+++ b/jsonschema/STECSatElement.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/STECSatElementIntegrity.json
+++ b/jsonschema/STECSatElementIntegrity.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/SatelliteAPC.json
+++ b/jsonschema/SatelliteAPC.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/SolutionInputType.json
+++ b/jsonschema/SolutionInputType.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/StatusJournalItem.json
+++ b/jsonschema/StatusJournalItem.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/SubSystemReport.json
+++ b/jsonschema/SubSystemReport.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/SvAzEl.json
+++ b/jsonschema/SvAzEl.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/SvId.json
+++ b/jsonschema/SvId.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/TelemetrySV.json
+++ b/jsonschema/TelemetrySV.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/TrackingChannelCorrelation.json
+++ b/jsonschema/TrackingChannelCorrelation.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/TrackingChannelState.json
+++ b/jsonschema/TrackingChannelState.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/TroposphericDelayCorrection.json
+++ b/jsonschema/TroposphericDelayCorrection.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/TroposphericDelayCorrectionNoStd.json
+++ b/jsonschema/TroposphericDelayCorrectionNoStd.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/UARTChannel.json
+++ b/jsonschema/UARTChannel.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/jsonschema/UtcTime.json
+++ b/jsonschema/UtcTime.json
@@ -4,7 +4,7 @@
     "Contact: https://support.swiftnav.com",
     "",
     "This source is subject to the license found in the file 'LICENSE' which must",
-    "be be distributed together with this source. All other rights reserved.",
+    "be distributed together with this source. All other rights reserved.",
     "",
     "THIS CODE AND INFORMATION IS PROVIDED 'AS IS' WITHOUT WARRANTY OF ANY KIND,",
     "EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED",

--- a/kaitai/ksy/acquisition.ksy
+++ b/kaitai/ksy/acquisition.ksy
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/ksy/bootload.ksy
+++ b/kaitai/ksy/bootload.ksy
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/ksy/ext_events.ksy
+++ b/kaitai/ksy/ext_events.ksy
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/ksy/file_io.ksy
+++ b/kaitai/ksy/file_io.ksy
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/ksy/flash.ksy
+++ b/kaitai/ksy/flash.ksy
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/ksy/gnss.ksy
+++ b/kaitai/ksy/gnss.ksy
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/ksy/imu.ksy
+++ b/kaitai/ksy/imu.ksy
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/ksy/integrity.ksy
+++ b/kaitai/ksy/integrity.ksy
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/ksy/linux.ksy
+++ b/kaitai/ksy/linux.ksy
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/ksy/logging.ksy
+++ b/kaitai/ksy/logging.ksy
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/ksy/mag.ksy
+++ b/kaitai/ksy/mag.ksy
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/ksy/navigation.ksy
+++ b/kaitai/ksy/navigation.ksy
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/ksy/ndb.ksy
+++ b/kaitai/ksy/ndb.ksy
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/ksy/observation.ksy
+++ b/kaitai/ksy/observation.ksy
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/ksy/orientation.ksy
+++ b/kaitai/ksy/orientation.ksy
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/ksy/piksi.ksy
+++ b/kaitai/ksy/piksi.ksy
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/ksy/profiling.ksy
+++ b/kaitai/ksy/profiling.ksy
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/ksy/sbas.ksy
+++ b/kaitai/ksy/sbas.ksy
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/ksy/sbp.ksy
+++ b/kaitai/ksy/sbp.ksy
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/ksy/settings.ksy
+++ b/kaitai/ksy/settings.ksy
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/ksy/signing.ksy
+++ b/kaitai/ksy/signing.ksy
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/ksy/solution_meta.ksy
+++ b/kaitai/ksy/solution_meta.ksy
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/ksy/ssr.ksy
+++ b/kaitai/ksy/ssr.ksy
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/ksy/system.ksy
+++ b/kaitai/ksy/system.ksy
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/ksy/telemetry.ksy
+++ b/kaitai/ksy/telemetry.ksy
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/ksy/tracking.ksy
+++ b/kaitai/ksy/tracking.ksy
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/ksy/user.ksy
+++ b/kaitai/ksy/user.ksy
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/ksy/vehicle.ksy
+++ b/kaitai/ksy/vehicle.ksy
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/Table.pm
+++ b/kaitai/perl/KaitaiSbp/Table.pm
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_acquisition_MsgAcqResult.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_acquisition_MsgAcqResult.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_acquisition_MsgAcqResultDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_acquisition_MsgAcqResultDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_acquisition_MsgAcqResultDepB.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_acquisition_MsgAcqResultDepB.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_acquisition_MsgAcqResultDepC.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_acquisition_MsgAcqResultDepC.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_acquisition_MsgAcqSvProfile.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_acquisition_MsgAcqSvProfile.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_acquisition_MsgAcqSvProfileDep.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_acquisition_MsgAcqSvProfileDep.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_bootload_MsgBootloaderHandshakeReq.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_bootload_MsgBootloaderHandshakeReq.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_bootload_MsgBootloaderHandshakeResp.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_bootload_MsgBootloaderHandshakeResp.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_bootload_MsgBootloaderJumptoApp.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_bootload_MsgBootloaderJumptoApp.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_bootload_MsgNapDeviceDnaReq.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_bootload_MsgNapDeviceDnaReq.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_bootload_MsgNapDeviceDnaResp.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_bootload_MsgNapDeviceDnaResp.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ext_events_MsgExtEvent.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ext_events_MsgExtEvent.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_file_io_MsgFileioConfigReq.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_file_io_MsgFileioConfigReq.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_file_io_MsgFileioConfigResp.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_file_io_MsgFileioConfigResp.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_file_io_MsgFileioReadDirReq.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_file_io_MsgFileioReadDirReq.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_file_io_MsgFileioReadDirResp.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_file_io_MsgFileioReadDirResp.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_file_io_MsgFileioReadReq.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_file_io_MsgFileioReadReq.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_file_io_MsgFileioReadResp.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_file_io_MsgFileioReadResp.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_file_io_MsgFileioRemove.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_file_io_MsgFileioRemove.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_file_io_MsgFileioWriteResp.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_file_io_MsgFileioWriteResp.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_flash_MsgFlashDone.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_flash_MsgFlashDone.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_flash_MsgFlashErase.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_flash_MsgFlashErase.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_flash_MsgFlashProgram.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_flash_MsgFlashProgram.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_flash_MsgFlashReadReq.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_flash_MsgFlashReadReq.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_flash_MsgFlashReadResp.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_flash_MsgFlashReadResp.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_flash_MsgM25FlashWriteStatus.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_flash_MsgM25FlashWriteStatus.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_flash_MsgStmFlashLockSector.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_flash_MsgStmFlashLockSector.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_flash_MsgStmFlashUnlockSector.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_flash_MsgStmFlashUnlockSector.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_flash_MsgStmUniqueIdReq.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_flash_MsgStmUniqueIdReq.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_flash_MsgStmUniqueIdResp.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_flash_MsgStmUniqueIdResp.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_imu_MsgImuAux.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_imu_MsgImuAux.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_imu_MsgImuRaw.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_imu_MsgImuRaw.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_integrity_MsgAcknowledge.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_integrity_MsgAcknowledge.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_integrity_MsgSsrFlagHighLevel.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_integrity_MsgSsrFlagHighLevel.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_integrity_MsgSsrFlagIonoGridPointSatLos.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_integrity_MsgSsrFlagIonoGridPointSatLos.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_integrity_MsgSsrFlagIonoGridPoints.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_integrity_MsgSsrFlagIonoGridPoints.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_integrity_MsgSsrFlagIonoTileSatLos.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_integrity_MsgSsrFlagIonoTileSatLos.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_integrity_MsgSsrFlagSatellites.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_integrity_MsgSsrFlagSatellites.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_integrity_MsgSsrFlagTropoGridPoints.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_integrity_MsgSsrFlagTropoGridPoints.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_linux_MsgLinuxCpuState.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_linux_MsgLinuxCpuState.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_linux_MsgLinuxCpuStateDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_linux_MsgLinuxCpuStateDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_linux_MsgLinuxMemState.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_linux_MsgLinuxMemState.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_linux_MsgLinuxMemStateDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_linux_MsgLinuxMemStateDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_linux_MsgLinuxProcessFdCount.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_linux_MsgLinuxProcessFdCount.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_linux_MsgLinuxProcessFdSummary.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_linux_MsgLinuxProcessFdSummary.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_linux_MsgLinuxProcessSocketCounts.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_linux_MsgLinuxProcessSocketCounts.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_linux_MsgLinuxProcessSocketQueues.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_linux_MsgLinuxProcessSocketQueues.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_linux_MsgLinuxSocketUsage.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_linux_MsgLinuxSocketUsage.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_linux_MsgLinuxSysState.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_linux_MsgLinuxSysState.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_linux_MsgLinuxSysStateDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_linux_MsgLinuxSysStateDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_logging_MsgFwd.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_logging_MsgFwd.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_logging_MsgLog.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_logging_MsgLog.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_logging_MsgPrintDep.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_logging_MsgPrintDep.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_mag_MsgMagRaw.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_mag_MsgMagRaw.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgAgeCorrections.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgAgeCorrections.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgBaselineECEF.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgBaselineECEF.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgBaselineECEFDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgBaselineECEFDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgBaselineHeadingDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgBaselineHeadingDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgBaselineNED.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgBaselineNED.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgBaselineNEDDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgBaselineNEDDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgDops.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgDops.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgDopsDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgDopsDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgGPSTime.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgGPSTime.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgGPSTimeDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgGPSTimeDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgGPSTimeGNSS.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgGPSTimeGNSS.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgPosECEF.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgPosECEF.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgPosECEFCov.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgPosECEFCov.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgPosECEFCovGNSS.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgPosECEFCovGNSS.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgPosECEFDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgPosECEFDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgPosECEFGNSS.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgPosECEFGNSS.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgPosLLH.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgPosLLH.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgPosLLHCov.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgPosLLHCov.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgPosLLHDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgPosLLHDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgPosLlhAcc.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgPosLlhAcc.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgPosLlhCovGnss.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgPosLlhCovGnss.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgPosLlhGnss.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgPosLlhGnss.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgPoseRelative.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgPoseRelative.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgProtectionLevel.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgProtectionLevel.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgProtectionLevelDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgProtectionLevelDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgReferenceFrameParam.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgReferenceFrameParam.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgUTCLeapSecond.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgUTCLeapSecond.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgUTCTime.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgUTCTime.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgUTCTimeGNSS.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgUTCTimeGNSS.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgVelBody.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgVelBody.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgVelCog.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgVelCog.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgVelECEF.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgVelECEF.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgVelECEFCov.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgVelECEFCov.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgVelECEFDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgVelECEFDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgVelEcefCovGnss.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgVelEcefCovGnss.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgVelEcefGnss.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgVelEcefGnss.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgVelNED.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgVelNED.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgVelNEDCOV.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgVelNEDCOV.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgVelNEDDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgVelNEDDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgVelNedCovGnss.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgVelNedCovGnss.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgVelNedGnss.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_navigation_MsgVelNedGnss.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ndb_MsgNdbEvent.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ndb_MsgNdbEvent.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgAlmanacGLO.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgAlmanacGLO.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgAlmanacGLODep.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgAlmanacGLODep.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgAlmanacGPS.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgAlmanacGPS.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgAlmanacGPSDep.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgAlmanacGPSDep.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgBasePosEcef.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgBasePosEcef.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgBasePosLLH.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgBasePosLLH.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisBds.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisBds.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisDepC.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisDepC.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisDepD.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisDepD.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisGLO.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisGLO.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisGLODepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisGLODepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisGLODepB.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisGLODepB.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisGLODepC.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisGLODepC.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisGLODepD.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisGLODepD.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisGPS.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisGPS.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisGPSDepE.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisGPSDepE.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisGPSDepF.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisGPSDepF.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisGal.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisGal.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisGalDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisGalDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisSbas.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisSbas.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisSbasDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisSbasDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisSbasDepB.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgEphemerisSbasDepB.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgGloBiases.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgGloBiases.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgGnssCapb.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgGnssCapb.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgGroupDelay.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgGroupDelay.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgGroupDelayDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgGroupDelayDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgGroupDelayDepB.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgGroupDelayDepB.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgIono.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgIono.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgObs.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgObs.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgObsDepB.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgObsDepB.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgObsDepC.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgObsDepC.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgOsr.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgOsr.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgSvAzEl.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgSvAzEl.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgSvConfigurationGpsDep.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_MsgSvConfigurationGpsDep.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_msgEphemerisDepB.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_msgEphemerisDepB.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_msgEphemerisQzss.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_msgEphemerisQzss.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_msgObsDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_observation_msgObsDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_orientation_MsgAngularRate.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_orientation_MsgAngularRate.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_orientation_MsgBaselineHeading.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_orientation_MsgBaselineHeading.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_orientation_MsgOrientEuler.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_orientation_MsgOrientEuler.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_orientation_MsgOrientQuat.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_orientation_MsgOrientQuat.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgAlmanac.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgAlmanac.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgCellModemStatus.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgCellModemStatus.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgCommandOutput.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgCommandOutput.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgCommandReq.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgCommandReq.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgCommandResp.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgCommandResp.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgCwResults.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgCwResults.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgCwStart.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgCwStart.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgDeviceMonitor.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgDeviceMonitor.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgFrontEndGain.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgFrontEndGain.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgIarState.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgIarState.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgInitBaseDep.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgInitBaseDep.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgMaskSatellite.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgMaskSatellite.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgMaskSatelliteDep.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgMaskSatelliteDep.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgNetworkBandwidthUsage.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgNetworkBandwidthUsage.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgNetworkStateReq.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgNetworkStateReq.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgNetworkStateResp.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgNetworkStateResp.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgReset.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgReset.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgResetDep.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgResetDep.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgResetFilters.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgResetFilters.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgSetTime.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgSetTime.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgSpecan.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgSpecan.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgSpecanDep.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgSpecanDep.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgThreadState.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgThreadState.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgUartState.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgUartState.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgUartStateDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_piksi_MsgUartStateDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_profiling_MsgMeasurementPoint.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_profiling_MsgMeasurementPoint.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_profiling_MsgProfilingResourceCounter.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_profiling_MsgProfilingResourceCounter.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_profiling_MsgProfilingSystemInfo.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_profiling_MsgProfilingSystemInfo.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_profiling_MsgProfilingThreadInfo.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_profiling_MsgProfilingThreadInfo.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_sbas_MsgSbasRaw.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_sbas_MsgSbasRaw.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_settings_MsgSettingsReadByIndexDone.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_settings_MsgSettingsReadByIndexDone.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_settings_MsgSettingsReadByIndexReq.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_settings_MsgSettingsReadByIndexReq.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_settings_MsgSettingsReadByIndexResp.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_settings_MsgSettingsReadByIndexResp.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_settings_MsgSettingsReadReq.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_settings_MsgSettingsReadReq.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_settings_MsgSettingsReadResp.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_settings_MsgSettingsReadResp.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_settings_MsgSettingsRegister.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_settings_MsgSettingsRegister.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_settings_MsgSettingsRegisterResp.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_settings_MsgSettingsRegisterResp.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_settings_MsgSettingsSave.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_settings_MsgSettingsSave.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_settings_MsgSettingsWrite.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_settings_MsgSettingsWrite.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_settings_MsgSettingsWriteResp.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_settings_MsgSettingsWriteResp.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_signing_MsgCertificateChain.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_signing_MsgCertificateChain.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_signing_MsgCertificateChainDep.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_signing_MsgCertificateChainDep.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_signing_MsgEcdsaCertificate.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_signing_MsgEcdsaCertificate.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_signing_MsgEcdsaSignature.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_signing_MsgEcdsaSignature.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_signing_MsgEcdsaSignatureDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_signing_MsgEcdsaSignatureDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_signing_MsgEcdsaSignatureDepB.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_signing_MsgEcdsaSignatureDepB.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_signing_MsgEd25519CertificateDep.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_signing_MsgEd25519CertificateDep.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_signing_MsgEd25519SignatureDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_signing_MsgEd25519SignatureDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_signing_MsgEd25519SignatureDepB.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_signing_MsgEd25519SignatureDepB.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_solution_meta_MsgSolnMeta.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_solution_meta_MsgSolnMeta.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_solution_meta_MsgSolnMetaDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_solution_meta_MsgSolnMetaDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrCodeBiases.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrCodeBiases.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrCodePhaseBiasesBounds.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrCodePhaseBiasesBounds.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrGridDefinitionDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrGridDefinitionDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrGriddedCorrection.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrGriddedCorrection.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrGriddedCorrectionBounds.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrGriddedCorrectionBounds.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrGriddedCorrectionDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrGriddedCorrectionDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrGriddedCorrectionNoStdDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrGriddedCorrectionNoStdDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrOrbitClock.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrOrbitClock.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrOrbitClockBounds.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrOrbitClockBounds.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrOrbitClockBoundsDegradation.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrOrbitClockBoundsDegradation.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrOrbitClockDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrOrbitClockDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrPhaseBiases.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrPhaseBiases.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrSatelliteApc.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrSatelliteApc.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrSatelliteApcDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrSatelliteApcDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrStecCorrection.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrStecCorrection.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrStecCorrectionDep.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrStecCorrectionDep.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrStecCorrectionDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrStecCorrectionDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrTileDefinition.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrTileDefinition.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrTileDefinitionDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrTileDefinitionDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrTileDefinitionDepB.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_ssr_MsgSsrTileDefinitionDepB.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_system_MsgCsacTelemetry.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_system_MsgCsacTelemetry.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_system_MsgCsacTelemetryLabels.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_system_MsgCsacTelemetryLabels.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_system_MsgDgnssStatus.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_system_MsgDgnssStatus.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_system_MsgGnssTimeOffset.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_system_MsgGnssTimeOffset.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_system_MsgGroupMeta.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_system_MsgGroupMeta.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_system_MsgHeartbeat.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_system_MsgHeartbeat.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_system_MsgInsStatus.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_system_MsgInsStatus.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_system_MsgInsUpdates.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_system_MsgInsUpdates.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_system_MsgPpsTime.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_system_MsgPpsTime.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_system_MsgSensorAidEvent.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_system_MsgSensorAidEvent.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_system_MsgStartup.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_system_MsgStartup.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_system_MsgStatusJournal.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_system_MsgStatusJournal.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_system_MsgStatusReport.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_system_MsgStatusReport.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_telemetry_MsgTelSv.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_telemetry_MsgTelSv.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_tracking_MsgMeasurementState.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_tracking_MsgMeasurementState.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_tracking_MsgTrackingIq.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_tracking_MsgTrackingIq.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_tracking_MsgTrackingIqDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_tracking_MsgTrackingIqDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_tracking_MsgTrackingIqDepB.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_tracking_MsgTrackingIqDepB.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_tracking_MsgTrackingState.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_tracking_MsgTrackingState.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_tracking_MsgTrackingStateDepB.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_tracking_MsgTrackingStateDepB.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_tracking_MsgTrackingStateDetailedDep.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_tracking_MsgTrackingStateDetailedDep.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_tracking_MsgTrackingStateDetailedDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_tracking_MsgTrackingStateDetailedDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_tracking_MsgtrackingStateDepA.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_tracking_MsgtrackingStateDepA.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_user_MsgUserData.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_user_MsgUserData.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_vehicle_MsgOdometry.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_vehicle_MsgOdometry.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/KaitaiSbp/t/auto_check_sbp_vehicle_MsgWheeltick.t
+++ b/kaitai/perl/KaitaiSbp/t/auto_check_sbp_vehicle_MsgWheeltick.t
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/perl/bin/sbp2json.pl
+++ b/kaitai/perl/bin/sbp2json.pl
@@ -4,7 +4,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/table.py
+++ b/kaitai/python/kaitai_sbp/table.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_acquisition_MsgAcqResult.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_acquisition_MsgAcqResult.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_acquisition_MsgAcqResultDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_acquisition_MsgAcqResultDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_acquisition_MsgAcqResultDepB.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_acquisition_MsgAcqResultDepB.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_acquisition_MsgAcqResultDepC.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_acquisition_MsgAcqResultDepC.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_acquisition_MsgAcqSvProfile.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_acquisition_MsgAcqSvProfile.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_acquisition_MsgAcqSvProfileDep.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_acquisition_MsgAcqSvProfileDep.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_bootload_MsgBootloaderHandshakeReq.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_bootload_MsgBootloaderHandshakeReq.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_bootload_MsgBootloaderHandshakeResp.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_bootload_MsgBootloaderHandshakeResp.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_bootload_MsgBootloaderJumptoApp.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_bootload_MsgBootloaderJumptoApp.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_bootload_MsgNapDeviceDnaReq.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_bootload_MsgNapDeviceDnaReq.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_bootload_MsgNapDeviceDnaResp.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_bootload_MsgNapDeviceDnaResp.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ext_events_MsgExtEvent.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ext_events_MsgExtEvent.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_file_io_MsgFileioConfigReq.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_file_io_MsgFileioConfigReq.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_file_io_MsgFileioConfigResp.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_file_io_MsgFileioConfigResp.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_file_io_MsgFileioReadDirReq.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_file_io_MsgFileioReadDirReq.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_file_io_MsgFileioReadDirResp.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_file_io_MsgFileioReadDirResp.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_file_io_MsgFileioReadReq.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_file_io_MsgFileioReadReq.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_file_io_MsgFileioReadResp.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_file_io_MsgFileioReadResp.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_file_io_MsgFileioRemove.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_file_io_MsgFileioRemove.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_file_io_MsgFileioWriteResp.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_file_io_MsgFileioWriteResp.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_flash_MsgFlashDone.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_flash_MsgFlashDone.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_flash_MsgFlashErase.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_flash_MsgFlashErase.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_flash_MsgFlashProgram.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_flash_MsgFlashProgram.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_flash_MsgFlashReadReq.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_flash_MsgFlashReadReq.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_flash_MsgFlashReadResp.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_flash_MsgFlashReadResp.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_flash_MsgM25FlashWriteStatus.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_flash_MsgM25FlashWriteStatus.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_flash_MsgStmFlashLockSector.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_flash_MsgStmFlashLockSector.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_flash_MsgStmFlashUnlockSector.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_flash_MsgStmFlashUnlockSector.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_flash_MsgStmUniqueIdReq.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_flash_MsgStmUniqueIdReq.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_flash_MsgStmUniqueIdResp.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_flash_MsgStmUniqueIdResp.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_imu_MsgImuAux.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_imu_MsgImuAux.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_imu_MsgImuRaw.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_imu_MsgImuRaw.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_integrity_MsgAcknowledge.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_integrity_MsgAcknowledge.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_integrity_MsgSsrFlagHighLevel.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_integrity_MsgSsrFlagHighLevel.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_integrity_MsgSsrFlagIonoGridPointSatLos.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_integrity_MsgSsrFlagIonoGridPointSatLos.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_integrity_MsgSsrFlagIonoGridPoints.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_integrity_MsgSsrFlagIonoGridPoints.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_integrity_MsgSsrFlagIonoTileSatLos.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_integrity_MsgSsrFlagIonoTileSatLos.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_integrity_MsgSsrFlagSatellites.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_integrity_MsgSsrFlagSatellites.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_integrity_MsgSsrFlagTropoGridPoints.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_integrity_MsgSsrFlagTropoGridPoints.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_linux_MsgLinuxCpuState.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_linux_MsgLinuxCpuState.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_linux_MsgLinuxCpuStateDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_linux_MsgLinuxCpuStateDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_linux_MsgLinuxMemState.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_linux_MsgLinuxMemState.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_linux_MsgLinuxMemStateDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_linux_MsgLinuxMemStateDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_linux_MsgLinuxProcessFdCount.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_linux_MsgLinuxProcessFdCount.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_linux_MsgLinuxProcessFdSummary.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_linux_MsgLinuxProcessFdSummary.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_linux_MsgLinuxProcessSocketCounts.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_linux_MsgLinuxProcessSocketCounts.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_linux_MsgLinuxProcessSocketQueues.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_linux_MsgLinuxProcessSocketQueues.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_linux_MsgLinuxSocketUsage.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_linux_MsgLinuxSocketUsage.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_linux_MsgLinuxSysState.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_linux_MsgLinuxSysState.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_linux_MsgLinuxSysStateDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_linux_MsgLinuxSysStateDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_logging_MsgFwd.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_logging_MsgFwd.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_logging_MsgLog.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_logging_MsgLog.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_logging_MsgPrintDep.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_logging_MsgPrintDep.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_mag_MsgMagRaw.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_mag_MsgMagRaw.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgAgeCorrections.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgAgeCorrections.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgBaselineECEF.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgBaselineECEF.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgBaselineECEFDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgBaselineECEFDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgBaselineHeadingDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgBaselineHeadingDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgBaselineNED.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgBaselineNED.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgBaselineNEDDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgBaselineNEDDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgDops.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgDops.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgDopsDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgDopsDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgGPSTime.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgGPSTime.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgGPSTimeDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgGPSTimeDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgGPSTimeGNSS.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgGPSTimeGNSS.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgPosECEF.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgPosECEF.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgPosECEFCov.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgPosECEFCov.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgPosECEFCovGNSS.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgPosECEFCovGNSS.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgPosECEFDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgPosECEFDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgPosECEFGNSS.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgPosECEFGNSS.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgPosLLH.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgPosLLH.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgPosLLHCov.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgPosLLHCov.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgPosLLHDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgPosLLHDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgPosLlhAcc.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgPosLlhAcc.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgPosLlhCovGnss.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgPosLlhCovGnss.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgPosLlhGnss.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgPosLlhGnss.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgPoseRelative.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgPoseRelative.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgProtectionLevel.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgProtectionLevel.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgProtectionLevelDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgProtectionLevelDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgReferenceFrameParam.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgReferenceFrameParam.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgUTCLeapSecond.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgUTCLeapSecond.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgUTCTime.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgUTCTime.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgUTCTimeGNSS.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgUTCTimeGNSS.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgVelBody.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgVelBody.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgVelCog.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgVelCog.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgVelECEF.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgVelECEF.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgVelECEFCov.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgVelECEFCov.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgVelECEFDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgVelECEFDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgVelEcefCovGnss.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgVelEcefCovGnss.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgVelEcefGnss.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgVelEcefGnss.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgVelNED.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgVelNED.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgVelNEDCOV.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgVelNEDCOV.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgVelNEDDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgVelNEDDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgVelNedCovGnss.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgVelNedCovGnss.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgVelNedGnss.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_navigation_MsgVelNedGnss.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ndb_MsgNdbEvent.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ndb_MsgNdbEvent.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgAlmanacGLO.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgAlmanacGLO.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgAlmanacGLODep.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgAlmanacGLODep.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgAlmanacGPS.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgAlmanacGPS.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgAlmanacGPSDep.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgAlmanacGPSDep.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgBasePosEcef.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgBasePosEcef.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgBasePosLLH.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgBasePosLLH.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisBds.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisBds.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisDepC.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisDepC.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisDepD.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisDepD.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisGLO.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisGLO.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisGLODepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisGLODepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisGLODepB.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisGLODepB.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisGLODepC.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisGLODepC.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisGLODepD.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisGLODepD.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisGPS.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisGPS.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisGPSDepE.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisGPSDepE.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisGPSDepF.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisGPSDepF.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisGal.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisGal.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisGalDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisGalDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisSbas.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisSbas.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisSbasDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisSbasDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisSbasDepB.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgEphemerisSbasDepB.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgGloBiases.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgGloBiases.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgGnssCapb.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgGnssCapb.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgGroupDelay.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgGroupDelay.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgGroupDelayDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgGroupDelayDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgGroupDelayDepB.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgGroupDelayDepB.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgIono.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgIono.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgObs.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgObs.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgObsDepB.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgObsDepB.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgObsDepC.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgObsDepC.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgOsr.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgOsr.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgSvAzEl.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgSvAzEl.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgSvConfigurationGpsDep.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_MsgSvConfigurationGpsDep.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_msgEphemerisDepB.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_msgEphemerisDepB.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_msgEphemerisQzss.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_msgEphemerisQzss.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_msgObsDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_observation_msgObsDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_orientation_MsgAngularRate.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_orientation_MsgAngularRate.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_orientation_MsgBaselineHeading.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_orientation_MsgBaselineHeading.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_orientation_MsgOrientEuler.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_orientation_MsgOrientEuler.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_orientation_MsgOrientQuat.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_orientation_MsgOrientQuat.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgAlmanac.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgAlmanac.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgCellModemStatus.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgCellModemStatus.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgCommandOutput.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgCommandOutput.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgCommandReq.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgCommandReq.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgCommandResp.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgCommandResp.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgCwResults.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgCwResults.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgCwStart.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgCwStart.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgDeviceMonitor.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgDeviceMonitor.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgFrontEndGain.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgFrontEndGain.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgIarState.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgIarState.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgInitBaseDep.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgInitBaseDep.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgMaskSatellite.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgMaskSatellite.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgMaskSatelliteDep.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgMaskSatelliteDep.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgNetworkBandwidthUsage.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgNetworkBandwidthUsage.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgNetworkStateReq.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgNetworkStateReq.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgNetworkStateResp.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgNetworkStateResp.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgReset.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgReset.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgResetDep.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgResetDep.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgResetFilters.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgResetFilters.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgSetTime.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgSetTime.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgSpecan.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgSpecan.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgSpecanDep.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgSpecanDep.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgThreadState.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgThreadState.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgUartState.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgUartState.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgUartStateDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_piksi_MsgUartStateDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_profiling_MsgMeasurementPoint.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_profiling_MsgMeasurementPoint.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_profiling_MsgProfilingResourceCounter.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_profiling_MsgProfilingResourceCounter.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_profiling_MsgProfilingSystemInfo.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_profiling_MsgProfilingSystemInfo.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_profiling_MsgProfilingThreadInfo.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_profiling_MsgProfilingThreadInfo.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_sbas_MsgSbasRaw.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_sbas_MsgSbasRaw.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_settings_MsgSettingsReadByIndexDone.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_settings_MsgSettingsReadByIndexDone.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_settings_MsgSettingsReadByIndexReq.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_settings_MsgSettingsReadByIndexReq.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_settings_MsgSettingsReadByIndexResp.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_settings_MsgSettingsReadByIndexResp.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_settings_MsgSettingsReadReq.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_settings_MsgSettingsReadReq.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_settings_MsgSettingsReadResp.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_settings_MsgSettingsReadResp.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_settings_MsgSettingsRegister.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_settings_MsgSettingsRegister.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_settings_MsgSettingsRegisterResp.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_settings_MsgSettingsRegisterResp.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_settings_MsgSettingsSave.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_settings_MsgSettingsSave.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_settings_MsgSettingsWrite.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_settings_MsgSettingsWrite.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_settings_MsgSettingsWriteResp.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_settings_MsgSettingsWriteResp.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_signing_MsgCertificateChain.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_signing_MsgCertificateChain.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_signing_MsgCertificateChainDep.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_signing_MsgCertificateChainDep.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_signing_MsgEcdsaCertificate.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_signing_MsgEcdsaCertificate.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_signing_MsgEcdsaSignature.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_signing_MsgEcdsaSignature.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_signing_MsgEcdsaSignatureDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_signing_MsgEcdsaSignatureDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_signing_MsgEcdsaSignatureDepB.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_signing_MsgEcdsaSignatureDepB.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_signing_MsgEd25519CertificateDep.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_signing_MsgEd25519CertificateDep.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_signing_MsgEd25519SignatureDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_signing_MsgEd25519SignatureDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_signing_MsgEd25519SignatureDepB.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_signing_MsgEd25519SignatureDepB.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_solution_meta_MsgSolnMeta.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_solution_meta_MsgSolnMeta.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_solution_meta_MsgSolnMetaDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_solution_meta_MsgSolnMetaDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrCodeBiases.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrCodeBiases.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrCodePhaseBiasesBounds.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrCodePhaseBiasesBounds.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrGridDefinitionDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrGridDefinitionDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrGriddedCorrection.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrGriddedCorrection.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrGriddedCorrectionBounds.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrGriddedCorrectionBounds.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrGriddedCorrectionDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrGriddedCorrectionDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrGriddedCorrectionNoStdDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrGriddedCorrectionNoStdDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrOrbitClock.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrOrbitClock.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrOrbitClockBounds.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrOrbitClockBounds.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrOrbitClockBoundsDegradation.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrOrbitClockBoundsDegradation.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrOrbitClockDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrOrbitClockDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrPhaseBiases.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrPhaseBiases.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrSatelliteApc.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrSatelliteApc.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrSatelliteApcDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrSatelliteApcDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrStecCorrection.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrStecCorrection.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrStecCorrectionDep.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrStecCorrectionDep.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrStecCorrectionDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrStecCorrectionDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrTileDefinition.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrTileDefinition.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrTileDefinitionDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrTileDefinitionDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrTileDefinitionDepB.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_ssr_MsgSsrTileDefinitionDepB.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_system_MsgCsacTelemetry.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_system_MsgCsacTelemetry.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_system_MsgCsacTelemetryLabels.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_system_MsgCsacTelemetryLabels.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_system_MsgDgnssStatus.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_system_MsgDgnssStatus.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_system_MsgGnssTimeOffset.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_system_MsgGnssTimeOffset.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_system_MsgGroupMeta.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_system_MsgGroupMeta.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_system_MsgHeartbeat.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_system_MsgHeartbeat.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_system_MsgInsStatus.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_system_MsgInsStatus.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_system_MsgInsUpdates.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_system_MsgInsUpdates.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_system_MsgPpsTime.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_system_MsgPpsTime.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_system_MsgSensorAidEvent.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_system_MsgSensorAidEvent.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_system_MsgStartup.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_system_MsgStartup.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_system_MsgStatusJournal.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_system_MsgStatusJournal.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_system_MsgStatusReport.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_system_MsgStatusReport.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_telemetry_MsgTelSv.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_telemetry_MsgTelSv.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_tracking_MsgMeasurementState.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_tracking_MsgMeasurementState.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_tracking_MsgTrackingIq.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_tracking_MsgTrackingIq.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_tracking_MsgTrackingIqDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_tracking_MsgTrackingIqDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_tracking_MsgTrackingIqDepB.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_tracking_MsgTrackingIqDepB.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_tracking_MsgTrackingState.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_tracking_MsgTrackingState.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_tracking_MsgTrackingStateDepB.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_tracking_MsgTrackingStateDepB.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_tracking_MsgTrackingStateDetailedDep.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_tracking_MsgTrackingStateDetailedDep.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_tracking_MsgTrackingStateDetailedDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_tracking_MsgTrackingStateDetailedDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_tracking_MsgtrackingStateDepA.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_tracking_MsgtrackingStateDepA.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_user_MsgUserData.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_user_MsgUserData.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_vehicle_MsgOdometry.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_vehicle_MsgOdometry.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_vehicle_MsgWheeltick.py
+++ b/kaitai/python/kaitai_sbp/tests/test_auto_check_sbp_vehicle_MsgWheeltick.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_benchmark_lite.py
+++ b/kaitai/python/kaitai_sbp/tests/test_benchmark_lite.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/kaitai/python/kaitai_sbp/tests/test_parsers.py
+++ b/kaitai/python/kaitai_sbp/tests/test_parsers.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/proto/acquisition.proto
+++ b/proto/acquisition.proto
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/proto/bootload.proto
+++ b/proto/bootload.proto
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/proto/ext_events.proto
+++ b/proto/ext_events.proto
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/proto/file_io.proto
+++ b/proto/file_io.proto
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/proto/flash.proto
+++ b/proto/flash.proto
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/proto/gnss.proto
+++ b/proto/gnss.proto
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/proto/imu.proto
+++ b/proto/imu.proto
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/proto/integrity.proto
+++ b/proto/integrity.proto
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/proto/linux.proto
+++ b/proto/linux.proto
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/proto/logging.proto
+++ b/proto/logging.proto
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/proto/mag.proto
+++ b/proto/mag.proto
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/proto/navigation.proto
+++ b/proto/navigation.proto
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/proto/ndb.proto
+++ b/proto/ndb.proto
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/proto/observation.proto
+++ b/proto/observation.proto
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/proto/orientation.proto
+++ b/proto/orientation.proto
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/proto/piksi.proto
+++ b/proto/piksi.proto
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/proto/profiling.proto
+++ b/proto/profiling.proto
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/proto/sbas.proto
+++ b/proto/sbas.proto
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/proto/settings.proto
+++ b/proto/settings.proto
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/proto/signing.proto
+++ b/proto/signing.proto
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/proto/solution_meta.proto
+++ b/proto/solution_meta.proto
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/proto/ssr.proto
+++ b/proto/ssr.proto
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/proto/system.proto
+++ b/proto/system.proto
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/proto/telemetry.proto
+++ b/proto/telemetry.proto
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/proto/tracking.proto
+++ b/proto/tracking.proto
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/proto/user.proto
+++ b/proto/user.proto
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/proto/vehicle.proto
+++ b/proto/vehicle.proto
@@ -3,7 +3,7 @@
  * Contact: https://support.swiftnav.com
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/bench/crc.py
+++ b/python/bench/crc.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/bench/memory.py
+++ b/python/bench/memory.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/__init__.py
+++ b/python/sbp/__init__.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/acquisition.py
+++ b/python/sbp/acquisition.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/bootload.py
+++ b/python/sbp/bootload.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/client/__init__.py
+++ b/python/sbp/client/__init__.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/client/drivers/base_driver.py
+++ b/python/sbp/client/drivers/base_driver.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/client/drivers/cdc_driver.py
+++ b/python/sbp/client/drivers/cdc_driver.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/client/drivers/file_driver.py
+++ b/python/sbp/client/drivers/file_driver.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/client/drivers/network_drivers.py
+++ b/python/sbp/client/drivers/network_drivers.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/client/drivers/pyftdi_driver.py
+++ b/python/sbp/client/drivers/pyftdi_driver.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/client/drivers/pyserial_driver.py
+++ b/python/sbp/client/drivers/pyserial_driver.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/client/examples/simple.py
+++ b/python/sbp/client/examples/simple.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/client/examples/tcp.py
+++ b/python/sbp/client/examples/tcp.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/client/examples/udp.py
+++ b/python/sbp/client/examples/udp.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/client/forwarder.py
+++ b/python/sbp/client/forwarder.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/client/framer.py
+++ b/python/sbp/client/framer.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/client/handler.py
+++ b/python/sbp/client/handler.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/client/loggers/base_logger.py
+++ b/python/sbp/client/loggers/base_logger.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/client/loggers/json_logger.py
+++ b/python/sbp/client/loggers/json_logger.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/client/loggers/null_logger.py
+++ b/python/sbp/client/loggers/null_logger.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/client/loggers/rotating_logger.py
+++ b/python/sbp/client/loggers/rotating_logger.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/client/loggers/udp_logger.py
+++ b/python/sbp/client/loggers/udp_logger.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/client/util/fftmonitor.py
+++ b/python/sbp/client/util/fftmonitor.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/client/util/settingmonitor.py
+++ b/python/sbp/client/util/settingmonitor.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/constants.py
+++ b/python/sbp/constants.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/ext_events.py
+++ b/python/sbp/ext_events.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/file_io.py
+++ b/python/sbp/file_io.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/flash.py
+++ b/python/sbp/flash.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/gnss.py
+++ b/python/sbp/gnss.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/imu.py
+++ b/python/sbp/imu.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/integrity.py
+++ b/python/sbp/integrity.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/linux.py
+++ b/python/sbp/linux.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/logging.py
+++ b/python/sbp/logging.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/mag.py
+++ b/python/sbp/mag.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/msg.py
+++ b/python/sbp/msg.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/navigation.py
+++ b/python/sbp/navigation.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/ndb.py
+++ b/python/sbp/ndb.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/observation.py
+++ b/python/sbp/observation.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/orientation.py
+++ b/python/sbp/orientation.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/piksi.py
+++ b/python/sbp/piksi.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/profiling.py
+++ b/python/sbp/profiling.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/sbas.py
+++ b/python/sbp/sbas.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/settings.py
+++ b/python/sbp/settings.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/signing.py
+++ b/python/sbp/signing.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/solution_meta.py
+++ b/python/sbp/solution_meta.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/ssr.py
+++ b/python/sbp/ssr.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/system.py
+++ b/python/sbp/system.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/table.py
+++ b/python/sbp/table.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/telemetry.py
+++ b/python/sbp/telemetry.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/tracking.py
+++ b/python/sbp/tracking.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/user.py
+++ b/python/sbp/user.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/utils.py
+++ b/python/sbp/utils.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/sbp/vehicle.py
+++ b/python/sbp/vehicle.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/tests/sbp/client/test_driver.py
+++ b/python/tests/sbp/client/test_driver.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/tests/sbp/client/test_handler.py
+++ b/python/tests/sbp/client/test_handler.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/tests/sbp/client/test_logger.py
+++ b/python/tests/sbp/client/test_logger.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/tests/sbp/test_deprecation.py
+++ b/python/tests/sbp/test_deprecation.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/tests/sbp/test_messages.py
+++ b/python/tests/sbp/test_messages.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/tests/sbp/test_sbp2json.py
+++ b/python/tests/sbp/test_sbp2json.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/tests/sbp/test_table.py
+++ b/python/tests/sbp/test_table.py
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/python/tests/sbp/utils.py
+++ b/python/tests/sbp/utils.py
@@ -3,7 +3,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/src/messages/acquisition.rs
+++ b/rust/sbp/src/messages/acquisition.rs
@@ -2,7 +2,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/src/messages/bootload.rs
+++ b/rust/sbp/src/messages/bootload.rs
@@ -2,7 +2,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/src/messages/ext_events.rs
+++ b/rust/sbp/src/messages/ext_events.rs
@@ -2,7 +2,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/src/messages/file_io.rs
+++ b/rust/sbp/src/messages/file_io.rs
@@ -2,7 +2,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/src/messages/flash.rs
+++ b/rust/sbp/src/messages/flash.rs
@@ -2,7 +2,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/src/messages/gnss.rs
+++ b/rust/sbp/src/messages/gnss.rs
@@ -2,7 +2,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/src/messages/imu.rs
+++ b/rust/sbp/src/messages/imu.rs
@@ -2,7 +2,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/src/messages/integrity.rs
+++ b/rust/sbp/src/messages/integrity.rs
@@ -2,7 +2,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/src/messages/linux.rs
+++ b/rust/sbp/src/messages/linux.rs
@@ -2,7 +2,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/src/messages/logging.rs
+++ b/rust/sbp/src/messages/logging.rs
@@ -2,7 +2,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/src/messages/mag.rs
+++ b/rust/sbp/src/messages/mag.rs
@@ -2,7 +2,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/src/messages/mod.rs
+++ b/rust/sbp/src/messages/mod.rs
@@ -2,7 +2,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/src/messages/navigation.rs
+++ b/rust/sbp/src/messages/navigation.rs
@@ -2,7 +2,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/src/messages/ndb.rs
+++ b/rust/sbp/src/messages/ndb.rs
@@ -2,7 +2,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/src/messages/observation.rs
+++ b/rust/sbp/src/messages/observation.rs
@@ -2,7 +2,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/src/messages/orientation.rs
+++ b/rust/sbp/src/messages/orientation.rs
@@ -2,7 +2,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/src/messages/piksi.rs
+++ b/rust/sbp/src/messages/piksi.rs
@@ -2,7 +2,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/src/messages/profiling.rs
+++ b/rust/sbp/src/messages/profiling.rs
@@ -2,7 +2,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/src/messages/sbas.rs
+++ b/rust/sbp/src/messages/sbas.rs
@@ -2,7 +2,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/src/messages/settings.rs
+++ b/rust/sbp/src/messages/settings.rs
@@ -2,7 +2,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/src/messages/signing.rs
+++ b/rust/sbp/src/messages/signing.rs
@@ -2,7 +2,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/src/messages/solution_meta.rs
+++ b/rust/sbp/src/messages/solution_meta.rs
@@ -2,7 +2,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/src/messages/ssr.rs
+++ b/rust/sbp/src/messages/ssr.rs
@@ -2,7 +2,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/src/messages/system.rs
+++ b/rust/sbp/src/messages/system.rs
@@ -2,7 +2,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/src/messages/telemetry.rs
+++ b/rust/sbp/src/messages/telemetry.rs
@@ -2,7 +2,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/src/messages/tracking.rs
+++ b/rust/sbp/src/messages/tracking.rs
@@ -2,7 +2,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/src/messages/user.rs
+++ b/rust/sbp/src/messages/user.rs
@@ -2,7 +2,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/src/messages/vehicle.rs
+++ b/rust/sbp/src/messages/vehicle.rs
@@ -2,7 +2,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_acquisition_msg_acq_result.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_acquisition_msg_acq_result.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_acquisition_msg_acq_result_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_acquisition_msg_acq_result_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_acquisition_msg_acq_result_dep_b.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_acquisition_msg_acq_result_dep_b.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_acquisition_msg_acq_result_dep_c.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_acquisition_msg_acq_result_dep_c.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_acquisition_msg_acq_sv_profile.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_acquisition_msg_acq_sv_profile.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_acquisition_msg_acq_sv_profile_dep.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_acquisition_msg_acq_sv_profile_dep.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_bootload_msg_bootloader_handshake_req.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_bootload_msg_bootloader_handshake_req.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_bootload_msg_bootloader_handshake_resp.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_bootload_msg_bootloader_handshake_resp.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_bootload_msg_bootloader_jumpto_app.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_bootload_msg_bootloader_jumpto_app.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_bootload_msg_nap_device_dna_req.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_bootload_msg_nap_device_dna_req.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_bootload_msg_nap_device_dna_resp.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_bootload_msg_nap_device_dna_resp.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_ext_events_msg_ext_event.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_ext_events_msg_ext_event.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_file_io_msg_fileio_config_req.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_file_io_msg_fileio_config_req.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_file_io_msg_fileio_config_resp.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_file_io_msg_fileio_config_resp.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_file_io_msg_fileio_read_dir_req.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_file_io_msg_fileio_read_dir_req.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_file_io_msg_fileio_read_dir_resp.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_file_io_msg_fileio_read_dir_resp.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_file_io_msg_fileio_read_req.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_file_io_msg_fileio_read_req.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_file_io_msg_fileio_read_resp.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_file_io_msg_fileio_read_resp.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_file_io_msg_fileio_remove.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_file_io_msg_fileio_remove.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_file_io_msg_fileio_write_resp.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_file_io_msg_fileio_write_resp.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_flash_msg_flash_done.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_flash_msg_flash_done.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_flash_msg_flash_erase.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_flash_msg_flash_erase.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_flash_msg_flash_program.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_flash_msg_flash_program.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_flash_msg_flash_read_req.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_flash_msg_flash_read_req.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_flash_msg_flash_read_resp.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_flash_msg_flash_read_resp.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_flash_msg_m25_flash_write_status.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_flash_msg_m25_flash_write_status.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_flash_msg_stm_flash_lock_sector.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_flash_msg_stm_flash_lock_sector.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_flash_msg_stm_flash_unlock_sector.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_flash_msg_stm_flash_unlock_sector.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_flash_msg_stm_unique_id_req.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_flash_msg_stm_unique_id_req.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_flash_msg_stm_unique_id_resp.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_flash_msg_stm_unique_id_resp.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_imu_msg_imu_aux.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_imu_msg_imu_aux.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_imu_msg_imu_raw.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_imu_msg_imu_raw.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_integrity_msg_acknowledge.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_integrity_msg_acknowledge.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_integrity_msg_ssr_flag_high_level.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_integrity_msg_ssr_flag_high_level.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_integrity_msg_ssr_flag_iono_grid_point_sat_los.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_integrity_msg_ssr_flag_iono_grid_point_sat_los.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_integrity_msg_ssr_flag_iono_grid_points.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_integrity_msg_ssr_flag_iono_grid_points.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_integrity_msg_ssr_flag_iono_tile_sat_los.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_integrity_msg_ssr_flag_iono_tile_sat_los.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_integrity_msg_ssr_flag_satellites.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_integrity_msg_ssr_flag_satellites.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_integrity_msg_ssr_flag_tropo_grid_points.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_integrity_msg_ssr_flag_tropo_grid_points.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_linux_msg_linux_cpu_state.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_linux_msg_linux_cpu_state.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_linux_msg_linux_cpu_state_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_linux_msg_linux_cpu_state_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_linux_msg_linux_mem_state.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_linux_msg_linux_mem_state.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_linux_msg_linux_mem_state_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_linux_msg_linux_mem_state_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_linux_msg_linux_process_fd_count.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_linux_msg_linux_process_fd_count.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_linux_msg_linux_process_fd_summary.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_linux_msg_linux_process_fd_summary.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_linux_msg_linux_process_socket_counts.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_linux_msg_linux_process_socket_counts.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_linux_msg_linux_process_socket_queues.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_linux_msg_linux_process_socket_queues.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_linux_msg_linux_socket_usage.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_linux_msg_linux_socket_usage.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_linux_msg_linux_sys_state.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_linux_msg_linux_sys_state.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_linux_msg_linux_sys_state_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_linux_msg_linux_sys_state_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_logging_msg_fwd.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_logging_msg_fwd.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_logging_msg_log.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_logging_msg_log.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_logging_msg_print_dep.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_logging_msg_print_dep.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_mag_msg_mag_raw.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_mag_msg_mag_raw.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_age_corrections.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_age_corrections.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_baseline_ecef.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_baseline_ecef.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_baseline_ecef_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_baseline_ecef_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_baseline_heading_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_baseline_heading_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_baseline_ned.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_baseline_ned.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_baseline_ned_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_baseline_ned_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_dops.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_dops.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_dops_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_dops_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_gps_time.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_gps_time.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_gps_time_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_gps_time_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_gps_time_gnss.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_gps_time_gnss.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_pos_ecef.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_pos_ecef.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_pos_ecef_cov.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_pos_ecef_cov.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_pos_ecef_cov_gnss.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_pos_ecef_cov_gnss.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_pos_ecef_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_pos_ecef_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_pos_ecefgnss.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_pos_ecefgnss.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_pos_llh.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_pos_llh.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_pos_llh_acc.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_pos_llh_acc.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_pos_llh_cov.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_pos_llh_cov.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_pos_llh_cov_gnss.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_pos_llh_cov_gnss.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_pos_llh_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_pos_llh_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_pos_llh_gnss.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_pos_llh_gnss.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_pose_relative.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_pose_relative.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_protection_level.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_protection_level.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_protection_level_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_protection_level_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_reference_frame_param.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_reference_frame_param.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_utc_leap_second.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_utc_leap_second.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_utc_time.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_utc_time.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_utc_time_gnss.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_utc_time_gnss.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_vel_body.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_vel_body.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_vel_cog.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_vel_cog.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_vel_ecef.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_vel_ecef.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_vel_ecef_cov.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_vel_ecef_cov.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_vel_ecef_cov_gnss.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_vel_ecef_cov_gnss.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_vel_ecef_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_vel_ecef_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_vel_ecef_gnss.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_vel_ecef_gnss.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_vel_ned.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_vel_ned.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_vel_ned_cov_gnss.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_vel_ned_cov_gnss.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_vel_ned_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_vel_ned_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_vel_ned_gnss.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_vel_ned_gnss.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_vel_nedcov.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_navigation_msg_vel_nedcov.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_ndb_msg_ndb_event.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_ndb_msg_ndb_event.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_almanac_glo.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_almanac_glo.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_almanac_glo_dep.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_almanac_glo_dep.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_almanac_gps.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_almanac_gps.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_almanac_gps_dep.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_almanac_gps_dep.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_base_pos_ecef.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_base_pos_ecef.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_base_pos_llh.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_base_pos_llh.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_bds.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_bds.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_dep_b.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_dep_b.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_dep_c.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_dep_c.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_dep_d.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_dep_d.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_gal.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_gal.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_gal_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_gal_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_glo.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_glo.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_glo_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_glo_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_glo_dep_b.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_glo_dep_b.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_glo_dep_c.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_glo_dep_c.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_glo_dep_d.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_glo_dep_d.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_gps.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_gps.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_gps_dep_e.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_gps_dep_e.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_gps_dep_f.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_gps_dep_f.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_qzss.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_qzss.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_sbas.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_sbas.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_sbas_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_sbas_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_sbas_dep_b.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_ephemeris_sbas_dep_b.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_glo_biases.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_glo_biases.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_gnss_capb.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_gnss_capb.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_group_delay.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_group_delay.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_group_delay_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_group_delay_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_group_delay_dep_b.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_group_delay_dep_b.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_iono.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_iono.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_obs.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_obs.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_obs_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_obs_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_obs_dep_b.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_obs_dep_b.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_obs_dep_c.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_obs_dep_c.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_osr.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_osr.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_sv_az_el.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_sv_az_el.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_observation_msg_sv_configuration_gps_dep.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_observation_msg_sv_configuration_gps_dep.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_orientation_msg_angular_rate.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_orientation_msg_angular_rate.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_orientation_msg_baseline_heading.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_orientation_msg_baseline_heading.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_orientation_msg_orient_euler.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_orientation_msg_orient_euler.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_orientation_msg_orient_quat.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_orientation_msg_orient_quat.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_almanac.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_almanac.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_cell_modem_status.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_cell_modem_status.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_command_output.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_command_output.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_command_req.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_command_req.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_command_resp.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_command_resp.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_cw_results.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_cw_results.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_cw_start.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_cw_start.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_device_monitor.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_device_monitor.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_front_end_gain.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_front_end_gain.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_iar_state.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_iar_state.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_init_base_dep.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_init_base_dep.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_mask_satellite.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_mask_satellite.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_mask_satellite_dep.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_mask_satellite_dep.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_network_bandwidth_usage.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_network_bandwidth_usage.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_network_state_req.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_network_state_req.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_network_state_resp.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_network_state_resp.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_reset.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_reset.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_reset_dep.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_reset_dep.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_reset_filters.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_reset_filters.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_set_time.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_set_time.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_specan.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_specan.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_specan_dep.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_specan_dep.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_thread_state.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_thread_state.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_uart_state.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_uart_state.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_uart_state_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_piksi_msg_uart_state_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_profiling_msg_measurement_point.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_profiling_msg_measurement_point.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_profiling_msg_profiling_resource_counter.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_profiling_msg_profiling_resource_counter.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_profiling_msg_profiling_system_info.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_profiling_msg_profiling_system_info.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_profiling_msg_profiling_thread_info.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_profiling_msg_profiling_thread_info.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_sbas_msg_sbas_raw.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_sbas_msg_sbas_raw.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_settings_msg_settings_read_by_index_done.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_settings_msg_settings_read_by_index_done.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_settings_msg_settings_read_by_index_req.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_settings_msg_settings_read_by_index_req.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_settings_msg_settings_read_by_index_resp.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_settings_msg_settings_read_by_index_resp.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_settings_msg_settings_read_req.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_settings_msg_settings_read_req.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_settings_msg_settings_read_resp.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_settings_msg_settings_read_resp.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_settings_msg_settings_register.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_settings_msg_settings_register.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_settings_msg_settings_register_resp.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_settings_msg_settings_register_resp.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_settings_msg_settings_save.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_settings_msg_settings_save.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_settings_msg_settings_write.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_settings_msg_settings_write.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_settings_msg_settings_write_resp.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_settings_msg_settings_write_resp.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_signing_msg_certificate_chain.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_signing_msg_certificate_chain.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_signing_msg_certificate_chain_dep.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_signing_msg_certificate_chain_dep.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_signing_msg_ecdsa_certificate.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_signing_msg_ecdsa_certificate.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_signing_msg_ecdsa_signature.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_signing_msg_ecdsa_signature.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_signing_msg_ecdsa_signature_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_signing_msg_ecdsa_signature_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_signing_msg_ecdsa_signature_dep_b.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_signing_msg_ecdsa_signature_dep_b.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_signing_msg_ed25519_certificate_dep.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_signing_msg_ed25519_certificate_dep.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_signing_msg_ed25519_signature_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_signing_msg_ed25519_signature_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_signing_msg_ed25519_signature_dep_b.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_signing_msg_ed25519_signature_dep_b.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_solution_meta_msg_soln_meta.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_solution_meta_msg_soln_meta.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_solution_meta_msg_soln_meta_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_solution_meta_msg_soln_meta_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_code_biases.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_code_biases.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_code_phase_biases_bounds.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_code_phase_biases_bounds.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_grid_definition_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_grid_definition_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_gridded_correction.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_gridded_correction.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_gridded_correction_bounds.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_gridded_correction_bounds.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_gridded_correction_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_gridded_correction_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_gridded_correction_no_std_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_gridded_correction_no_std_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_orbit_clock.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_orbit_clock.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_orbit_clock_bounds.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_orbit_clock_bounds.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_orbit_clock_bounds_degradation.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_orbit_clock_bounds_degradation.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_orbit_clock_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_orbit_clock_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_phase_biases.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_phase_biases.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_satellite_apc.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_satellite_apc.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_satellite_apc_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_satellite_apc_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_stec_correction.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_stec_correction.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_stec_correction_dep.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_stec_correction_dep.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_stec_correction_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_stec_correction_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_tile_definition.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_tile_definition.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_tile_definition_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_tile_definition_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_tile_definition_dep_b.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_ssr_msg_ssr_tile_definition_dep_b.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_system_msg_csac_telemetry.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_system_msg_csac_telemetry.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_system_msg_csac_telemetry_labels.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_system_msg_csac_telemetry_labels.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_system_msg_dgnss_status.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_system_msg_dgnss_status.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_system_msg_gnss_time_offset.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_system_msg_gnss_time_offset.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_system_msg_group_meta.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_system_msg_group_meta.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_system_msg_heartbeat.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_system_msg_heartbeat.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_system_msg_ins_status.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_system_msg_ins_status.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_system_msg_ins_updates.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_system_msg_ins_updates.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_system_msg_pps_time.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_system_msg_pps_time.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_system_msg_sensor_aid_event.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_system_msg_sensor_aid_event.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_system_msg_startup.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_system_msg_startup.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_system_msg_status_journal.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_system_msg_status_journal.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_system_msg_status_report.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_system_msg_status_report.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_telemetry_msg_tel_sv.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_telemetry_msg_tel_sv.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_tracking_msg_measurement_state.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_tracking_msg_measurement_state.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_tracking_msg_tracking_iq.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_tracking_msg_tracking_iq.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_tracking_msg_tracking_iq_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_tracking_msg_tracking_iq_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_tracking_msg_tracking_iq_dep_b.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_tracking_msg_tracking_iq_dep_b.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_tracking_msg_tracking_state.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_tracking_msg_tracking_state.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_tracking_msg_tracking_state_dep_b.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_tracking_msg_tracking_state_dep_b.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_tracking_msg_tracking_state_detailed_dep.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_tracking_msg_tracking_state_detailed_dep.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_tracking_msg_tracking_state_detailed_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_tracking_msg_tracking_state_detailed_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_tracking_msgtracking_state_dep_a.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_tracking_msgtracking_state_dep_a.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_user_msg_user_data.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_user_msg_user_data.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_vehicle_msg_odometry.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_vehicle_msg_odometry.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/auto_check_sbp_vehicle_msg_wheeltick.rs
+++ b/rust/sbp/tests/integration/auto_check_sbp_vehicle_msg_wheeltick.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/rust/sbp/tests/integration/main.rs
+++ b/rust/sbp/tests/integration/main.rs
@@ -3,7 +3,7 @@
 // Contact: https://support.swiftnav.com
 //
 // This source is subject to the license found in the file 'LICENSE' which must
-// be be distributed together with this source. All other rights reserved.
+// be distributed together with this source. All other rights reserved.
 //
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 // EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/example/yaml/example.yaml
+++ b/spec/example/yaml/example.yaml
@@ -76,7 +76,7 @@ definitions:
                         - 0: Float RTK
                         - 1: Fixed RTK
 
- # Defitions lacking an id are not treated as SBP messages, but are
+ # Definitions lacking an id are not treated as SBP messages, but are
  # structured types that can be embedded into SBP definitions. Here,
  # UARTChannel is a struct composed of primitive types...
 

--- a/spec/validation/current/field_name_changed/observation.yaml
+++ b/spec/validation/current/field_name_changed/observation.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/validation/current/field_order_changed/observation.yaml
+++ b/spec/validation/current/field_order_changed/observation.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/validation/current/field_type_changed/observation.yaml
+++ b/spec/validation/current/field_type_changed/observation.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/validation/current/message_id_changed/observation.yaml
+++ b/spec/validation/current/message_id_changed/observation.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/validation/current/message_id_changed_dep/observation.yaml
+++ b/spec/validation/current/message_id_changed_dep/observation.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/validation/current/message_id_changed_dep/ssr.yaml
+++ b/spec/validation/current/message_id_changed_dep/ssr.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/validation/current/message_id_changed_dep_fail/observation.yaml
+++ b/spec/validation/current/message_id_changed_dep_fail/observation.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/validation/current/new_field_appended/observation.yaml
+++ b/spec/validation/current/new_field_appended/observation.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/validation/current/new_message_added/observation.yaml
+++ b/spec/validation/current/new_message_added/observation.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/validation/current/new_package_added/navigation.yaml
+++ b/spec/validation/current/new_package_added/navigation.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/validation/current/new_package_added/observation.yaml
+++ b/spec/validation/current/new_package_added/observation.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/validation/previous/field_name_changed/observation.yaml
+++ b/spec/validation/previous/field_name_changed/observation.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/validation/previous/field_order_changed/observation.yaml
+++ b/spec/validation/previous/field_order_changed/observation.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/validation/previous/field_type_changed/observation.yaml
+++ b/spec/validation/previous/field_type_changed/observation.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/validation/previous/message_id_changed/observation.yaml
+++ b/spec/validation/previous/message_id_changed/observation.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/validation/previous/message_id_changed_dep/observation.yaml
+++ b/spec/validation/previous/message_id_changed_dep/observation.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/validation/previous/message_id_changed_dep/ssr.yaml
+++ b/spec/validation/previous/message_id_changed_dep/ssr.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/validation/previous/message_id_changed_dep_fail/observation.yaml
+++ b/spec/validation/previous/message_id_changed_dep_fail/observation.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/validation/previous/new_field_appended/observation.yaml
+++ b/spec/validation/previous/new_field_appended/observation.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/validation/previous/new_message_added/observation.yaml
+++ b/spec/validation/previous/new_message_added/observation.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/validation/previous/new_package_added/observation.yaml
+++ b/spec/validation/previous/new_package_added/observation.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/validation/previous/remove_package/observation.yaml
+++ b/spec/validation/previous/remove_package/observation.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/yaml/swiftnav/sbp/acquisition.yaml
+++ b/spec/yaml/swiftnav/sbp/acquisition.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/yaml/swiftnav/sbp/base.yaml
+++ b/spec/yaml/swiftnav/sbp/base.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/yaml/swiftnav/sbp/bootload.yaml
+++ b/spec/yaml/swiftnav/sbp/bootload.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/yaml/swiftnav/sbp/ext_events.yaml
+++ b/spec/yaml/swiftnav/sbp/ext_events.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/yaml/swiftnav/sbp/file_io.yaml
+++ b/spec/yaml/swiftnav/sbp/file_io.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/yaml/swiftnav/sbp/flash.yaml
+++ b/spec/yaml/swiftnav/sbp/flash.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/yaml/swiftnav/sbp/gnss.yaml
+++ b/spec/yaml/swiftnav/sbp/gnss.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/yaml/swiftnav/sbp/imu.yaml
+++ b/spec/yaml/swiftnav/sbp/imu.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/yaml/swiftnav/sbp/integrity.yaml
+++ b/spec/yaml/swiftnav/sbp/integrity.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/yaml/swiftnav/sbp/linux.yaml
+++ b/spec/yaml/swiftnav/sbp/linux.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/yaml/swiftnav/sbp/logging.yaml
+++ b/spec/yaml/swiftnav/sbp/logging.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/yaml/swiftnav/sbp/mag.yaml
+++ b/spec/yaml/swiftnav/sbp/mag.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/yaml/swiftnav/sbp/navigation.yaml
+++ b/spec/yaml/swiftnav/sbp/navigation.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/yaml/swiftnav/sbp/ndb.yaml
+++ b/spec/yaml/swiftnav/sbp/ndb.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/yaml/swiftnav/sbp/observation.yaml
+++ b/spec/yaml/swiftnav/sbp/observation.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/yaml/swiftnav/sbp/orientation.yaml
+++ b/spec/yaml/swiftnav/sbp/orientation.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/yaml/swiftnav/sbp/piksi.yaml
+++ b/spec/yaml/swiftnav/sbp/piksi.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/yaml/swiftnav/sbp/profiling.yaml
+++ b/spec/yaml/swiftnav/sbp/profiling.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/yaml/swiftnav/sbp/sbas.yaml
+++ b/spec/yaml/swiftnav/sbp/sbas.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/yaml/swiftnav/sbp/settings.yaml
+++ b/spec/yaml/swiftnav/sbp/settings.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/yaml/swiftnav/sbp/signing.yaml
+++ b/spec/yaml/swiftnav/sbp/signing.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/yaml/swiftnav/sbp/solution_meta.yaml
+++ b/spec/yaml/swiftnav/sbp/solution_meta.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/yaml/swiftnav/sbp/ssr.yaml
+++ b/spec/yaml/swiftnav/sbp/ssr.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/yaml/swiftnav/sbp/system.yaml
+++ b/spec/yaml/swiftnav/sbp/system.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/yaml/swiftnav/sbp/tracking.yaml
+++ b/spec/yaml/swiftnav/sbp/tracking.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/yaml/swiftnav/sbp/types.yaml
+++ b/spec/yaml/swiftnav/sbp/types.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/yaml/swiftnav/sbp/user.yaml
+++ b/spec/yaml/swiftnav/sbp/user.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/spec/yaml/swiftnav/sbp/vehicle.yaml
+++ b/spec/yaml/swiftnav/sbp/vehicle.yaml
@@ -2,7 +2,7 @@
 # Contact: https://support.swiftnav.com
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED


### PR DESCRIPTION
# Description

While reading over libsbp for another task, realized that pretty much all the license files had the grammar mistake of an extra `be`. To avoid further copy/paste errors, I've tried to fix them all.

Also realized that when launching cmake I kept getting warnings due to not prefixing the `sbp` library reference with `swiftnav::` (ex: `c/test/string/CMakeLists.txt`), fix that as well.

# API compatibility

No compatability issues

## API compatibility plan

N/A

# JIRA Reference

None