### PR TITLE
Remove clang-tidy CI gate

### DIFF
--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -352,7 +352,3 @@ jobs:
         with:
           name: clang-tidy-sarif-report
           path: clang-tidy-output/merged-report.sarif
-
-      - name: Fail if clang-tidy errors were found
-        if: steps.run_clang_tidy.outcome == 'failure'
-        run: exit 1

--- a/.github/workflows/c.yaml
+++ b/.github/workflows/c.yaml
@@ -31,7 +31,10 @@ jobs:
           ]
         build_shared_libraries: [true, false]
 
-    name: "Ubuntu 20.04 (Build: ${{ matrix.build_type }}, Compilers: ${{ matrix.compiler.c }}/${{ matrix.compiler.cxx }}, Shared Library: ${{ matrix.build_shared_libraries }})"
+    name:
+      "Ubuntu 20.04 (Build: ${{ matrix.build_type }}, Compilers: ${{
+      matrix.compiler.c }}/${{ matrix.compiler.cxx }}, Shared Library: ${{
+      matrix.build_shared_libraries }})"
 
     # We run on a docker image to avoid being affected from GitHub
     # decommissioning certain runners
@@ -139,7 +142,8 @@ jobs:
           CC: mips-linux-gnu-gcc
           CXX: mips-linux-gnu-g++
 
-          CMAKEFLAGS: -DCMAKE_EXE_LINKER_FLAGS="-static" -Dgtest_disable_pthreads=ON
+          CMAKEFLAGS:
+            -DCMAKE_EXE_LINKER_FLAGS="-static" -Dgtest_disable_pthreads=ON
 
   bazel:
     name: Bazel
@@ -173,7 +177,6 @@ jobs:
           disk-cache: ${{ github.workflow }}
           repository-cache: true
 
-
       - name: Bazel Build & Test
         run: |
           bazel test --config=asan //...
@@ -201,7 +204,9 @@ jobs:
       matrix:
         generator: ["MinGW Makefiles", "Visual Studio 17 2022"]
         build_shared_libraries: [true, false]
-    name: "Windows Latest (Generator: ${{ matrix.generator }}, Shared Library: ${{ matrix.build_shared_libraries }})"
+    name:
+      "Windows Latest (Generator: ${{ matrix.generator }}, Shared Library: ${{
+      matrix.build_shared_libraries }})"
     # Pinned to windows-2022: the "Visual Studio 17 2022" generator requires VS
     # 2022, which the migrated windows-latest image no longer ships.
     runs-on: windows-2022
@@ -272,16 +277,20 @@ jobs:
           path: code_coverage_html/
 
       - name: Find existing coverage comment
-        if: github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]'
+        if:
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.user.login != 'dependabot[bot]'
         uses: peter-evans/find-comment@v4
         id: find-comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: '<!-- code-coverage-libsbp -->'
+          comment-author: "github-actions[bot]"
+          body-includes: "<!-- code-coverage-libsbp -->"
 
       - name: Post coverage comment
-        if: github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]'
+        if:
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.user.login != 'dependabot[bot]'
         uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}


### PR DESCRIPTION
# Description

@swift-nav/algint-team

Removes `clang-tidy` CI gate to enable roll-out of new `clang-tidy` config in `rules_swiftnav`. With the gate in place, PRs would be gated with the new rules if _any_ file contains `clang-tidy` violations. The new gating logic will be implemented differently.

# API compatibility

Does this change introduce a API compatibility risk?

No

## API compatibility plan

If the above is "Yes", please detail the compatibility (or migration) plan:

<!-- Provide a short explanation plan here -->

# JIRA Reference

https://swift-nav.atlassian.net/browse/AP-5338
