### PR TITLE
Fix benchmark builds [AP-3937]

### DIFF
--- a/kaitai/python/kaitai_sbp/tests/tox.ini
+++ b/kaitai/python/kaitai_sbp/tests/tox.ini
@@ -6,7 +6,7 @@ envlist = py
 [testenv]
 deps =
   pytest
-  kaitaistruct
+  kaitaistruct==0.10.0
   construct
   python-rapidjson
 changedir = ../../../..

--- a/python/Dockerfile.benchmark
+++ b/python/Dockerfile.benchmark
@@ -19,7 +19,8 @@ ADD . /work
 
 RUN pip3 install -r /work/setup_requirements.txt
 RUN pip3 install -r /work/requirements.txt
-RUN pip3 install kaitaistruct
+# keep in sync with above
+RUN pip3 install kaitaistruct==0.10.0
 
 RUN pip3 install wheel setuptools
 

--- a/python/Dockerfile.benchmark
+++ b/python/Dockerfile.benchmark
@@ -1,4 +1,4 @@
-FROM python:3.7-slim-bookworm
+FROM python:3.10-slim-bookworm
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN    apt-get update \

--- a/python/Dockerfile.benchmark
+++ b/python/Dockerfile.benchmark
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bookworm
+FROM python:3.13-slim-bookworm
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN    apt-get update \


### PR DESCRIPTION
# Description

@swift-nav/algint-team

- New version of [kaitaistruct](https://pypi.org/project/kaitaistruct/#history)/[runtime](https://github.com/kaitai-io/kaitai_struct_perl_runtime/releases/tag/0.11) breaks pipelines. Fix to `0.10.0`
- Update python version

# API compatibility

Does this change introduce a API compatibility risk?

No

# JIRA Reference

https://swift-nav.atlassian.net/browse/AP-3937
