### PR TITLE
Remove haskell from bench

### DIFF
--- a/.github/additional_reviewers_config.yaml
+++ b/.github/additional_reviewers_config.yaml
@@ -1,8 +1,8 @@
 files:
   'docs/sbp.pdf':
-    - woodfell
+    - sokhealy
   'spec/yaml/swiftnav/sbp/*.yaml':
-    - woodfell
+    - sokhealy
 
 options:
   ignore_draft: true

--- a/scripts/ci_benchmark.bash
+++ b/scripts/ci_benchmark.bash
@@ -2,31 +2,6 @@
 
 set -ex
 
-pushd haskell
-
-docker build --tag haskell-sbp2json .
-
-docker run \
-  -v "$PWD:/work" \
-  -v "$HOME/.docker-cache/stack/work:/work/.stack-work" \
-  -v "$HOME/.docker-cache/stack/home:/root/.stack" \
-  --rm \
-  --name haskell-sbp2json-run \
-  haskell-sbp2json \
-  stack build -j4 --allow-different-user
-
-sudo chown    "$USER:$USER" "$HOME/.docker-cache"
-sudo chown -R "$USER:$USER" "$HOME/.docker-cache/stack"
-sudo chown -R "$USER:$USER" "$PWD"
-
-haskell_bins="$(find "$HOME/.docker-cache/stack/work/install" -name bin)"
-
-cp "$haskell_bins/sbp2json" .
-cp "$haskell_bins/json2sbp" .
-cp "$haskell_bins/json2json" .
-
-popd
-
 pushd rust
 
 docker build --tag rust-sbp2json .


### PR DESCRIPTION
# Description

@swift-nav/devinfra

the Haskell benchmarking pipeline is failing. This PR removes that check.

# API compatibility

Does this change introduce a API compatibility risk?

No

## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan:

None

# JIRA Reference

N/A
