### PR TITLE
Fix dependabot SONAR_TOKEN

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -17,7 +17,7 @@ jobs:
         uses: sonarsource/sonarqube-scan-action@v5.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_AUTO }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           args: >
             -Dsonar.organization=swift-nav
@@ -51,7 +51,7 @@ jobs:
         uses: SonarSource/sonarqube-scan-action@v5.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_C }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           args: >
             -Dsonar.organization=swift-nav


### PR DESCRIPTION
# Description

@swift-nav/algint-team

Use `SONAR_TOKEN` as that is set up as Dependabot secret in this repo.

# API compatibility

Does this change introduce a API compatibility risk?

No

## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan:

<!-- Provide a short explanation plan here -->

# JIRA Reference

None
