### PR TITLE
bumping to latest version of libswiftnav

### DIFF
--- a/rust/sbp/Cargo.toml
+++ b/rust/sbp/Cargo.toml
@@ -34,7 +34,7 @@ crc16 = "0.4"
 log = "0.4"
 
 [dependencies.swiftnav]
-version = "0.8"
+version = "0.10"
 optional = true
 
 [dependencies.slotmap]


### PR DESCRIPTION
For some reason, the proc_macro of swiftnav-sys is failing on MacOS and Windows but succeeding on Linux. I'm no sure why but it appears there is some precedent for this: https://github.com/rust-lang/rust/issues/59998

When I update the version to the latest version `v0.10.0` it succeeds.

I would recommend getting dependabot to bump these versions in the future and also updating the CI/CD to run on a build matrix with `cargo c --all-features`

# Description

@swift-nav/algint-team

# API compatibility

Does this change introduce a API compatibility risk?

No

## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan:

# JIRA Reference

https://swift-nav.atlassian.net/browse/BOARD-XXXX
