### PR TITLE
Update to C++17 [AP-3454]

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,9 @@
 # Causes the build to default to the custom toolchain
 build --incompatible_enable_cc_toolchain_resolution
 
-build --action_env=BAZEL_CXXOPTS='-std=c++14'
+# Compile all swift targets and all other codes with C++17 standards
+build --@rules_swiftnav//cc:cxx_standard=17
+build --@rules_swiftnav//cc:global_cxx_standard=17
 
 build:clang-tidy --aspects @rules_swiftnav//clang_tidy:clang_tidy.bzl%clang_tidy_aspect
 build:clang-tidy --output_groups=report
@@ -23,7 +25,7 @@ common:sanitize --@rules_swiftnav//cc:enable_symbolizer=true
 # the compiler falls back to a linear register allocator.  This
 # shouldn't cause a sanitizer build to fail.
 common:sanitize --cxxopt=-Wno-error=disabled-optimization
-common:sanitize --copt=-Wno-error=disabled-optimization 
+common:sanitize --copt=-Wno-error=disabled-optimization
 common:sanitize --linkopt=-Wno-error=disabled-optimization
 # https://github.com/bazelbuild/bazel/issues/12797#issuecomment-980641064
 common:sanitize --linkopt='-fsanitize-link-c++-runtime'

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -3,6 +3,7 @@ project(libsbp C CXX)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake" "${CMAKE_CURRENT_LIST_DIR}/cmake/common")
 option(I_KNOW_WHAT_I_AM_DOING_AND_HOW_DANGEROUS_IT_IS__LIBSBP_DISABLE_CRC_VALIDATION "Disable all CRC validation in Libsbp" OFF)
+set(SWIFT_CXX_STANDARD 17 CACHE STRING "Default C++ version for all swift targets")
 
 include(GNUInstallDirs)
 include(CCache)


### PR DESCRIPTION
# Description

@swift-nav/algint-team

This updates the few C++ targets in this repo to C++17. The change consists of
- Update Bazel and CMake build systems to compile C++ targets according to the C++17 standard

# API compatibility

Does this change introduce a API compatibility risk?

No

## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan:

<!-- Provide a short explanation plan here -->

# JIRA Reference

https://swift-nav.atlassian.net/browse/AP-3454
