### PR TITLE
Pcrumley/update actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+---
+version: 2
+updates:
+# Set update schedule for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -23,7 +23,7 @@ jobs:
     name: Benchmark
     runs-on: [xlarge]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup
         run: ./scripts/ci_prepare_python.bash
       - name: Run benchmarks

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -47,7 +47,7 @@ jobs:
           apt-get -qq update
           apt-get -qq install libeigen3-dev libserialport-dev git cmake build-essential ${{ matrix.compiler.package }}
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
@@ -84,7 +84,7 @@ jobs:
     name: macOS
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
@@ -117,7 +117,7 @@ jobs:
     name: Test Big Endian
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
@@ -139,7 +139,7 @@ jobs:
     name: Bazel
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -160,7 +160,7 @@ jobs:
     name: ASAN
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -181,7 +181,7 @@ jobs:
     name: UBSAN
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -206,7 +206,7 @@ jobs:
     name: "Windows 2019 (Generator: ${{ matrix.generator }}, Shared Library: ${{ matrix.build_shared_libraries }})"
     runs-on: windows-2019
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Build docker image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -25,7 +25,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}:/mnt/workspace
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
@@ -56,7 +56,7 @@ jobs:
           cp docs/sbp.pdf .
           echo "::set-output name=artifact_name::sbp.pdf"
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.pdf.outputs.artifact_name }}
           path: ${{ steps.pdf.outputs.artifact_name }}

--- a/.github/workflows/haskell.yaml
+++ b/.github/workflows/haskell.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Build
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: actions/cache@v3
         name: Cache ~/.stack
@@ -57,7 +57,7 @@ jobs:
             sbp2nmea
           echo "::set-output name=artifact_name::$ARTIFACT_NAME"
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.build.outputs.artifact_name }}
           path: ./haskell/${{ steps.build.outputs.artifact_name }}
@@ -68,9 +68,9 @@ jobs:
     name: Publish github release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           path: artifacts
 

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Test
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: gradle/gradle-build-action@v2
         with:
           gradle-version: 7.1.1
@@ -27,7 +27,7 @@ jobs:
 #   name: SonarQube
 #   runs-on: ubuntu-20.04
 #   steps:
-#     - uses: actions/checkout@v2
+#     - uses: actions/checkout@v4
 #       with:
 #         fetch-depth: 0
 #     - uses: gradle/gradle-build-action@v2

--- a/.github/workflows/javascript.yaml
+++ b/.github/workflows/javascript.yaml
@@ -19,7 +19,7 @@ jobs:
     name: Test
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Run tests
         shell: bash

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -20,7 +20,7 @@ jobs:
     name: Test
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup
         run: ./scripts/ci_prepare_python.bash

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -20,7 +20,7 @@ jobs:
     name: Format and lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - run: ./scripts/ci_prepare_rust.bash
         shell: bash
@@ -48,7 +48,7 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - run: ./scripts/ci_prepare_rust.bash
         shell: bash
@@ -73,7 +73,7 @@ jobs:
           - windows-2022
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - run: ./scripts/ci_prepare_rust.bash
         shell: bash

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -10,7 +10,7 @@ jobs:
   sonarcloud:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: SonarCloud Scan
@@ -31,7 +31,7 @@ jobs:
     name: C Code Coverage
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0

--- a/.github/workflows/test_validate.yaml
+++ b/.github/workflows/test_validate.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout Sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run Tests
         run: |

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout Current Spec
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Checkout Previous Spec
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: master
           path: previous


### PR DESCRIPTION
# Description

@swift-nav/algint-team

Update some action versions, including upload-artifact & download-artifact which will be deprecated. Adds dependabot to update actions.

I got a dependabot warning about some of our github actions being deprecated 
# API compatibility

Does this change introduce a API compatibility risk?
No

## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan:

# JIRA Reference

N/A
