### PR TITLE
Add inertially to the spelling wordlist

### DIFF
--- a/python/docs/source/spelling_wordlist.txt
+++ b/python/docs/source/spelling_wordlist.txt
@@ -81,6 +81,7 @@ hydrostatic
 ifaddrs
 imu
 incrementing
+inertially
 infofirmware
 interoperable
 io


### PR DESCRIPTION
# Description

@swift-nav/algint-team

Added `inertially` to the spelling worldlist

# API compatibility

Does this change introduce a API compatibility risk?

No

## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan:

N/A

# JIRA Reference

https://swift-nav.atlassian.net/browse/BOARD-XXXX
