### PR TITLE
Sync Cargo.lock during releases

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -294,6 +294,12 @@ and something needs to be repeated.
 
 7. Push the release to GitHub:
 
+    > (Optional) Before pushing, confirm everything builds, e.g.:
+    >
+    > ```sh
+    > bazel test //...
+    > ```
+
     ```sh
     git push origin master <INCREMENTED_TAG>
     ```

--- a/Makefile
+++ b/Makefile
@@ -307,6 +307,12 @@ gen-rust:
 
 	$(call announce-end,"Finished formatting Rust code")
 
+	$(call announce-begin,"Syncing Cargo.lock to generated manifest versions")
+
+	cd $(SWIFTNAV_ROOT) && cargo update --workspace
+
+	$(call announce-end,"Finished syncing Cargo.lock")
+
 gen-protobuf:
 	$(call announce-begin,"Generating Protocol Buffers bindings")
 	cd $(SWIFTNAV_ROOT)/generator; \


### PR DESCRIPTION
# Description

@swift-nav/algint-team

Since this [PR](https://github.com/swift-nav/libsbp/pull/1584) the root Cargo.lock is tracked, but the release tooling bumped rust/*/Cargo.toml without updating it, breaking make `dist-rust` and `bazel` builds of the tagged release.

- Makefile (gen-rust): run `cargo update --workspace` after generating the manifests so the lock stays in sync automatically.
- HOWTO.md: add an optional `bazel test //...` reminder before pushing.

# API compatibility

Does this change introduce a API compatibility risk?

NO