### PR TITLE
fix rust lints

### DIFF
--- a/c/include/libsbp/observation/AlmanacCommonContent.h
+++ b/c/include/libsbp/observation/AlmanacCommonContent.h
@@ -73,6 +73,7 @@ typedef struct {
    *   - bits 0-4: Signal health status. See IS-GPS-200H
    *     Table 20-VIII. Codes for Health of SV Signal
    *     Components.
+   *
    * Satellite health status for GLO (see GLO ICD 5.1 table 5.1 for details):
    *   - bit 0: C(n), "unhealthy" flag that is transmitted within
    *     non-immediate data and indicates overall constellation status

--- a/c/include/libsbp/observation/AlmanacCommonContentDep.h
+++ b/c/include/libsbp/observation/AlmanacCommonContentDep.h
@@ -73,6 +73,7 @@ typedef struct {
    *   - bits 0-4: Signal health status. See IS-GPS-200H
    *     Table 20-VIII. Codes for Health of SV Signal
    *     Components.
+   *
    * Satellite health status for GLO (see GLO ICD 5.1 table 5.1 for details):
    *   - bit 0: C(n), "unhealthy" flag that is transmitted within
    *     non-immediate data and indicates overall constellation status

--- a/haskell/src/SwiftNav/SBP/Observation.hs
+++ b/haskell/src/SwiftNav/SBP/Observation.hs
@@ -2731,6 +2731,7 @@ data AlmanacCommonContent = AlmanacCommonContent
     --   - bits 0-4: Signal health status. See IS-GPS-200H
     --     Table 20-VIII. Codes for Health of SV Signal
     --     Components.
+    --
     -- Satellite health status for GLO (see GLO ICD 5.1 table 5.1 for
     -- details):
     --   - bit 0: C(n), "unhealthy" flag that is transmitted within
@@ -2781,6 +2782,7 @@ data AlmanacCommonContentDep = AlmanacCommonContentDep
     --   - bits 0-4: Signal health status. See IS-GPS-200H
     --     Table 20-VIII. Codes for Health of SV Signal
     --     Components.
+    --
     -- Satellite health status for GLO (see GLO ICD 5.1 table 5.1 for
     -- details):
     --   - bit 0: C(n), "unhealthy" flag that is transmitted within

--- a/java/src/com/swiftnav/sbp/observation/AlmanacCommonContent.java
+++ b/java/src/com/swiftnav/sbp/observation/AlmanacCommonContent.java
@@ -40,12 +40,13 @@ public class AlmanacCommonContent extends SBPStruct {
     /**
      * Satellite health status for GPS: - bits 5-7: NAV data health status. See IS-GPS-200H Table
      * 20-VII: NAV Data Health Indications. - bits 0-4: Signal health status. See IS-GPS-200H Table
-     * 20-VIII. Codes for Health of SV Signal Components. Satellite health status for GLO (see GLO
-     * ICD 5.1 table 5.1 for details): - bit 0: C(n), "unhealthy" flag that is transmitted within
-     * non-immediate data and indicates overall constellation status at the moment of almanac
-     * uploading. '0' indicates malfunction of n-satellite. '1' indicates that n-satellite is
-     * operational. - bit 1: Bn(ln), '0' indicates the satellite is operational and suitable for
-     * navigation.
+     * 20-VIII. Codes for Health of SV Signal Components.
+     *
+     * <p>Satellite health status for GLO (see GLO ICD 5.1 table 5.1 for details): - bit 0: C(n),
+     * "unhealthy" flag that is transmitted within non-immediate data and indicates overall
+     * constellation status at the moment of almanac uploading. '0' indicates malfunction of
+     * n-satellite. '1' indicates that n-satellite is operational. - bit 1: Bn(ln), '0' indicates
+     * the satellite is operational and suitable for navigation.
      */
     public int health_bits;
 

--- a/java/src/com/swiftnav/sbp/observation/AlmanacCommonContentDep.java
+++ b/java/src/com/swiftnav/sbp/observation/AlmanacCommonContentDep.java
@@ -40,12 +40,13 @@ public class AlmanacCommonContentDep extends SBPStruct {
     /**
      * Satellite health status for GPS: - bits 5-7: NAV data health status. See IS-GPS-200H Table
      * 20-VII: NAV Data Health Indications. - bits 0-4: Signal health status. See IS-GPS-200H Table
-     * 20-VIII. Codes for Health of SV Signal Components. Satellite health status for GLO (see GLO
-     * ICD 5.1 table 5.1 for details): - bit 0: C(n), "unhealthy" flag that is transmitted within
-     * non-immediate data and indicates overall constellation status at the moment of almanac
-     * uploading. '0' indicates malfunction of n-satellite. '1' indicates that n-satellite is
-     * operational. - bit 1: Bn(ln), '0' indicates the satellite is operational and suitable for
-     * navigation.
+     * 20-VIII. Codes for Health of SV Signal Components.
+     *
+     * <p>Satellite health status for GLO (see GLO ICD 5.1 table 5.1 for details): - bit 0: C(n),
+     * "unhealthy" flag that is transmitted within non-immediate data and indicates overall
+     * constellation status at the moment of almanac uploading. '0' indicates malfunction of
+     * n-satellite. '1' indicates that n-satellite is operational. - bit 1: Bn(ln), '0' indicates
+     * the satellite is operational and suitable for navigation.
      */
     public int health_bits;
 

--- a/javascript/sbp/observation.js
+++ b/javascript/sbp/observation.js
@@ -2495,7 +2495,7 @@ MsgGroupDelay.prototype.fieldSpec.push(['isc_l2c', 'writeInt16LE', 2]);
  * @field health_bits number (unsigned 8-bit int, 1 byte) Satellite health status for GPS:   - bits 5-7: NAV data health status. See IS-
  *   GPS-200H     Table 20-VII: NAV Data Health Indications.   - bits 0-4: Signal
  *   health status. See IS-GPS-200H     Table 20-VIII. Codes for Health of SV Signal
- *   Components. Satellite health status for GLO (see GLO ICD 5.1 table 5.1 for
+ *   Components.  Satellite health status for GLO (see GLO ICD 5.1 table 5.1 for
  *   details):   - bit 0: C(n), "unhealthy" flag that is transmitted within     non-
  *   immediate data and indicates overall constellation status     at the moment of
  *   almanac uploading.     '0' indicates malfunction of n-satellite.     '1'
@@ -2543,7 +2543,7 @@ AlmanacCommonContent.prototype.fieldSpec.push(['health_bits', 'writeUInt8', 1]);
  * @field health_bits number (unsigned 8-bit int, 1 byte) Satellite health status for GPS:   - bits 5-7: NAV data health status. See IS-
  *   GPS-200H     Table 20-VII: NAV Data Health Indications.   - bits 0-4: Signal
  *   health status. See IS-GPS-200H     Table 20-VIII. Codes for Health of SV Signal
- *   Components. Satellite health status for GLO (see GLO ICD 5.1 table 5.1 for
+ *   Components.  Satellite health status for GLO (see GLO ICD 5.1 table 5.1 for
  *   details):   - bit 0: C(n), "unhealthy" flag that is transmitted within     non-
  *   immediate data and indicates overall constellation status     at the moment of
  *   almanac uploading.     '0' indicates malfunction of n-satellite.     '1'

--- a/kaitai/ksy/observation.ksy
+++ b/kaitai/ksy/observation.ksy
@@ -2210,6 +2210,7 @@ types:
             - bits 0-4: Signal health status. See IS-GPS-200H
               Table 20-VIII. Codes for Health of SV Signal
               Components.
+
           Satellite health status for GLO (see GLO ICD 5.1 table 5.1 for
           details):
             - bit 0: C(n), "unhealthy" flag that is transmitted within
@@ -2251,6 +2252,7 @@ types:
             - bits 0-4: Signal health status. See IS-GPS-200H
               Table 20-VIII. Codes for Health of SV Signal
               Components.
+
           Satellite health status for GLO (see GLO ICD 5.1 table 5.1 for
           details):
             - bit 0: C(n), "unhealthy" flag that is transmitted within

--- a/python/sbp/observation.py
+++ b/python/sbp/observation.py
@@ -782,6 +782,7 @@ class AlmanacCommonContent(object):
       - bits 0-4: Signal health status. See IS-GPS-200H
         Table 20-VIII. Codes for Health of SV Signal
         Components.
+
     Satellite health status for GLO (see GLO ICD 5.1 table 5.1 for details):
       - bit 0: C(n), "unhealthy" flag that is transmitted within
         non-immediate data and indicates overall constellation status
@@ -850,6 +851,7 @@ class AlmanacCommonContentDep(object):
       - bits 0-4: Signal health status. See IS-GPS-200H
         Table 20-VIII. Codes for Health of SV Signal
         Components.
+
     Satellite health status for GLO (see GLO ICD 5.1 table 5.1 for details):
       - bit 0: C(n), "unhealthy" flag that is transmitted within
         non-immediate data and indicates overall constellation status

--- a/rust/sbp/src/messages/invalid.rs
+++ b/rust/sbp/src/messages/invalid.rs
@@ -1,9 +1,9 @@
 //! Invalid messages. This message type should be created out of two errors:
 //! The SbpMsgParseError, & the CrcError. They correspond to two cases
-//! 1) the Frame is invalid because either it either has an invalid CRC or
-//! it is missing some metadata like msg_type or similar.
-//! 2) The message is invalid because the payload is not large enough and cannot be
-//! parsed into a message. This is the SbpMsgParseError.
+//!   1. The Frame is invalid because either it either has an invalid CRC or
+//!      it is missing some metadata like msg_type or similar.
+//!   2. The message is invalid because the payload is not large enough and cannot be
+//!      parsed into a message. This is the SbpMsgParseError.
 
 use bytes::{Buf, BufMut};
 

--- a/rust/sbp/src/messages/observation.rs
+++ b/rust/sbp/src/messages/observation.rs
@@ -102,6 +102,7 @@ pub mod almanac_common_content {
         ///   - bits 0-4: Signal health status. See IS-GPS-200H
         ///     Table 20-VIII. Codes for Health of SV Signal
         ///     Components.
+        ///
         /// Satellite health status for GLO (see GLO ICD 5.1 table 5.1 for details):
         ///   - bit 0: C(n), "unhealthy" flag that is transmitted within
         ///     non-immediate data and indicates overall constellation status
@@ -182,6 +183,7 @@ pub mod almanac_common_content_dep {
         ///   - bits 0-4: Signal health status. See IS-GPS-200H
         ///     Table 20-VIII. Codes for Health of SV Signal
         ///     Components.
+        ///
         /// Satellite health status for GLO (see GLO ICD 5.1 table 5.1 for details):
         ///   - bit 0: C(n), "unhealthy" flag that is transmitted within
         ///     non-immediate data and indicates overall constellation status

--- a/spec/yaml/swiftnav/sbp/observation.yaml
+++ b/spec/yaml/swiftnav/sbp/observation.yaml
@@ -2270,6 +2270,7 @@ definitions:
                 - bits 0-4: Signal health status. See IS-GPS-200H
                   Table 20-VIII. Codes for Health of SV Signal
                   Components.
+
               Satellite health status for GLO (see GLO ICD 5.1 table 5.1 for details):
                 - bit 0: C(n), "unhealthy" flag that is transmitted within
                   non-immediate data and indicates overall constellation status
@@ -2308,6 +2309,7 @@ definitions:
                 - bits 0-4: Signal health status. See IS-GPS-200H
                   Table 20-VIII. Codes for Health of SV Signal
                   Components.
+
               Satellite health status for GLO (see GLO ICD 5.1 table 5.1 for details):
                 - bit 0: C(n), "unhealthy" flag that is transmitted within
                   non-immediate data and indicates overall constellation status


### PR DESCRIPTION
# Description

@swift-nav/devinfra

A simple whitespace fix to get rust lints passing

# API compatibility

Does this change introduce a API compatibility risk?

No

## API compatibility plan

N/A

# JIRA Reference

N/A
