### PR TITLE
Update Additional Reviewers

### DIFF
--- a/.github/additional_reviewers_config.yaml
+++ b/.github/additional_reviewers_config.yaml
@@ -1,8 +1,8 @@
 files:
   'docs/sbp.pdf':
-    - woodfell
+    - sokhealy
   'spec/yaml/swiftnav/sbp/*.yaml':
-    - woodfell
+    - sokhealy
 
 options:
   ignore_draft: true


### PR DESCRIPTION
# Description

@swift-nav/devinfra

Changes the requested additional reviewer to @sokhealy

If I need to, I can change it to someone else, or we can remove the gh action. It rightfully fails because the reviewer must be a member of the `swift-nav` organization

# API compatibility

Does this change introduce a API compatibility risk?

No

## API compatibility plan

N/A

# JIRA Reference

N/A
