### PR TITLE
Update github actions [AP-3937]

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -23,7 +23,7 @@ jobs:
     name: Benchmark
     runs-on: [ubuntu-22.04]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup
         run: ./scripts/ci_prepare_python.bash
       - name: Run benchmarks

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -83,7 +83,7 @@ jobs:
     name: macOS
     runs-on: macos-13
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
           fetch-depth: 0
@@ -115,7 +115,7 @@ jobs:
     name: Test Big Endian
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
           fetch-depth: 0
@@ -137,7 +137,7 @@ jobs:
     name: Bazel
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -157,7 +157,7 @@ jobs:
     name: ASAN
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -177,7 +177,7 @@ jobs:
     name: UBSAN
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -201,7 +201,7 @@ jobs:
     name: "Windows Latest (Generator: ${{ matrix.generator }}, Shared Library: ${{ matrix.build_shared_libraries }})"
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
           fetch-depth: 0

--- a/.github/workflows/generator.yaml
+++ b/.github/workflows/generator.yaml
@@ -25,7 +25,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}:/mnt/workspace
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/haskell.yaml
+++ b/.github/workflows/haskell.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Build
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/cache@v4
         name: Cache ~/.stack
@@ -68,7 +68,7 @@ jobs:
     name: Publish github release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-24.04
     container: ubuntu:20.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-java@v4.7.1
         with:
           java-version: "11"

--- a/.github/workflows/javascript.yaml
+++ b/.github/workflows/javascript.yaml
@@ -19,7 +19,7 @@ jobs:
     name: Test
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Run tests
         shell: bash

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -20,7 +20,7 @@ jobs:
     name: Test
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup
         run: ./scripts/ci_prepare_python.bash

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -20,7 +20,7 @@ jobs:
     name: Format and lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - run: ./scripts/ci_prepare_rust.bash
         shell: bash
@@ -48,7 +48,7 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - run: ./scripts/ci_prepare_rust.bash
         shell: bash
@@ -73,7 +73,7 @@ jobs:
           - windows-2022
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v2

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -10,7 +10,7 @@ jobs:
   sonarcloud:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Sonarcloud Scan
@@ -31,7 +31,7 @@ jobs:
     name: C Code Coverage
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
           fetch-depth: 0

--- a/.github/workflows/test_validate.yaml
+++ b/.github/workflows/test_validate.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run Tests
         run: |

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Current Spec
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout Previous Spec
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: master
           path: previous


### PR DESCRIPTION
# Description

@swift-nav/algint-team

Update github actions:
- sonarcloud action is [deprecated](https://github.com/SonarSource/sonarcloud-github-action)

# API compatibility

Does this change introduce a API compatibility risk?

No, just github actions.

# JIRA Reference

https://swift-nav.atlassian.net/browse/AP-3937