### PR TITLE
Fix spellings to unblock libsbp release

### DIFF
--- a/python/docs/source/spelling_wordlist.txt
+++ b/python/docs/source/spelling_wordlist.txt
@@ -48,6 +48,7 @@ cdc
 cn
 correctionPointSetID
 correlators
+cov
 covariances
 cpu
 dataset
@@ -117,6 +118,8 @@ oc
 odometry
 oe
 orthometric
+parameterization
+parameterizations
 piksi
 pseudorange
 pseudoranges


### PR DESCRIPTION
# Description

@swift-nav/algint-team

This PR adds two words to the spellings list to make `make docs` pass

# API compatibility

No

## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan:

<!-- Provide a short explanation plan here -->

# JIRA Reference

https://swift-nav.atlassian.net/browse/BOARD-XXXX
