### PR TITLE
bump macos to 13

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -82,7 +82,7 @@ jobs:
 
   macos:
     name: macOS
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -69,7 +69,7 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
-          - macos-12
+          - macos-13
           - windows-2022
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
# Description

MacOs-12 had been deprecated see here:
https://github.com/actions/runner-images/issues/10721

@swift-nav/algint-team

<!-- Changes proposed in this PR -->

# API compatibility

No changes to API, Just changing MacOs from 12 to 13.

## API compatibility plan

None

# JIRA Reference

https://swift-nav.atlassian.net/browse/AP-3230
