### PR TITLE
Update rust Docker image to rust:1.88.0-slim

### DIFF
--- a/.github/workflows/haskell.yaml
+++ b/.github/workflows/haskell.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/haskell/Dockerfile
+++ b/haskell/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 RUN \
   apt-get update && \

--- a/python/Dockerfile.benchmark
+++ b/python/Dockerfile.benchmark
@@ -1,8 +1,8 @@
-FROM python:3.7-slim-buster
+FROM python:3.7-slim-bookworm
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN    apt-get update \
-    && apt-get install -y git llvm-7-dev build-essential unzip curl libjson-perl libdigest-crc-perl
+    && apt-get install -y git build-essential unzip curl libjson-perl libdigest-crc-perl
 
 # install perl runtime for kaitai struct
 RUN \

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.67.1-slim-buster
+FROM rust:1.88.0-slim
 
 ARG DEBIAN_FRONTEND=noninterative
 

--- a/test_data/benchmark_main.py
+++ b/test_data/benchmark_main.py
@@ -11,10 +11,10 @@ SLUSH_PERCENTAGE = 0.25
 
 # How much faster Rust should be than other implementations
 RATIOS_SBP2JSON = {
-    "haskell"       : 3.01,
+    "haskell"       : 3.2,
     "python"        : 23.38,
     "kaitai_python" : 5.00,
-    "kaitai_perl"   : 18,
+    "kaitai_perl"   : 20,
 }
 
 RATIOS_JSON2SBP = {


### PR DESCRIPTION
# Description

Update rust Docker image to the latest version (rust:1.88.0-slim).  This fixes the following build error when trying to compile sbp2json:

```
error: failed to compile `sbp2json v6.2.2-alpha (https://github.com/swift-nav/libsbp.git#635fc94f)`, intermediate artifacts can be found at `/tmp/cargo-installwOcSKv`

Caused by:
  package `textwrap v0.16.2` cannot be built because it requires rustc 1.70 or newer, while the currently active rustc version is 1.67.1
  Either upgrade to rustc 1.70 or newer, or use
  cargo update -p textwrap@0.16.2 --precise ver
  where `ver` is the latest version of `textwrap` supporting rustc 1.67.1
```

Also bump the haskell and python benchmarking Docker images to debian:bookworm-slim to fix the benchmark step in CI.

# API compatibility

Does this change introduce a API compatibility risk?

No

## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan:

N/A

# JIRA Reference

https://swift-nav.atlassian.net/browse/BOARD-XXXX
