### PR TITLE
ci: add Claude review via reusable workflow [AP-5410]

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,22 @@
+# Claude review via swift-nav/swift-context-hub reusable workflow.
+# Docs/prereqs: https://github.com/swift-nav/swift-context-hub
+# Requires repo secrets: ANTHROPIC_API_KEY, SSH_KEY.
+
+name: Claude
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened]
+
+jobs:
+  claude_review:
+    uses: swift-nav/swift-context-hub/.github/workflows/claude.yml@v0.1.8
+    secrets:
+      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+      SSH_KEY: ${{ secrets.SSH_KEY }}


### PR DESCRIPTION
## Summary

- Add on-demand Claude code review via the swift-context-hub reusable workflow; pinned `@v0.1.8`.

## ⚠️ Required before this runs

This repo had no Claude workflow, so neither secret exists yet. Add **both** repo secrets:

- **`ANTHROPIC_API_KEY`** — Anthropic API key for the reviewer.
- **`SSH_KEY`** — org SSH key with read access to swift-nav/swift-context-hub.

## Triggers

- `@claude` / `@claude review` on PRs and issues.
- Auto-review on PR approval.

## Test plan

- [ ] both secrets added
- [ ] @claude review on a PR runs the reviewer
