### PR TITLE
cover CI hole which appears to be hiding a proc_macro bindgen bug

### DIFF
--- a/scripts/ci_build_rust.bash
+++ b/scripts/ci_build_rust.bash
@@ -22,6 +22,7 @@ else
 fi
 
 cargo build --no-default-features -p sbp
+cargo build --no-default-features -p sbp --features swiftnav
 cargo build --no-default-features -p sbp --features serde
 cargo build --no-default-features -p sbp --features json
 cargo build --no-default-features -p sbp --features async


### PR DESCRIPTION
# Description

@swift-nav/algint-team

Prior to this PR, we only tested `cargo build --all-targets --all-features` on Linux machines. This seems to be a gap where inside of a proc-macro in the `swiftnav-rs` which can fail on different OSes. After we take this PR we no longer will have this gap.

Note, this is possibly not the best place to put this check, it may make more sense to have the ci, lint format run on a matrix instead.

# API compatibility

Does this change introduce a API compatibility risk?

None

## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan:

No

# JIRA Reference

None
