### PR TITLE
Update from Ubuntu 18 (gcc-6, clang-6) to Ubuntu 20 (gcc-7, clang-6) [AP-3178]

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -18,28 +18,29 @@ jobs:
         build_type: ["Debug", "Release"]
         compiler:
           [
-            { c: "gcc-14", cxx: "g++-14", package: "gcc-14 g++-14" },
-            { c: "clang-18", cxx: "clang++-18", package: "clang-18" },
+            { c: "gcc-7", cxx: "g++-7", package: "gcc-7 g++-7" },
+            { c: "clang-6.0", cxx: "clang++-6.0", package: "clang-6.0" },
           ]
         build_shared_libraries: [true, false]
 
-    name: "Ubuntu 24.04 (Build: ${{ matrix.build_type }}, Compilers: ${{ matrix.compiler.c }}/${{ matrix.compiler.cxx }}, Shared Library: ${{ matrix.build_shared_libraries }})"
+    name: "Ubuntu 20.04 (Build: ${{ matrix.build_type }}, Compilers: ${{ matrix.compiler.c }}/${{ matrix.compiler.cxx }}, Shared Library: ${{ matrix.build_shared_libraries }})"
 
-    runs-on: ubuntu-24.04
+    # We run on a docker image to avoid being affected from GitHub
+    # decommissioning certain runners
+    runs-on: ubuntu-latest
+    container: ubuntu:20.04
 
     steps:
       - name: Setup
         run: |
-          sudo bash -c '
           apt-get -qq update
           apt-get -qq install software-properties-common gpg wget
           add-apt-repository -y ppa:git-core/ppa
           wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
-          echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ bionic-rc main" \
+          echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ bionic-rc main' \
             | tee -a /etc/apt/sources.list.d/kitware.list >/dev/null
           apt-get -qq update
           apt-get -qq install libeigen3-dev libserialport-dev git cmake build-essential ${{ matrix.compiler.package }}
-          '
 
       - name: Checkout
         run: |

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -22,14 +22,6 @@ jobs:
             { c: "clang-18", cxx: "clang++-18", package: "clang-18" },
           ]
         build_shared_libraries: [true, false]
-        exclude:
-          [
-            {
-              build_type: "Debug",
-              compiler: { c: "gcc-14", cxx: "g++-14" },
-              build_shared_libraries: false,
-            },
-          ]
 
     name: "Ubuntu 24.04 (Build: ${{ matrix.build_type }}, Compilers: ${{ matrix.compiler.c }}/${{ matrix.compiler.cxx }}, Shared Library: ${{ matrix.build_shared_libraries }})"
 

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -12,28 +12,30 @@ on:
       - "c/**"
       - .github/workflows/c.yaml
 jobs:
-
   ubuntu-lts:
-
     strategy:
       matrix:
-        build_type: [ "Debug", "Release" ]
-        compiler: [
-          { c: "gcc-6", cxx: "g++-6", package: "gcc-6 g++-6" },
-          { c: "clang-6.0", cxx: "clang++-6.0", package: "clang-6.0" }
-        ]
-        build_shared_libraries: [ true, false ]
-        exclude: [
-          { build_type: "Debug", compiler: { c: "gcc-6", cxx: "g++-6" }, build_shared_libraries: false }
-        ]
+        build_type: ["Debug", "Release"]
+        compiler:
+          [
+            { c: "gcc-14", cxx: "g++-14", package: "gcc-14 g++-14" },
+            { c: "clang-18", cxx: "clang++-18", package: "clang-18" },
+          ]
+        build_shared_libraries: [true, false]
+        exclude:
+          [
+            {
+              build_type: "Debug",
+              compiler: { c: "gcc-14", cxx: "g++-14" },
+              build_shared_libraries: false,
+            },
+          ]
 
-    name: "Ubuntu 18.04 (Build: ${{ matrix.build_type }}, Compilers: ${{ matrix.compiler.c }}/${{ matrix.compiler.cxx }}, Shared Library: ${{ matrix.build_shared_libraries }})"
+    name: "Ubuntu 24.04 (Build: ${{ matrix.build_type }}, Compilers: ${{ matrix.compiler.c }}/${{ matrix.compiler.cxx }}, Shared Library: ${{ matrix.build_shared_libraries }})"
 
-    runs-on: ubuntu-latest
-    container: ubuntu:18.04
+    runs-on: ubuntu-24.04
 
     steps:
-
       - name: Setup
         run: |
           apt-get -qq update
@@ -66,7 +68,7 @@ jobs:
             -DBUILD_EXAMPLES=true
 
       - name: Build
-        run: cmake --build build --parallel 
+        run: cmake --build build --parallel
 
       - name: Example
         run: cmake --build build --parallel --target examples
@@ -114,7 +116,6 @@ jobs:
           cmake -S c/test_package -B c/test_package/build -DCMAKE_PREFIX_PATH="${{ github.workspace }}/install"
           cmake --build c/test_package/build
 
-
   big-endian:
     name: Test Big Endian
     runs-on: ubuntu-20.04
@@ -157,7 +158,6 @@ jobs:
         run: |
           bazel test //...
 
-
   asan:
     name: ASAN
     runs-on: ubuntu-20.04
@@ -177,7 +177,6 @@ jobs:
       - name: Bazel Build & Test
         run: |
           bazel test --config=asan //...
-
 
   ubsan:
     name: UBSAN
@@ -199,12 +198,11 @@ jobs:
         run: |
           bazel test --config=ubsan //...
 
-
   windows-2019:
     strategy:
       matrix:
-        generator: [ "MinGW Makefiles", "Visual Studio 16 2019" ]
-        build_shared_libraries: [ true, false ]
+        generator: ["MinGW Makefiles", "Visual Studio 16 2019"]
+        build_shared_libraries: [true, false]
     name: "Windows 2019 (Generator: ${{ matrix.generator }}, Shared Library: ${{ matrix.build_shared_libraries }})"
     runs-on: windows-2019
     steps:
@@ -239,4 +237,3 @@ jobs:
         run: |
           cmake -G "${{ matrix.generator }}" -S c/test_package -B c/test_package/build -DCMAKE_PREFIX_PATH="${{ github.workspace }}/install"
           cmake --build c/test_package/build
-

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -38,14 +38,16 @@ jobs:
     steps:
       - name: Setup
         run: |
+          sudo bash -c '
           apt-get -qq update
           apt-get -qq install software-properties-common gpg wget
           add-apt-repository -y ppa:git-core/ppa
           wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
-          echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ bionic-rc main' \
+          echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ bionic-rc main" \
             | tee -a /etc/apt/sources.list.d/kitware.list >/dev/null
           apt-get -qq update
           apt-get -qq install libeigen3-dev libserialport-dev git cmake build-essential ${{ matrix.compiler.package }}
+          '
 
       - name: Checkout
         run: |


### PR DESCRIPTION
# Description

@swift-nav/algint-team

This PR updates the C stages in the CI from relying on Ubuntu 18 (gcc-6, clang-6) to Ubuntu 20 (gcc-7, clang-6). Ubuntu 18 is EOL since May 2023. Recently, we observed issues, e.g. in GitHub Actions due to old versions of GLIBC in Ubuntu 18 jobs. We decided to not further invest time and energy in maintaining these old pipelines, because:
- No customer directly relies on gcc-6.
- We are planning to update our codebase to C++17, which requires at least gcc-8 (or 7 without CTAD).
- If we want to have full coverage for all customer required toolchains, that is a different topic and an additional effort. Currently, that is not done for dependency repositories like `libsbp`.
- To still have a certain confidence that gcc versions down to 7 are supported, this PR updates to Ubuntu 20, which is still maintained and offers gcc 7 in its apt repositories.

# API compatibility

Does this change introduce a API compatibility risk?

No, there are no changes to the code.

## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan:

<!-- Provide a short explanation plan here -->

# JIRA Reference

https://swift-nav.atlassian.net/browse/AP-3178