### PR TITLE
Remove auto-generated directories from CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,3 @@
-# DevInfra team is default owner of anything in the repo.
 * @swift-nav/algint-team
-/rust @notoriaga @pcrumley @sbmueller
-/c @swift-nav/algint-team
 
 # Add new codeowners above here


### PR DESCRIPTION
# Description

@swift-nav/algint-team

Remove sections from the CODEOWNERS file that target auto-generated directories. Since the files are auto-generated, there is nothing to review.

# API compatibility

Does this change introduce a API compatibility risk?

No

## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan:

<!-- Provide a short explanation plan here -->
