### PR TITLE
Fix actions/checkout@v2

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -53,7 +53,7 @@ jobs:
           git config --global --add safe.directory "${PWD}"
           git init
           git remote add origin "https://github.com/${{ github.repository }}"
-          git fetch --no-tags --depth=1 origin "${{ github.ssh }}"
+          git fetch --no-tags --depth=1 origin "${{ github.sha }}"
           git checkout "${{ github.sha }}"
           git submodule update --recursive --init --depth=1
 

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -49,7 +49,10 @@ jobs:
 
       - name: Checkout
         run: |
-          git submodule update --recursive --init
+          git clone --depth 1 --filter=blob:none --no-checkout https://github.com/swift-nav/libsbp .
+          git fetch --depth 1 origin ${{ github.sha }}
+          git checkout ${{ github.sha }}
+          git submodule update --depth=1 --recursive --init
 
       - name: Configure
         run: |
@@ -79,161 +82,161 @@ jobs:
           cmake -S c/test_package -B c/test_package/build -DCMAKE_PREFIX_PATH="$PWD/install"
           cmake --build c/test_package/build
 
-  macos:
-    name: macOS
-    runs-on: macos-13
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: 0
+  # macos:
+  #   name: macOS
+  #   runs-on: macos-13
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         submodules: recursive
+  #         fetch-depth: 0
 
-      - name: Configure
-        run: |
-          cmake -S c -B build \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER=clang \
-            -DCMAKE_CXX_COMPILER=clang++ \
-            -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/install" \
-            -DINSTALL_GTEST=false
+  #     - name: Configure
+  #       run: |
+  #         cmake -S c -B build \
+  #           -DCMAKE_BUILD_TYPE=Release \
+  #           -DCMAKE_C_COMPILER=clang \
+  #           -DCMAKE_CXX_COMPILER=clang++ \
+  #           -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/install" \
+  #           -DINSTALL_GTEST=false
 
-      - name: Build
-        run: cmake --build build
+  #     - name: Build
+  #       run: cmake --build build
 
-      - name: Test
-        run: cmake --build build --target do-all-tests
+  #     - name: Test
+  #       run: cmake --build build --target do-all-tests
 
-      - name: Install
-        run: cmake --build build --target install
+  #     - name: Install
+  #       run: cmake --build build --target install
 
-      - name: Test Package
-        run: |
-          cmake -S c/test_package -B c/test_package/build -DCMAKE_PREFIX_PATH="${{ github.workspace }}/install"
-          cmake --build c/test_package/build
-
-
-  big-endian:
-    name: Test Big Endian
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: 0
-
-      - name: Setup
-        run: |
-          sudo apt-get -qq update
-          sudo apt-get -qq install gcc-multilib-mips-linux-gnu gcc-mips-linux-gnu qemu-user g++-mips-linux-gnu
-
-      - name: Run big endian tests
-        run: make test-c-modern
-        env:
-          CC: mips-linux-gnu-gcc
-          CXX: mips-linux-gnu-g++
-
-          CMAKEFLAGS: -DCMAKE_EXE_LINKER_FLAGS_RELEASE="-static" -Dgtest_disable_pthreads=ON
-
-  bazel:
-    name: Bazel
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - uses: bazelbuild/setup-bazelisk@v3
-
-      - name: Mount bazel cache
-        uses: actions/cache@v4
-        with:
-          path: "~/.cache/bazel"
-          key: bazel
-
-      - name: Bazel Build & Test
-        run: |
-          bazel test //...
+  #     - name: Test Package
+  #       run: |
+  #         cmake -S c/test_package -B c/test_package/build -DCMAKE_PREFIX_PATH="${{ github.workspace }}/install"
+  #         cmake --build c/test_package/build
 
 
-  asan:
-    name: ASAN
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
+  # big-endian:
+  #   name: Test Big Endian
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         submodules: recursive
+  #         fetch-depth: 0
 
-      - uses: bazelbuild/setup-bazelisk@v3
+  #     - name: Setup
+  #       run: |
+  #         sudo apt-get -qq update
+  #         sudo apt-get -qq install gcc-multilib-mips-linux-gnu gcc-mips-linux-gnu qemu-user g++-mips-linux-gnu
 
-      - name: Mount bazel cache
-        uses: actions/cache@v4
-        with:
-          path: "~/.cache/bazel"
-          key: bazel
+  #     - name: Run big endian tests
+  #       run: make test-c-modern
+  #       env:
+  #         CC: mips-linux-gnu-gcc
+  #         CXX: mips-linux-gnu-g++
 
-      - name: Bazel Build & Test
-        run: |
-          bazel test --config=asan //...
+  #         CMAKEFLAGS: -DCMAKE_EXE_LINKER_FLAGS_RELEASE="-static" -Dgtest_disable_pthreads=ON
 
+  # bazel:
+  #   name: Bazel
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         submodules: recursive
 
-  ubsan:
-    name: UBSAN
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
+  #     - uses: bazelbuild/setup-bazelisk@v3
 
-      - uses: bazelbuild/setup-bazelisk@v3
+  #     - name: Mount bazel cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: "~/.cache/bazel"
+  #         key: bazel
 
-      - name: Mount bazel cache
-        uses: actions/cache@v4
-        with:
-          path: "~/.cache/bazel"
-          key: bazel
-
-      - name: Bazel Build & Test
-        run: |
-          bazel test --config=ubsan //...
+  #     - name: Bazel Build & Test
+  #       run: |
+  #         bazel test //...
 
 
-  windows-2019:
-    strategy:
-      matrix:
-        generator: [ "MinGW Makefiles", "Visual Studio 16 2019" ]
-        build_shared_libraries: [ true, false ]
-    name: "Windows 2019 (Generator: ${{ matrix.generator }}, Shared Library: ${{ matrix.build_shared_libraries }})"
-    runs-on: windows-2019
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: 0
+  # asan:
+  #   name: ASAN
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         submodules: recursive
 
-      - name: Configure
-        run: |
-          cmake -G "${{ matrix.generator }}" -S c -B build `
-            -DCMAKE_BUILD_TYPE=Release `
-            -DBUILD_SHARED_LIBS=${{ matrix.build_shared_libraries }} `
-            -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/install" `
-            -Dgtest_force_shared_crt=true `
-            -DINSTALL_GTEST=false
+  #     - uses: bazelbuild/setup-bazelisk@v3
 
-      - name: Build
-        run: cmake --build build
+  #     - name: Mount bazel cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: "~/.cache/bazel"
+  #         key: bazel
 
-      - name: Build Test
-        run: cmake --build build --target build-all-tests
+  #     - name: Bazel Build & Test
+  #       run: |
+  #         bazel test --config=asan //...
 
-      - name: Run Test
-        run: cmake --build build --target do-all-tests
-        if: ${{ !matrix.build_shared_libraries }}
 
-      - name: Install
-        run: cmake --build build --target install
+  # ubsan:
+  #   name: UBSAN
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         submodules: recursive
 
-      - name: Test Package
-        run: |
-          cmake -G "${{ matrix.generator }}" -S c/test_package -B c/test_package/build -DCMAKE_PREFIX_PATH="${{ github.workspace }}/install"
-          cmake --build c/test_package/build
+  #     - uses: bazelbuild/setup-bazelisk@v3
+
+  #     - name: Mount bazel cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: "~/.cache/bazel"
+  #         key: bazel
+
+  #     - name: Bazel Build & Test
+  #       run: |
+  #         bazel test --config=ubsan //...
+
+
+  # windows-2019:
+  #   strategy:
+  #     matrix:
+  #       generator: [ "MinGW Makefiles", "Visual Studio 16 2019" ]
+  #       build_shared_libraries: [ true, false ]
+  #   name: "Windows 2019 (Generator: ${{ matrix.generator }}, Shared Library: ${{ matrix.build_shared_libraries }})"
+  #   runs-on: windows-2019
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         submodules: recursive
+  #         fetch-depth: 0
+
+  #     - name: Configure
+  #       run: |
+  #         cmake -G "${{ matrix.generator }}" -S c -B build `
+  #           -DCMAKE_BUILD_TYPE=Release `
+  #           -DBUILD_SHARED_LIBS=${{ matrix.build_shared_libraries }} `
+  #           -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/install" `
+  #           -Dgtest_force_shared_crt=true `
+  #           -DINSTALL_GTEST=false
+
+  #     - name: Build
+  #       run: cmake --build build
+
+  #     - name: Build Test
+  #       run: cmake --build build --target build-all-tests
+
+  #     - name: Run Test
+  #       run: cmake --build build --target do-all-tests
+  #       if: ${{ !matrix.build_shared_libraries }}
+
+  #     - name: Install
+  #       run: cmake --build build --target install
+
+  #     - name: Test Package
+  #       run: |
+  #         cmake -G "${{ matrix.generator }}" -S c/test_package -B c/test_package/build -DCMAKE_PREFIX_PATH="${{ github.workspace }}/install"
+  #         cmake --build c/test_package/build
 

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -31,8 +31,6 @@ jobs:
 
     runs-on: ubuntu-latest
     container: ubuntu:18.04
-    env:
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
 

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -53,7 +53,7 @@ jobs:
           git init
           git remote add origin "https://github.com/${{ github.repository }}"
           git fetch --no-tags --depth=1 origin "${{ github.ssh }}"
-          git checkout "${{ github.sha }}""
+          git checkout "${{ github.sha }}"
           git submodule update --recursive --init --depth=1
 
       - name: Configure

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -84,161 +84,161 @@ jobs:
           cmake -S c/test_package -B c/test_package/build -DCMAKE_PREFIX_PATH="$PWD/install"
           cmake --build c/test_package/build
 
-  # macos:
-  #   name: macOS
-  #   runs-on: macos-13
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         submodules: recursive
-  #         fetch-depth: 0
+  macos:
+    name: macOS
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
-  #     - name: Configure
-  #       run: |
-  #         cmake -S c -B build \
-  #           -DCMAKE_BUILD_TYPE=Release \
-  #           -DCMAKE_C_COMPILER=clang \
-  #           -DCMAKE_CXX_COMPILER=clang++ \
-  #           -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/install" \
-  #           -DINSTALL_GTEST=false
+      - name: Configure
+        run: |
+          cmake -S c -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/install" \
+            -DINSTALL_GTEST=false
 
-  #     - name: Build
-  #       run: cmake --build build
+      - name: Build
+        run: cmake --build build
 
-  #     - name: Test
-  #       run: cmake --build build --target do-all-tests
+      - name: Test
+        run: cmake --build build --target do-all-tests
 
-  #     - name: Install
-  #       run: cmake --build build --target install
+      - name: Install
+        run: cmake --build build --target install
 
-  #     - name: Test Package
-  #       run: |
-  #         cmake -S c/test_package -B c/test_package/build -DCMAKE_PREFIX_PATH="${{ github.workspace }}/install"
-  #         cmake --build c/test_package/build
-
-
-  # big-endian:
-  #   name: Test Big Endian
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         submodules: recursive
-  #         fetch-depth: 0
-
-  #     - name: Setup
-  #       run: |
-  #         sudo apt-get -qq update
-  #         sudo apt-get -qq install gcc-multilib-mips-linux-gnu gcc-mips-linux-gnu qemu-user g++-mips-linux-gnu
-
-  #     - name: Run big endian tests
-  #       run: make test-c-modern
-  #       env:
-  #         CC: mips-linux-gnu-gcc
-  #         CXX: mips-linux-gnu-g++
-
-  #         CMAKEFLAGS: -DCMAKE_EXE_LINKER_FLAGS_RELEASE="-static" -Dgtest_disable_pthreads=ON
-
-  # bazel:
-  #   name: Bazel
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         submodules: recursive
-
-  #     - uses: bazelbuild/setup-bazelisk@v3
-
-  #     - name: Mount bazel cache
-  #       uses: actions/cache@v4
-  #       with:
-  #         path: "~/.cache/bazel"
-  #         key: bazel
-
-  #     - name: Bazel Build & Test
-  #       run: |
-  #         bazel test //...
+      - name: Test Package
+        run: |
+          cmake -S c/test_package -B c/test_package/build -DCMAKE_PREFIX_PATH="${{ github.workspace }}/install"
+          cmake --build c/test_package/build
 
 
-  # asan:
-  #   name: ASAN
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         submodules: recursive
+  big-endian:
+    name: Test Big Endian
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
-  #     - uses: bazelbuild/setup-bazelisk@v3
+      - name: Setup
+        run: |
+          sudo apt-get -qq update
+          sudo apt-get -qq install gcc-multilib-mips-linux-gnu gcc-mips-linux-gnu qemu-user g++-mips-linux-gnu
 
-  #     - name: Mount bazel cache
-  #       uses: actions/cache@v4
-  #       with:
-  #         path: "~/.cache/bazel"
-  #         key: bazel
+      - name: Run big endian tests
+        run: make test-c-modern
+        env:
+          CC: mips-linux-gnu-gcc
+          CXX: mips-linux-gnu-g++
 
-  #     - name: Bazel Build & Test
-  #       run: |
-  #         bazel test --config=asan //...
+          CMAKEFLAGS: -DCMAKE_EXE_LINKER_FLAGS_RELEASE="-static" -Dgtest_disable_pthreads=ON
 
+  bazel:
+    name: Bazel
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
-  # ubsan:
-  #   name: UBSAN
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         submodules: recursive
+      - uses: bazelbuild/setup-bazelisk@v3
 
-  #     - uses: bazelbuild/setup-bazelisk@v3
+      - name: Mount bazel cache
+        uses: actions/cache@v4
+        with:
+          path: "~/.cache/bazel"
+          key: bazel
 
-  #     - name: Mount bazel cache
-  #       uses: actions/cache@v4
-  #       with:
-  #         path: "~/.cache/bazel"
-  #         key: bazel
-
-  #     - name: Bazel Build & Test
-  #       run: |
-  #         bazel test --config=ubsan //...
+      - name: Bazel Build & Test
+        run: |
+          bazel test //...
 
 
-  # windows-2019:
-  #   strategy:
-  #     matrix:
-  #       generator: [ "MinGW Makefiles", "Visual Studio 16 2019" ]
-  #       build_shared_libraries: [ true, false ]
-  #   name: "Windows 2019 (Generator: ${{ matrix.generator }}, Shared Library: ${{ matrix.build_shared_libraries }})"
-  #   runs-on: windows-2019
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         submodules: recursive
-  #         fetch-depth: 0
+  asan:
+    name: ASAN
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
-  #     - name: Configure
-  #       run: |
-  #         cmake -G "${{ matrix.generator }}" -S c -B build `
-  #           -DCMAKE_BUILD_TYPE=Release `
-  #           -DBUILD_SHARED_LIBS=${{ matrix.build_shared_libraries }} `
-  #           -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/install" `
-  #           -Dgtest_force_shared_crt=true `
-  #           -DINSTALL_GTEST=false
+      - uses: bazelbuild/setup-bazelisk@v3
 
-  #     - name: Build
-  #       run: cmake --build build
+      - name: Mount bazel cache
+        uses: actions/cache@v4
+        with:
+          path: "~/.cache/bazel"
+          key: bazel
 
-  #     - name: Build Test
-  #       run: cmake --build build --target build-all-tests
+      - name: Bazel Build & Test
+        run: |
+          bazel test --config=asan //...
 
-  #     - name: Run Test
-  #       run: cmake --build build --target do-all-tests
-  #       if: ${{ !matrix.build_shared_libraries }}
 
-  #     - name: Install
-  #       run: cmake --build build --target install
+  ubsan:
+    name: UBSAN
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
-  #     - name: Test Package
-  #       run: |
-  #         cmake -G "${{ matrix.generator }}" -S c/test_package -B c/test_package/build -DCMAKE_PREFIX_PATH="${{ github.workspace }}/install"
-  #         cmake --build c/test_package/build
+      - uses: bazelbuild/setup-bazelisk@v3
+
+      - name: Mount bazel cache
+        uses: actions/cache@v4
+        with:
+          path: "~/.cache/bazel"
+          key: bazel
+
+      - name: Bazel Build & Test
+        run: |
+          bazel test --config=ubsan //...
+
+
+  windows-2019:
+    strategy:
+      matrix:
+        generator: [ "MinGW Makefiles", "Visual Studio 16 2019" ]
+        build_shared_libraries: [ true, false ]
+    name: "Windows 2019 (Generator: ${{ matrix.generator }}, Shared Library: ${{ matrix.build_shared_libraries }})"
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Configure
+        run: |
+          cmake -G "${{ matrix.generator }}" -S c -B build `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DBUILD_SHARED_LIBS=${{ matrix.build_shared_libraries }} `
+            -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/install" `
+            -Dgtest_force_shared_crt=true `
+            -DINSTALL_GTEST=false
+
+      - name: Build
+        run: cmake --build build
+
+      - name: Build Test
+        run: cmake --build build --target build-all-tests
+
+      - name: Run Test
+        run: cmake --build build --target do-all-tests
+        if: ${{ !matrix.build_shared_libraries }}
+
+      - name: Install
+        run: cmake --build build --target install
+
+      - name: Test Package
+        run: |
+          cmake -G "${{ matrix.generator }}" -S c/test_package -B c/test_package/build -DCMAKE_PREFIX_PATH="${{ github.workspace }}/install"
+          cmake --build c/test_package/build
 

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -47,10 +47,9 @@ jobs:
           apt-get -qq update
           apt-get -qq install libeigen3-dev libserialport-dev git cmake build-essential ${{ matrix.compiler.package }}
 
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
-          fetch-depth: 0
+      - name: Checkout
+        run: |
+          git submodule update --recursive --init
 
       - name: Configure
         run: |

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -49,8 +49,8 @@ jobs:
 
       - name: Checkout
         run: |
+          git config --global --add safe.directory "${PWD}"
           git init
-          git config --add safe.directory "${PWD}"
           git remote add origin "https://github.com/${{ github.repository }}"
           git fetch --no-tags --depth=1 origin "${{ github.ssh }}"
           git checkout "${{ github.sha }}""

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -49,8 +49,8 @@ jobs:
 
       - name: Checkout
         run: |
-          git config --add safe.directory "${PWD}"
           git init
+          git config --add safe.directory "${PWD}"
           git remote add origin "https://github.com/${{ github.repository }}"
           git fetch --no-tags --depth=1 origin "${{ github.ssh }}"
           git checkout "${{ github.sha }}""

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -49,7 +49,6 @@ jobs:
 
       - name: Checkout
         run: |
-          set -x
           git config --global --add safe.directory "${PWD}"
           git init
           git remote add origin "https://github.com/${{ github.repository }}"

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -49,10 +49,12 @@ jobs:
 
       - name: Checkout
         run: |
-          git clone --depth 1 --filter=blob:none --no-checkout https://github.com/swift-nav/libsbp .
-          git fetch --depth 1 origin ${{ github.sha }}
-          git checkout ${{ github.sha }}
-          git submodule update --depth=1 --recursive --init
+          git config --add safe.directory "${PWD}"
+          git init
+          git remote add origin "https://github.com/${{ github.repository }}"
+          git fetch --no-tags --depth=1 origin "${{ github.ssh }}"
+          git checkout "${{ github.sha }}""
+          git submodule update --recursive --init --depth=1
 
       - name: Configure
         run: |

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -49,6 +49,7 @@ jobs:
 
       - name: Checkout
         run: |
+          set -x
           git config --global --add safe.directory "${PWD}"
           git init
           git remote add origin "https://github.com/${{ github.repository }}"


### PR DESCRIPTION
# Changes

Using `actions/checkout@v2` to checkout the github code onto your local workspace is nice, but can be problematic when using old docker image. From what I understand, the action uses NodeJS version internally and therefore requires a modern glibc version as the action can impose newer NodeJS version and therefore can eventually break our build.

To avoid this, I'm just going to manually checkout the code and run the submodule update manually. This will fix our C builds.