### PR TITLE
Remove deprecated  ubuntu-20.04 runners [OI-3101]

### DIFF
--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -15,8 +15,18 @@ jobs:
   tests-java-1_8:
     name: Test
     runs-on: ubuntu-24.04
+    container: ubuntu:20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4.7.1
+        with:
+          java-version: "11"
+          distribution: "temurin"
+      - name: Update apt and install unzip
+        run: |
+          apt-get update
+          apt-get install -y unzip make
+        shell: bash
       - uses: gradle/gradle-build-action@v3
         with:
           gradle-version: 7.1.1

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   tests-java-1_8:
     name: Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: gradle/gradle-build-action@v3
@@ -22,22 +22,3 @@ jobs:
           gradle-version: 7.1.1
       - name: Run tests
         run: make test-java
-
-# sonarqube:
-#   name: SonarQube
-#   runs-on: ubuntu-20.04
-#   steps:
-#     - uses: actions/checkout@v4
-#       with:
-#         fetch-depth: 0
-#     - uses: gradle/gradle-build-action@v3
-#       with:
-#         gradle-version: 7.1.1
-#     - name: Run tests
-#       run: make test-java
-#
-#     - name: Run sonarqube
-#       env:
-#         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-#       run: (cd java && gradle sonarqube)

--- a/.github/workflows/javascript.yaml
+++ b/.github/workflows/javascript.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
   coverage:
     name: Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test_validate.yaml
+++ b/.github/workflows/test_validate.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test_validation:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v4

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -6,17 +6,17 @@ on:
       - "spec/**"
   push:
     branches:
-      - 'v*-release'
-      - 'starling-v*-release'
-      - 'libsbp-v*-release'
+      - "v*-release"
+      - "starling-v*-release"
+      - "libsbp-v*-release"
     tags:
-      - 'v*'
+      - "v*"
     paths:
       - "spec/**"
 
 jobs:
   validation:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Current Spec
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description

While working on https://github.com/swift-nav/libsbp/pull/1487 I noticed several pipelines pipelines are failing/timing out (example: https://github.com/swift-nav/libsbp/actions/runs/16514255607/job/46702019004).

These are relying on deprecated github actions runners (ubuntu-20.04), which are not available anymore. This PR removes as much ubuntu-20.04 references as possible.

With this PR, all existing libsbp CI workflows are functional 🎉 

# API compatibility

No API change

# Related PRs
Implemented while working on https://github.com/swift-nav/libsbp/pull/1487

